### PR TITLE
refactor: improve logging on oppijanumero

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/ExternalSystem.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ExternalSystem.kt
@@ -5,4 +5,6 @@ enum class ExternalSystem(
 ) {
     Koealusta("koealusta"),
     Solki("solki"),
+    Cas("cas"),
+    Oppijanumero("oppijanumero"),
 }

--- a/server/src/main/kotlin/fi/oph/kitu/ExternalSystem.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ExternalSystem.kt
@@ -1,0 +1,8 @@
+package fi.oph.kitu
+
+enum class ExternalSystem(
+    val value: String,
+) {
+    Koealusta("koealusta"),
+    Solki("solki"),
+}

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
@@ -3,7 +3,9 @@ package fi.oph.kitu.kotoutumiskoulutus
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import fi.oph.kitu.ExternalSystem
 import fi.oph.kitu.logging.add
+import fi.oph.kitu.logging.addExternalSystem
 import fi.oph.kitu.logging.addResponse
 import fi.oph.kitu.logging.withEvent
 import org.slf4j.LoggerFactory
@@ -71,10 +73,9 @@ class KoealustaService(
                     .toEntity<String>()
 
             event
-                .add(
-                    "request.token" to koealustaToken,
-                    "external-system" to "solki",
-                ).addResponse(response)
+                .add("request.token" to koealustaToken)
+                .addExternalSystem(ExternalSystem.Koealusta)
+                .addResponse(response)
 
             if (response.body == null) {
                 return@withEvent from

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import fi.oph.kitu.ExternalSystem
 import fi.oph.kitu.logging.add
-import fi.oph.kitu.logging.addExternalSystem
 import fi.oph.kitu.logging.addResponse
 import fi.oph.kitu.logging.withEvent
 import org.slf4j.LoggerFactory
@@ -74,8 +73,7 @@ class KoealustaService(
 
             event
                 .add("request.token" to koealustaToken)
-                .addExternalSystem(ExternalSystem.Koealusta)
-                .addResponse(response)
+                .addResponse(response, ExternalSystem.Koealusta)
 
             if (response.body == null) {
                 return@withEvent from

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
@@ -71,8 +71,10 @@ class KoealustaService(
                     .toEntity<String>()
 
             event
-                .add("request.token" to koealustaToken)
-                .addResponse(response)
+                .add(
+                    "request.token" to koealustaToken,
+                    "external-system" to "solki",
+                ).addResponse(response)
 
             if (response.body == null) {
                 return@withEvent from

--- a/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.logging
 
+import fi.oph.kitu.ExternalSystem
 import org.slf4j.spi.LoggingEventBuilder
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.ResponseEntity
@@ -34,6 +35,9 @@ fun LoggingEventBuilder.addIsDuplicateKeyException(ex: Exception): LoggingEventB
 
     return this
 }
+
+fun LoggingEventBuilder.addExternalSystem(externalSystem: ExternalSystem) =
+    this.addKeyValue("external-system", externalSystem.value)
 
 fun LoggingEventBuilder.add(vararg pairs: Pair<String, Any?>): LoggingEventBuilder {
     for ((key, value) in pairs) {

--- a/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
@@ -4,13 +4,17 @@ import fi.oph.kitu.ExternalSystem
 import org.slf4j.spi.LoggingEventBuilder
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.ResponseEntity
+import java.net.http.HttpResponse
 
-inline fun <reified T> LoggingEventBuilder.addResponse(response: ResponseEntity<T>): LoggingEventBuilder {
-    this.addKeyValue("response.headers", response.headers)
-    this.addKeyValue("response.body", response.body)
+inline fun <reified T> LoggingEventBuilder.addResponse(response: HttpResponse<T>): LoggingEventBuilder =
+    this
+        .addKeyValue("response.headers", response.headers().toString())
+        .addKeyValue("response.body", response.body().toString())
 
-    return this
-}
+inline fun <reified T> LoggingEventBuilder.addResponse(response: ResponseEntity<T>): LoggingEventBuilder =
+    this
+        .addKeyValue("response.headers", response.headers)
+        .addKeyValue("response.body", response.body)
 
 fun LoggingEventBuilder.addIsDuplicateKeyException(ex: Exception): LoggingEventBuilder {
     val isDuplicateKeyException = ex is DuplicateKeyException || ex.cause is DuplicateKeyException

--- a/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
@@ -6,15 +6,23 @@ import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.ResponseEntity
 import java.net.http.HttpResponse
 
-inline fun <reified T> LoggingEventBuilder.addResponse(response: HttpResponse<T>): LoggingEventBuilder =
+inline fun <reified T> LoggingEventBuilder.addResponse(
+    response: HttpResponse<T>,
+    externalSystem: ExternalSystem,
+): LoggingEventBuilder =
     this
         .addKeyValue("response.headers", response.headers().toString())
         .addKeyValue("response.body", response.body().toString())
+        .addKeyValue("external-system", externalSystem.value)
 
-inline fun <reified T> LoggingEventBuilder.addResponse(response: ResponseEntity<T>): LoggingEventBuilder =
+inline fun <reified T> LoggingEventBuilder.addResponse(
+    response: ResponseEntity<T>,
+    externalSystem: ExternalSystem,
+): LoggingEventBuilder =
     this
         .addKeyValue("response.headers", response.headers)
         .addKeyValue("response.body", response.body)
+        .addKeyValue("external-system", externalSystem.value)
 
 fun LoggingEventBuilder.addIsDuplicateKeyException(ex: Exception): LoggingEventBuilder {
     val isDuplicateKeyException = ex is DuplicateKeyException || ex.cause is DuplicateKeyException
@@ -39,9 +47,6 @@ fun LoggingEventBuilder.addIsDuplicateKeyException(ex: Exception): LoggingEventB
 
     return this
 }
-
-fun LoggingEventBuilder.addExternalSystem(externalSystem: ExternalSystem) =
-    this.addKeyValue("external-system", externalSystem.value)
 
 fun LoggingEventBuilder.add(vararg pairs: Pair<String, Any?>): LoggingEventBuilder {
     for ((key, value) in pairs) {

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.oppijanumero
 
+import fi.oph.kitu.ExternalSystem
 import fi.oph.kitu.logging.addResponse
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -33,14 +34,14 @@ class CasAuthenticatedService(
             .header("CSRF", "CSRF")
             .header("Cookie", "CSRF=CSRF")
         val response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(response).log()
+        logger.atInfo().addResponse(response, ExternalSystem.Oppijanumero).log()
 
         if (isLoginToCas(response)) {
             // Oppijanumerorekisteri ohjaa CAS kirjautumissivulle, jos autentikaatiota
             // ei ole tehty. Luodaan uusi CAS ticket ja yritetään uudelleen.
             authenticateToCas() // gets JSESSIONID Cookie and it will be used in the next request below
             val authenticatedResponse = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
-            logger.atInfo().addResponse(authenticatedResponse).log()
+            logger.atInfo().addResponse(authenticatedResponse, ExternalSystem.Oppijanumero).log()
 
             return authenticatedResponse
         } else if (response.statusCode() == 401) {
@@ -48,7 +49,7 @@ class CasAuthenticatedService(
             // HUOM! Oppijanumerorekisteri vastaa HTTP 401 myös jos käyttöoikeudet eivät riitä.
             authenticateToCas() // gets JSESSIONID Cookie and it will be used in the next request below
             val authenticatedResponse = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
-            logger.atInfo().addResponse(authenticatedResponse).log()
+            logger.atInfo().addResponse(authenticatedResponse, ExternalSystem.Oppijanumero).log()
             return authenticatedResponse
         } else {
             return response

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.oppijanumero
 
+import fi.oph.kitu.logging.addResponse
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -27,25 +28,28 @@ class CasAuthenticatedService(
     }
 
     fun sendRequest(requestBuilder: HttpRequest.Builder): HttpResponse<String> {
-        logger.atInfo().log("Sending CAS authenticated request")
         requestBuilder
             .header("Caller-Id", callerId)
             .header("CSRF", "CSRF")
             .header("Cookie", "CSRF=CSRF")
         val response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+        logger.atInfo().addResponse(response).log()
 
         if (isLoginToCas(response)) {
             // Oppijanumerorekisteri ohjaa CAS kirjautumissivulle, jos autentikaatiota
             // ei ole tehty. Luodaan uusi CAS ticket ja yritetään uudelleen.
-            logger.atInfo().log("Was redirected to CAS login")
             authenticateToCas() // gets JSESSIONID Cookie and it will be used in the next request below
-            return httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+            val authenticatedResponse = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+            logger.atInfo().addResponse(authenticatedResponse).log()
+
+            return authenticatedResponse
         } else if (response.statusCode() == 401) {
             // Oppijanumerorekisteri vastaa HTTP 401 kun sessio on vanhentunut.
             // HUOM! Oppijanumerorekisteri vastaa HTTP 401 myös jos käyttöoikeudet eivät riitä.
-            logger.atInfo().log("Received HTTP 401 response")
             authenticateToCas() // gets JSESSIONID Cookie and it will be used in the next request below
-            return httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+            val authenticatedResponse = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+            logger.atInfo().addResponse(authenticatedResponse).log()
+            return authenticatedResponse
         } else {
             return response
         }

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.oppijanumero
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.net.URI
@@ -12,6 +13,8 @@ import java.net.http.HttpResponse
 class CasService(
     private val httpClient: HttpClient,
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     @Value("\${kitu.oppijanumero.username}")
     private lateinit var onrUsername: String
 
@@ -31,7 +34,7 @@ class CasService(
                 .method("GET", HttpRequest.BodyPublishers.noBody())
                 .build()
         val authResponse = httpClient.send(authRequest, HttpResponse.BodyHandlers.ofString())
-        println("Auth reset response: $authResponse")
+        logger.atInfo().log("Auth reset response: $authResponse")
     }
 
     fun getServiceTicket(ticketGrantingTicket: String): String {
@@ -52,7 +55,7 @@ class CasService(
         }
 
         val ticket = response.body()
-        println("Successfully got service ticket $ticket")
+        logger.atInfo().log("Successfully got service ticket $ticket")
         return ticket
     }
 
@@ -78,7 +81,7 @@ class CasService(
 
         val location = response.headers().firstValue("Location").get()
         val ticket = location.substring(location.lastIndexOf("/") + 1)
-        println("Successfully fetched TGT (Ticket Granting Ticket): $ticket")
+        logger.atInfo().log("Successfully fetched TGT (Ticket Granting Ticket): $ticket")
 
         return ticket
     }

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.oppijanumero
 
+import fi.oph.kitu.ExternalSystem
 import fi.oph.kitu.logging.addResponse
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -35,7 +36,7 @@ class CasService(
                 .method("GET", HttpRequest.BodyPublishers.noBody())
                 .build()
         val authResponse = httpClient.send(authRequest, HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(authResponse).log()
+        logger.atInfo().addResponse(authResponse, ExternalSystem.Oppijanumero).log()
     }
 
     fun getServiceTicket(ticketGrantingTicket: String): String {
@@ -50,7 +51,7 @@ class CasService(
                 .build()
 
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(response).log()
+        logger.atInfo().addResponse(response, ExternalSystem.Cas).log()
 
         if (response.statusCode() != 200) {
             throw RuntimeException("Unexpected status code: ${response.statusCode()} and message: ${response.body()}")
@@ -73,7 +74,7 @@ class CasService(
 
         // Step 3 - Get the response
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(response).log()
+        logger.atInfo().addResponse(response, ExternalSystem.Cas).log()
 
         val statusCode = response.statusCode()
         val body = response.body()

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.oppijanumero
 
+import fi.oph.kitu.logging.addResponse
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -34,7 +35,7 @@ class CasService(
                 .method("GET", HttpRequest.BodyPublishers.noBody())
                 .build()
         val authResponse = httpClient.send(authRequest, HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().log("Auth reset response: $authResponse")
+        logger.atInfo().addResponse(authResponse).log()
     }
 
     fun getServiceTicket(ticketGrantingTicket: String): String {
@@ -49,13 +50,13 @@ class CasService(
                 .build()
 
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        logger.atInfo().addResponse(response).log()
 
         if (response.statusCode() != 200) {
             throw RuntimeException("Unexpected status code: ${response.statusCode()} and message: ${response.body()}")
         }
 
         val ticket = response.body()
-        logger.atInfo().log("Successfully got service ticket $ticket")
         return ticket
     }
 
@@ -72,6 +73,8 @@ class CasService(
 
         // Step 3 - Get the response
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        logger.atInfo().addResponse(response).log()
+
         val statusCode = response.statusCode()
         val body = response.body()
 
@@ -80,9 +83,6 @@ class CasService(
         }
 
         val location = response.headers().firstValue("Location").get()
-        val ticket = location.substring(location.lastIndexOf("/") + 1)
-        logger.atInfo().log("Successfully fetched TGT (Ticket Granting Ticket): $ticket")
-
-        return ticket
+        return location.substring(location.lastIndexOf("/") + 1)
     }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroController.kt
@@ -1,6 +1,7 @@
 package fi.oph.kitu.oppijanumero
 
 import fi.oph.kitu.generated.api.OppijanumeroControllerApi
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController
 class OppijanumeroController(
     private val oppijanumeroService: OppijanumeroService,
 ) : OppijanumeroControllerApi {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     override fun getOppijanumero(): ResponseEntity<String> {
         try {
             val response =
@@ -25,7 +28,7 @@ class OppijanumeroController(
                 if (response.statusCode() == 200) HttpStatus.OK else HttpStatus.INTERNAL_SERVER_ERROR,
             )
         } catch (e: Exception) {
-            println("ERROR: ${e.message}")
+            logger.atError().setCause(e).log()
 
             return ResponseEntity(
                 "An unexpected error has occurred:${e.localizedMessage}",

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController
 class OppijanumeroController(
     private val oppijanumeroService: OppijanumeroService,
 ) : OppijanumeroControllerApi {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val event = LoggerFactory.getLogger(javaClass).atInfo()
 
     override fun getOppijanumero(): ResponseEntity<String> {
         try {
@@ -28,12 +28,14 @@ class OppijanumeroController(
                 if (response.statusCode() == 200) HttpStatus.OK else HttpStatus.INTERNAL_SERVER_ERROR,
             )
         } catch (e: Exception) {
-            logger.atError().setCause(e).log()
+            event.setCause(e)
 
             return ResponseEntity(
                 "An unexpected error has occurred:${e.localizedMessage}",
                 HttpStatus.INTERNAL_SERVER_ERROR,
             )
+        } finally {
+            event.log()
         }
     }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
@@ -1,6 +1,5 @@
 package fi.oph.kitu.oppijanumero
 
-import fi.oph.kitu.logging.addResponse
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -24,9 +23,7 @@ class OppijanumeroService(
                 .POST(toBodyPublisher(request))
                 .header("Content-Type", "application/json")
 
-        val response = casAuthenticatedService.sendRequest(httpRequest)
-        logger.atInfo().addResponse(response).log()
-        return response
+        return casAuthenticatedService.sendRequest(httpRequest)
     }
 
     private fun toBodyPublisher(request: YleistunnisteHaeRequest): HttpRequest.BodyPublisher =

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
@@ -1,5 +1,7 @@
 package fi.oph.kitu.oppijanumero
 
+import fi.oph.kitu.logging.addResponse
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.net.URI
@@ -10,6 +12,8 @@ import java.net.http.HttpResponse
 class OppijanumeroService(
     private val casAuthenticatedService: CasAuthenticatedService,
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     @Value("\${kitu.oppijanumero.serviceUrl}")
     private lateinit var serviceUrl: String
 
@@ -21,6 +25,7 @@ class OppijanumeroService(
                 .header("Content-Type", "application/json")
 
         val response = casAuthenticatedService.sendRequest(httpRequest)
+        logger.atInfo().addResponse(response).log()
         return response
     }
 

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -3,8 +3,6 @@ package fi.oph.kitu.yki
 import fi.oph.kitu.ExternalSystem
 import fi.oph.kitu.csvparsing.asCsv
 import fi.oph.kitu.logging.add
-import fi.oph.kitu.logging.addExternalSystem
-import fi.oph.kitu.logging.addIsDuplicateKeyException
 import fi.oph.kitu.logging.addResponse
 import fi.oph.kitu.logging.withEvent
 import org.slf4j.Logger
@@ -28,8 +26,7 @@ class YkiService(
         lastSeen: LocalDate? = null,
         dryRun: Boolean? = null,
     ) = logger.atInfo().withEvent("yki.importSuoritukset") { event ->
-        event
-            .add("dryRun" to dryRun, "lastSeen" to lastSeen)
+        event.add("dryRun" to dryRun, "lastSeen" to lastSeen)
 
         val response =
             solkiRestClient
@@ -38,11 +35,7 @@ class YkiService(
                 .retrieve()
                 .toEntity<String>()
 
-        event
-            .addResponse(response)
-            .addKeyValue("external-system", "solki")
-                .addResponse(response)
-                .addExternalSystem(ExternalSystem.Solki)
+        event.addResponse(response, ExternalSystem.Solki)
 
         val suoritukset =
             response.body?.asCsv<SolkiSuoritusResponse>() ?: throw RestClientException("Response body is empty")

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -1,7 +1,10 @@
 package fi.oph.kitu.yki
 
+import fi.oph.kitu.ExternalSystem
 import fi.oph.kitu.csvparsing.asCsv
 import fi.oph.kitu.logging.add
+import fi.oph.kitu.logging.addExternalSystem
+import fi.oph.kitu.logging.addIsDuplicateKeyException
 import fi.oph.kitu.logging.addResponse
 import fi.oph.kitu.logging.withEvent
 import org.slf4j.Logger
@@ -38,6 +41,8 @@ class YkiService(
         event
             .addResponse(response)
             .addKeyValue("external-system", "solki")
+                .addResponse(response)
+                .addExternalSystem(ExternalSystem.Solki)
 
         val suoritukset =
             response.body?.asCsv<SolkiSuoritusResponse>() ?: throw RestClientException("Response body is empty")


### PR DESCRIPTION
refactor logging. In oppijanumero, logs all HTTP responses to the same log event. I recommend to read this commit by commit.

refactor loggin, mostly on oppijaumero.
- replaced `println` from Oppijanumero with `logger.atInfo ... .log()`, since it was already printing each request.
  - removed few redundant log row 
 - `addResponse` requires now a parameter `ExternalSystem`. This is to tag external systems easier (for example if the message was from CAS or Oppijamumero)