### PR TITLE
fix: remove CloudFront

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -74,7 +74,7 @@ const dnsStack = new DnsStack(app, "DnsStack", {
   terminationProtection: true,
 })
 
-const certificateStack = new CertificateStack(app, "CertificateStack", {
+new CertificateStack(app, "CertificateStack", {
   crossRegionReferences: true,
   env: { ...env, region: "us-east-1" },
   hostedZone: dnsStack.hostedZone,
@@ -94,7 +94,6 @@ new InfraStack(app, "InfraStack", {
   env,
   name: env.name,
   domainName: env.domainName,
-  certificate: certificateStack.certificate,
   vpc: networkStack.vpc,
   database: dbStack.cluster,
 })

--- a/infra/lib/certificate-stack.ts
+++ b/infra/lib/certificate-stack.ts
@@ -12,16 +12,5 @@ export class CertificateStack extends cdk.Stack {
 
   constructor(scope: Construct, id: string, props: CertificateStackProps) {
     super(scope, id, props)
-
-    this.certificate = new aws_certificatemanager.Certificate(
-      this,
-      "Certificate",
-      {
-        domainName: props.domainName,
-        validation: aws_certificatemanager.CertificateValidation.fromDns(
-          props.hostedZone,
-        ),
-      },
-    )
   }
 }


### PR DESCRIPTION
It's really difficult to secure CloudFront -> ALB communication so that only CF is allowed to call the ALB. Instead of doing that, let's just remove CloudFront for now.