### PR TITLE
Add audit logging capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
-
+*.log
 
 local.properties
 

--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -64,6 +64,7 @@ export class EnvironmentStage extends Stage {
       serviceSecurityGroup: connectionsStack.serviceSG,
       loadBalancerSecurityGroup: connectionsStack.loadBalancerSG,
       logGroup: logGroupsStack.serviceLogGroup,
+      auditLogGroup: logGroupsStack.serviceAuditLogGroup,
       vpc: networkStack.vpc,
       database: dbStack.cluster,
       databaseName: environmentConfig.databaseName,

--- a/infra/lib/log-groups-stack.ts
+++ b/infra/lib/log-groups-stack.ts
@@ -10,6 +10,7 @@ export interface LogGroupsStackProps extends StackProps {
 
 export class LogGroupsStack extends Stack {
   readonly serviceLogGroup: LogGroup
+  readonly serviceAuditLogGroup: LogGroup
 
   constructor(scope: Construct, id: string, props: LogGroupsStackProps) {
     super(scope, id, props)
@@ -17,12 +18,15 @@ export class LogGroupsStack extends Stack {
     this.serviceLogGroup = new LogGroup(this, "Service", {
       logGroupName: "KituService",
     })
+    this.serviceAuditLogGroup = new LogGroup(this, "ServiceAudit", {
+      logGroupName: "KituServiceAudit",
+    })
 
     const alarm = this.serviceLogGroup
       .addMetricFilter("Errors", {
         metricName: "LogErrors",
         metricNamespace: "Kitu",
-        filterPattern: FilterPattern.anyTerm("ERROR"),
+        filterPattern: FilterPattern.stringValue("$.level", "=", "error"),
       })
       .metric()
       .createAlarm(this, "ErrorsAlarm", {

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -35,6 +35,17 @@
         <local-env.datasource.user>kitu</local-env.datasource.user>
         <local-env.datasource.password>kitu</local-env.datasource.password>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.20.129</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -77,6 +88,10 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatchlogs</artifactId>
         </dependency>
 
         <dependency>

--- a/server/src/main/kotlin/fi/oph/kitu/Constants.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/Constants.kt
@@ -1,0 +1,3 @@
+package fi.oph.kitu
+
+const val AUDIT_LOGGER_NAME = "auditLogger"

--- a/server/src/main/kotlin/fi/oph/kitu/logging/CloudWatchAppender.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/CloudWatchAppender.kt
@@ -1,0 +1,82 @@
+package fi.oph.kitu.logging
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import ch.qos.logback.core.encoder.Encoder
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
+import software.amazon.awssdk.services.cloudwatchlogs.model.CreateLogStreamRequest
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest
+
+// Copied from https://github.com/Opetushallitus/ludos/blob/main/server/src/main/kotlin/fi/oph/ludos/aws/LudosLogbackCloudwatchAppender.kt
+class CloudwatchAppender : AppenderBase<ILoggingEvent>() {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    // <logback-spring.xml-attributes>
+    var encoder: Encoder<ILoggingEvent>? = null
+    var logGroupName: String? = null
+    // </logback-spring.xml-attributes>
+
+    private lateinit var cloudWatchLogsClient: CloudWatchLogsClient
+
+    private val logStreamName: String = getEcsTaskIdFromEnv()
+
+    override fun start() {
+        if (started) {
+            return
+        }
+
+        checkNotNull(encoder) { "encoder was not set for appender" }
+        checkNotNull(logGroupName) { "logGroupName was not set for appender" }
+        if (logGroupName!!.isBlank()) {
+            throw IllegalStateException("logGroupName was blank")
+        }
+
+        cloudWatchLogsClient = CloudWatchLogsClient.create()
+        val createLogStreamRequest =
+            CreateLogStreamRequest
+                .builder()
+                .logGroupName(logGroupName)
+                .logStreamName(logStreamName)
+                .build()
+        cloudWatchLogsClient.createLogStream(createLogStreamRequest)
+
+        super.start()
+    }
+
+    override fun append(eventObject: ILoggingEvent) {
+        val message = encoder?.encode(eventObject)?.toString(Charsets.UTF_8) ?: eventObject.formattedMessage
+        val request =
+            PutLogEventsRequest
+                .builder()
+                .logGroupName(logGroupName)
+                .logStreamName(logStreamName)
+                .logEvents(
+                    InputLogEvent
+                        .builder()
+                        .message(message)
+                        .timestamp(eventObject.timeStamp)
+                        .build(),
+                ).build()
+
+        try {
+            cloudWatchLogsClient.putLogEvents(request)
+        } catch (e: Throwable) {
+            logger.error("Error calling put-log-events(${eventObject.formattedMessage})", e)
+        }
+    }
+}
+
+fun getEcsTaskIdFromEnv(): String {
+    // Esimerkki ECS_CONTAINER_METADATA_URI:n muodosta:
+    // http://169.254.170.2/v3/2df36241782d45e5ad3816ea5cc10f61-2990360344
+    val metadataUri = System.getenv("ECS_CONTAINER_METADATA_URI")
+    val taskId =
+        metadataUri
+            ?.split("/")
+            ?.last()
+            ?.split("-")
+            ?.first()
+    return taskId ?: ("unknown_task_id-" + System.currentTimeMillis())
+}

--- a/server/src/main/kotlin/fi/oph/kitu/logging/Logging.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/Logging.kt
@@ -1,4 +1,4 @@
-package fi.oph.kitu
+package fi.oph.kitu.logging
 
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest

--- a/server/src/main/kotlin/fi/oph/kitu/oppija/OppijaService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppija/OppijaService.kt
@@ -1,12 +1,22 @@
 package fi.oph.kitu.oppija
 
+import fi.oph.kitu.AUDIT_LOGGER_NAME
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class OppijaService(
     private val oppijaRepository: OppijaRepository,
 ) {
+    private val auditLogger = LoggerFactory.getLogger(AUDIT_LOGGER_NAME)
+
     fun getAll(): Iterable<Oppija> = oppijaRepository.getAll()
 
-    fun insert(name: String): Oppija? = oppijaRepository.insert(name)
+    fun insert(name: String): Oppija? {
+        val result = oppijaRepository.insert(name)
+
+        auditLogger.atInfo().addKeyValue("example", "value").log("Inserted oppija")
+
+        return result
+    }
 }

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -1,19 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProfile name="!local">
+    <springProfile name="local | ci | e2e">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
         </appender>
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-        </root>
-    </springProfile>
-    <springProfile name="local">
-        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+
+        <appender name="AUDIT_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/audit.log</file>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>logs/audit.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
         </appender>
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-        </root>
+
+        <logger name="auditLogger" level="INFO" additivity="true">
+            <appender-ref ref="AUDIT_LOCAL"/>
+        </logger>
     </springProfile>
+
+    <springProfile name="!local &amp; !ci &amp; !e2e">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        </appender>
+
+        <appender name="AUDIT_CLOUDWATCH" class="fi.oph.kitu.logging.CloudwatchAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>correlation_id</includeMdcKeyName>
+            </encoder>
+            <logGroupName>${AUDIT_LOG_LOG_GROUP_NAME:-}</logGroupName>
+        </appender>
+
+        <logger name="auditLogger" level="INFO" additivity="true">
+            <appender-ref ref="AUDIT_CLOUDWATCH"/>
+        </logger>
+    </springProfile>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
 </configuration>


### PR DESCRIPTION
Toteutusvaihtoehdot:

- FireLens-sidecar
- Sovellus kirjoittaa itse CloudWatchiin
- OpenTelemetry collector -sidecar (nykyään osaa myös lokeja)

Valitsin tässä yksinkertaisimman eli sen että sovellus itse kirjoittaa audit-lokirivit CloudWatchiin.

Tämä riippuu PR:stä #213 

Esimerkki käytöstä:

https://github.com/Opetushallitus/ludos/blob/efa925c4638a5f86fbb8d1e3c29a4da750f1dd25/server/src/main/kotlin/fi/oph/ludos/auth/CasConfig.kt#L98-L102