### PR TITLE
feat(deps): automatically merge minor npm dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,16 +1,10 @@
 {
   "extends": ["config:recommended"],
-  "mise": {
-    "packageRules": [
-      {
-        "matchPackageNames": ["awscli"],
-        "versionCompatibility": "^(?<compatibility>.*):(?<version>.*)$"
-      },
-      {
-        "matchPackageNames": ["java"],
-        "versionCompatibility": "^(?<compatibility>.*?)-(?<version>.*)$",
-        "versioning": "semver"
-      }
-    ]
-  }
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
NPM updates seem to work consistently (unlike mise updates), so let's test automatically merging minor and patch updates if CI passes.