### PR TITLE
Add renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:recommended"]
+}


### PR DESCRIPTION
Trying to test why renovate isn't grouping aws-cdk and aws-cdk-lib together.