### PR TITLE
Add Spring Security config and disable csrf protection for api

### DIFF
--- a/src/main/kotlin/fi/oph/kitu/WebSecurityConfig.kt
+++ b/src/main/kotlin/fi/oph/kitu/WebSecurityConfig.kt
@@ -1,0 +1,26 @@
+package fi.oph.kitu
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.Customizer
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class WebSecurityConfig {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { csrf -> csrf.ignoringRequestMatchers("/api/*") }
+            .authorizeHttpRequests { authorize ->
+                authorize
+                    .anyRequest()
+                    .authenticated()
+            }.httpBasic(Customizer.withDefaults())
+            .formLogin(Customizer.withDefaults())
+
+        return http.build()
+    }
+}

--- a/src/main/kotlin/fi/oph/kitu/oppija/OppijaController.kt
+++ b/src/main/kotlin/fi/oph/kitu/oppija/OppijaController.kt
@@ -11,10 +11,10 @@ class OppijaController {
     @Autowired
     private lateinit var oppijaService: OppijaService
 
-    @GetMapping("/oppija")
+    @GetMapping("/api/oppija")
     fun getOppijat(): Iterable<Oppija> = oppijaService.getAll()
 
-    @PostMapping("/oppija")
+    @PostMapping("/api/oppija")
     fun addOppija(
         @RequestBody name: String,
     ) = oppijaService.insert(name)

--- a/src/test/kotlin/fi/oph/kitu/oppija/OppijaTests.kt
+++ b/src/test/kotlin/fi/oph/kitu/oppija/OppijaTests.kt
@@ -24,7 +24,7 @@ class OppijaTests(
     fun `get oppija`() {
         client
             .get()
-            .uri("/oppija")
+            .uri("/api/oppija")
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus()
@@ -37,7 +37,7 @@ class OppijaTests(
     fun `post oppija`() {
         client
             .post()
-            .uri("/oppija")
+            .uri("/api/oppija")
             .bodyValue("Mikko Mallikas")
             .exchange()
             .expectStatus()


### PR DESCRIPTION
To add data for local dev with a POST request:
- encode a basic auth token using the generated password with e.g. `echo -n 'user:<password>' | openssl base64`
- make a POST request to `/api/oppija` with the header `Authentication: Basic <token>`