### PR TITLE
feat: create a mock api for YKi

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
@@ -50,7 +50,7 @@ class WebSecurityConfig {
         ) {
             http.authorizeHttpRequests { authorize ->
                 authorize
-                    .requestMatchers("/dev/*")
+                    .requestMatchers("/dev/**")
                     .permitAll()
             }
         }

--- a/server/src/main/kotlin/fi/oph/kitu/dev/MockYkiControllerApi.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/dev/MockYkiControllerApi.kt
@@ -1,4 +1,4 @@
-package fi.oph.kitu.mock
+package fi.oph.kitu.dev
 
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController

--- a/server/src/main/kotlin/fi/oph/kitu/dev/MockYkiControllerApi.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/dev/MockYkiControllerApi.kt
@@ -1,11 +1,13 @@
 package fi.oph.kitu.dev
 
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@RequestMapping("/dev/mock/yki")
 class MockYkiControllerApi {
-    @GetMapping("/api/mock/yki")
+    @GetMapping
     fun mockYki() =
         YkiMockData(
             "Yrjö Ykittäjä",

--- a/server/src/main/kotlin/fi/oph/kitu/dev/MockYkiControllerApi.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/dev/MockYkiControllerApi.kt
@@ -1,12 +1,34 @@
 package fi.oph.kitu.dev
 
+import jakarta.annotation.PostConstruct
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.SpringApplication
+import org.springframework.context.annotation.Profile
+import org.springframework.core.env.Environment
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.context.WebApplicationContext
+import kotlin.system.exitProcess
 
 @RestController
 @RequestMapping("/dev/mock/yki")
-class MockYkiControllerApi {
+@Profile("local", "e2e")
+class MockYkiControllerApi(
+    private val environment: Environment,
+    private val applicationContext: WebApplicationContext,
+) {
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun init() {
+        if (environment.activeProfiles.any { it == "qa" || it.lowercase().contains("prod") }) {
+            logger.error("Fatal error: ${this::class.simpleName} loaded in a prod-like environment")
+            exitProcess(SpringApplication.exit(applicationContext))
+        }
+    }
+
     @GetMapping
     fun mockYki() =
         YkiMockData(

--- a/server/src/main/kotlin/fi/oph/kitu/mock/MockYkiControllerApi.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/MockYkiControllerApi.kt
@@ -1,0 +1,33 @@
+package fi.oph.kitu.mock
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MockYkiControllerApi {
+    @GetMapping("/api/mock/yki")
+    fun mockYki() =
+        YkiMockData(
+            "Yrjö Ykittäjä",
+            "010106A911C",
+            "Yhdistynyt Kuningaskunta",
+            "Muu",
+            "Taitotalo, Helsinki",
+            "suomi",
+            "EVK B2/YKI 4",
+            "2024-09-27 12:40",
+            "Yrjönkatu 13 C, 00120 Helsinki",
+        )
+}
+
+data class YkiMockData(
+    val nimi: String,
+    val henkilötunnus: String,
+    val kansalaisuus: String,
+    val sukupuoli: String,
+    val tutkinnonSuorittamispaikka: String,
+    val tutkintokieli: String,
+    val saadutTaitotasoarviot: String,
+    val tutkintokertojenAjankohta: String,
+    val tarpeellisetYhteystiedot: String,
+)


### PR DESCRIPTION
Ajatus on, että on joku mock-rajapinta, jota meidän YKI-api voi kutsua. Ongelma ratkaistu luomalla oma endpoint `api/mock/yki` - joka palauttaa aina samat tiedot