### PR TITLE
Match only ERRORs in log alarm

### DIFF
--- a/infra/lib/log-groups-stack.ts
+++ b/infra/lib/log-groups-stack.ts
@@ -1,4 +1,5 @@
 import { aws_sns, Stack, StackProps } from "aws-cdk-lib"
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch"
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions"
 import { FilterPattern, LogGroup } from "aws-cdk-lib/aws-logs"
 import { Construct } from "constructs"
@@ -27,6 +28,7 @@ export class LogGroupsStack extends Stack {
       .createAlarm(this, "ErrorsAlarm", {
         threshold: 1,
         evaluationPeriods: 1,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
       })
 
     alarm.addAlarmAction(new SnsAction(props.alarmsSnsTopic))

--- a/infra/lib/log-groups-stack.ts
+++ b/infra/lib/log-groups-stack.ts
@@ -21,7 +21,7 @@ export class LogGroupsStack extends Stack {
       .addMetricFilter("Errors", {
         metricName: "LogErrors",
         metricNamespace: "Kitu",
-        filterPattern: FilterPattern.anyTerm("error", "Error", "ERROR"),
+        filterPattern: FilterPattern.anyTerm("ERROR"),
       })
       .metric()
       .createAlarm(this, "ErrorsAlarm", {


### PR DESCRIPTION
We don't want to match this:

    2024-10-08T19:45:38.572Z INFO 1 --- [kitu] [nio-8080-exec-8] o.apache.coyote.http11.Http11Processor : Error parsing HTTP request header

Also, treat missing data as OK, since metric filters don't output a value when they don't match.