### PR TITLE
fix: tell GHA where we're deploying again

### DIFF
--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -3,64 +3,58 @@ name: Deploy
 on:
   workflow_call:
     inputs:
-      env:
-        type: string
-        required: true
-      account_id:
-        type: string
-        required: true
       stacks:
         type: string
         default: "**"
+      environment:
+        type: string
+      action:
+        type: string
   workflow_dispatch:
     inputs:
-      env:
+      environment:
+        type: environment
+        description: Target environment
+      action:
         type: choice
         options:
-          - Dev
-          - Test
-          - Prod
-        description: Target environment
-        required: true
-      account_id:
-        type: string
-        description: Target AWS account
-        required: true
+          - deploy
+          - diff
+        description: Action to perform
       stacks:
         type: string
         description: Stacks to deploy
         default: "**"
 
-concurrency: deploy-${{ github.ref_name }}-${{ inputs.env }}
+concurrency: deploy-${{ github.ref_name }}-${{ vars.account_id }}
+
+env:
+  TAG: ${{ github.sha }}
 
 jobs:
   run:
-    name: ${{ github.ref_name == 'main' && 'Deploy' || 'Diff' }} to ${{ inputs.env }} (${{ inputs.account_id }})
+    name: ${{ inputs.action }} to ${{ inputs.environment }} (${{ vars.account_id }})
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-    env:
-      TAG: ${{ github.sha }}
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ vars.environment_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
         uses: jdx/mise-action@v2
         with:
           experimental: true
-      - name: Log in to ${{ inputs.env }}
+      - name: Log in to ${{ inputs.environment }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/kitu-github-actions-role
+          role-to-assume: arn:aws:iam::${{ vars.account_id }}:role/kitu-github-actions-role
       - name: Install dependencies
         run: npm ci
         working-directory: infra
-      - name: Deploy
-        if: github.ref_name == 'main'
-        run: npx cdk deploy --require-approval=never --exclusively '${{ inputs.env }}/${{ inputs.stacks }}'
-        working-directory: infra
-      - name: Diff
-        if: github.ref_name != 'main'
-        run: npx cdk diff --require-approval=never --exclusively '${{ inputs.env }}/${{ inputs.stacks }}'
+      - name: ${{ inputs.action }}
+        run: npx cdk ${{ inputs.action }} --require-approval=never --exclusively '${{ inputs.environment }}/${{ inputs.stacks }}'
         working-directory: infra

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
   build_image:
     name: Build image
     runs-on: ubuntu-latest
+    needs: deploy_util
     permissions:
       id-token: write
       contents: read
@@ -54,29 +55,29 @@ jobs:
     name: util
     uses: ./.github/workflows/_deploy-env.yml
     with:
-      env: Util
-      account_id: 961341524988
+      environment: Util
+      action: ${{ github.ref_name == 'main' && 'deploy' || 'diff' }}
 
   deploy_dev:
     name: dev
     needs: build_image
     uses: ./.github/workflows/_deploy-env.yml
     with:
-      env: Dev
-      account_id: 682033502734
+      environment: Dev
+      action: ${{ github.ref_name == 'main' && 'deploy' || 'diff' }}
 
   deploy_test:
     name: test
     needs: deploy_dev
     uses: ./.github/workflows/_deploy-env.yml
     with:
-      env: Test
-      account_id: 961341546901
+      environment: Test
+      action: ${{ github.ref_name == 'main' && 'deploy' || 'diff' }}
 
   deploy_prod:
     name: prod
     needs: deploy_test
     uses: ./.github/workflows/_deploy-env.yml
     with:
-      env: Prod
-      account_id: 515966535475
+      environment: Prod
+      action: ${{ github.ref_name == 'main' && 'deploy' || 'diff' }}


### PR DESCRIPTION
Tämä PR kertoo GitHub Actionsille kohdeympäristöt, jolloin deploymentit tulevat näkyviin myös repon etusivun Deployments-osioon. Tällä hetkellä myös diffit PR:stä tulevat sinne, mikä voi olla joko OK tai turhaa. On vähän hankala kuitenkaan workflow-syntaksilla estää tuota.