### PR TITLE
fix: use setup node action in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: Install tools
         uses: jdx/mise-action@v2
         with:
@@ -97,7 +98,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
       - name: Install tools
         uses: jdx/mise-action@v2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -78,6 +78,10 @@ jobs:
       # to build your code.
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - if: matrix.build-mode == 'none'
+        name: Setup node
+        uses: actions/setup-node@v4
+
       - if: matrix.build-mode == 'manual'
         uses: jdx/mise-action@v2
         with:

--- a/.mise.local.toml
+++ b/.mise.local.toml
@@ -1,0 +1,5 @@
+[env]
+SPRING_PROFILES_ACTIVE = 'local'
+
+[tools]
+node = '23.1.0'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,7 @@
 [env]
-SPRING_PROFILES_ACTIVE = 'local'
 KOTLIN_POST_PROCESS_FILE = "ktlint -F"
 
 [tools]
-node = '23.1.0'
 "npm:prettier" = "3.3.3"
 maven = "3.9.9"
 awscli = "ref:2.18.17"


### PR DESCRIPTION
and mise in local development to setup node

This should fix: https://github.com/Opetushallitus/koto-rekisteri/actions/runs/11589570975/


My guess is, that the issue is that CI tries to install node via mise, but github recommends to install node via `actions/setup-node` in github actions.