### PR TITLE
feat: create health - endpoint that does not need authentication

### DIFF
--- a/src/main/kotlin/fi/oph/kitu/WebSecurityConfig.kt
+++ b/src/main/kotlin/fi/oph/kitu/WebSecurityConfig.kt
@@ -16,6 +16,8 @@ class WebSecurityConfig {
             .csrf { csrf -> csrf.ignoringRequestMatchers("/api/*") }
             .authorizeHttpRequests { authorize ->
                 authorize
+                    .requestMatchers("api/health/**")
+                    .permitAll()
                     .anyRequest()
                     .authenticated()
             }.httpBasic(Customizer.withDefaults())

--- a/src/main/kotlin/fi/oph/kitu/health/HealthController.kt
+++ b/src/main/kotlin/fi/oph/kitu/health/HealthController.kt
@@ -1,0 +1,10 @@
+package fi.oph.kitu.health
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthController {
+    @GetMapping("api/health")
+    fun getHealth() = "OK"
+}


### PR DESCRIPTION
HTTP GET `/api/health`, pitäisi palauttaa `OK`. Ei vaadi sisäänkirjautumista. 