### PR TITLE
Attach request user information to structured log data

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/logging/UserIdLogFilterConfiguration.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/UserIdLogFilterConfiguration.kt
@@ -1,0 +1,48 @@
+package fi.oph.kitu.logging
+
+import fi.oph.kitu.auth.CasUserDetails
+import fi.oph.kitu.auth.CasUserDetailsService
+import jakarta.servlet.Filter
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.MDC
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.cas.authentication.CasAssertionAuthenticationToken
+import org.springframework.security.cas.authentication.CasAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+
+@Configuration
+class UserIdLogFilterConfiguration {
+    @Bean
+    fun userIdLogFilter(userDetailsService: CasUserDetailsService) =
+        Filter { request, response, filterChain ->
+            val token = (request as? HttpServletRequest)?.userPrincipal
+            MDC.put("user.auth_type", token?.javaClass?.kotlin?.simpleName ?: "not authenticated")
+            val user =
+                when (token) {
+                    is CasAuthenticationToken -> token.userDetails as CasUserDetails
+                    is CasAssertionAuthenticationToken ->
+                        userDetailsService.loadUserDetails(
+                            token,
+                        ) as CasUserDetails
+
+                    else -> null
+                }
+
+            if (user != null) {
+                MDC.put("user.id", user.oid)
+                MDC.put("user.roles", authoritiesToString(user.authorities))
+
+                MDC.put("user.strong_auth", user.strongAuth.toString())
+                MDC.put("user.type", user.kayttajaTyyppi)
+            }
+
+            filterChain.doFilter(request, response)
+            MDC.clear()
+        }
+
+    private fun authoritiesToString(authorities: List<GrantedAuthority>): String =
+        authorities
+            .joinToString(",", transform = { "\"${it.authority}\"" })
+            .let { "[$it]" }
+}


### PR DESCRIPTION
Muutokset käyttävät SLF4J/Logback MDC:ta (Mapped Diagnostic Context) liittämään "globaalisti" kaikkien sisään tulevien autentikoitujen pyyntöjen käyttäjätiedoista OID:n lokirivien rakenteellisiin tietoihin.

MDC:hen lisätyt avain-arvoparit näkyvät lokiriveillä vastaavasti kuin `.addKeyValue`:lla lisätyt avain-arvoparit, sillä erotuksella, että MDC:n arvot säilyvät `.log()`-kutsujen yli, eli sinne liitetyt arvot ovat ns. "globaalia kontekstia".

Etuna on ettei jokaista lokiriviä varten tarvitse erikseen muistaa kutsua jotakin `.addUserInfo()` tmv, vaan tällainen kontekstitieto olisi aina automaattisesti saatavilla. Varjopuolena menetetään kontrollia siitä mitä tietoja yksittäiselle lokiriville liitetään. MDC on myös toiminnaltaan hieman maaginen, joten joissain tilanteissa voi olla yllättävää, että lokiriveille vain tupsahtaa datakenttiä "jostakin".