### PR TITLE
fix: renovate pom match

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       "automerge": true
     },
     {
-      "fileMatch": ["pom.xml$"],
+      "matchFileNames": ["**/pom.xml"],
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }


### PR DESCRIPTION
This should fix the following warning (wrong behaviour) found in [Renovate logs](https://developer.mend.io/github/Opetushallitus/koto-rekisteri/-/job/7fcb7fbc-fa8d-4ecc-af0e-0b8a2572d154):

```
WARN: Found renovate config warnings
{
  "warnings": [
    {
      "topic": "Config warning",
      "message": "\"fileMatch\" must be configured in a manager block and not here: packageRules[1]"
    }
  ]
}
```