### PR TITLE
chore: try concurrent deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
       - main
   pull_request:
 
-concurrency: build-${{ github.ref }}
-
 jobs:
   deploy_dev:
     name: dev


### PR DESCRIPTION
Let the top level workflow start concurrently so that while an older workflow is deploying to test, a newer one can already start deploying to dev, instead of having to wait for the old workflow to complete.