### PR TITLE
fix: format markdown with prettier

### DIFF
--- a/scripts/check-formatting.sh
+++ b/scripts/check-formatting.sh
@@ -2,6 +2,6 @@
 
 set -eux
 
-prettier --check .
+prettier --check '**/*.{md,yml,yaml,js,ts,jsx,tsx,cjs,cts,mjs,mts,vue,astro,json}'
 (cd server && ktlint)
 shellcheck -P ./scripts ./scripts/*.sh

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
-prettier --write .
+prettier --write '**/*.{md,yml,yaml,js,ts,jsx,tsx,cjs,cts,mjs,mts,vue,astro,json}'
 (cd server && ktlint --format)


### PR DESCRIPTION
I copied the glob from IDEA's Prettier plugin.
