### PR TITLE
chore: add awscli to mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -9,3 +9,4 @@ java = 'corretto-21'
 ktlint = "latest"
 maven = "3.9.9"
 shellcheck = "latest"
+awscli = "ref:2.17.55"


### PR DESCRIPTION
We force mise to build awscli from source because otherwise it would use the x86_64 binary distribution even on ARM Macs.