### PR TITLE
fix: add servers to openapi spec

### DIFF
--- a/server/src/main/resources/static/open-api.yaml
+++ b/server/src/main/resources/static/open-api.yaml
@@ -5,6 +5,15 @@ info:
 tags:
   - name: kitu
     description: KOTO-rekisteri
+servers:
+  - url: http://localhost:8080
+    description: Lokaali ympäristö
+  - url: https://kios.untuvaopintopolku.fi
+    description: Kehitysympäristö
+  - url: https://kios.testiopintopolku.fi
+    description: Testiympäristö
+  - url: https://kios.opintopolku.fi
+    description: Tuotantoympäristö
 paths:
   /api/oppija:
     get:


### PR DESCRIPTION
# Ennen

```
[INFO] --- openapi-generator:7.8.0:generate (default) @ kitu ---
[INFO] Generating with dryRun=false
[INFO] No .openapi-generator-ignore file found.
[INFO] OpenAPI Generator: kotlin-spring (server)
[INFO] Generator 'kotlin-spring' is considered stable.
[INFO] Setup code generator for Kotlin Spring Boot
[INFO] 'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [http://localhost] for server URL [http://localhost/]
[INFO] 'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [http://localhost] for server URL [http://localhost/]
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/model/Oppija.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/model/Oppija.kt
[INFO] 'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [http://localhost] for server URL [http://localhost/]
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijaControllerApi.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijaControllerApi.kt
[INFO] 'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [http://localhost] for server URL [http://localhost/]
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijanumeroControllerApi.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijanumeroControllerApi.kt
[INFO] 'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [http://localhost] for server URL [http://localhost/]
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/UserControllerApi.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/UserControllerApi.kt
[INFO] Skipping generation of Webhooks.
[INFO] 'host' (OAS 2.0) or 'servers' (OAS 3.0) not defined in the spec. Default to [http://localhost] for server URL [http://localhost/]
[INFO] Skipping generation of supporting files.
```

# Jälkeen

```
[INFO] --- openapi-generator:7.8.0:generate (default) @ kitu ---
[INFO] Generating with dryRun=false
[INFO] No .openapi-generator-ignore file found.
[INFO] OpenAPI Generator: kotlin-spring (server)
[INFO] Generator 'kotlin-spring' is considered stable.
[INFO] Setup code generator for Kotlin Spring Boot
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/model/Oppija.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/model/Oppija.kt
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijaControllerApi.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijaControllerApi.kt
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijanumeroControllerApi.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/OppijanumeroControllerApi.kt
[INFO] writing file /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/UserControllerApi.kt
[INFO] Successfully executed: ktlint -F /Users/ivacklin/code/koto-rekisteri/server/src/main/kotlin/fi/oph/kitu/generated/api/UserControllerApi.kt
[INFO] Skipping generation of Webhooks.
[INFO] Skipping generation of supporting files.
```

![Screenshot 2024-09-27 at 14 42 33](https://github.com/user-attachments/assets/d476c88b-69f0-467c-a6b7-2083ccc19a66)
