### PR TITLE
fix: oppijanumero password in local env

### DIFF
--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -10,7 +10,6 @@ kitu.opintopolkuHostname=virkailija.untuvaopintopolku.fi
 kitu.kielitesti.baseurl=https://kielitesti.mmg.fi
 
 kitu.oppijanumero.username=koto-rekisteri
-kitu.oppijanumero.password=${OPPIJANUMERO_PASSWORD}
 kitu.oppijanumero.callerid=1.2.246.562.24.85478397072
 kitu.oppijanumero.casUrl=https://virkailija.untuvaopintopolku.fi/cas
 kitu.oppijanumero.serviceUrl=https://virkailija.untuvaopintopolku.fi/oppijanumerorekisteri-service


### PR DESCRIPTION
Tämä arvo kuuluu tulla `local.properties`-tiedostosta lokaaliympäristössä, joten poistetaan `application-local.properties` viittaus ympäristömuuttujaan jota ei ole tarkoituskaan käyttää.