### PR TITLE
chore(.github): keep 'ref:' - prefix in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,18 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
+  ],
+  "customManagers": [
+    {
+      "fileMatch": ["\\.mise\\.toml$"],
+      "matchStrings": [
+        "^(?<depName>[a-zA-Z0-9_-]+)\\s*=\\s*\"ref:(?<currentValue>.*?)\"$"
+      ],
+      "depNameTemplate": "{{depName}}",
+      "versioningTemplate": "semver",
+      "datasourceTemplate": "pypi",
+      "extractVersionTemplate": "ref:{{newVersion}}",
+      "replaceStringTemplate": "{{depName}} = \"ref:{{newVersion}}\""
+    }
   ]
 }


### PR DESCRIPTION
Only tested dry-run, but not sure yet if this works. Atleast dry-run passes.