### PR TITLE
fix: remove insecure transitive dependency

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -52,6 +52,12 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-cas</artifactId>
             <version>6.3.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
It seems like the app runs fine without this dependency, but who knows.
This is a suggestion PR; I'm not sure this is the right approach.

There is no fixed release of `org.bouncycastle.bcprov-jdk15on`. There are newer versions of `org.bouncycastle.bcprov-jdk18on`, but I failed to figure out if it's possible to force a dep to use another artifact entirely as its dependency.