### PR TITLE
chore: disable integrations in prod

### DIFF
--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -7,13 +7,13 @@ spring.datasource.username=${DATABASE_USER}
 spring.datasource.password=${DATABASE_PASSWORD}
 
 kitu.kotoutumiskoulutus.koealusta.baseurl=https://kielitesti.oph.fi
-kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=true
-kitu.kotoutumiskoulutus.koealusta.scheduling.import.schedule=FIXED_DELAY|60s
+kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=false
+kitu.kotoutumiskoulutus.koealusta.scheduling.import.schedule=DAILY|01:00
 
 kitu.oppijanumero.username=koto-rekisteri
 kitu.oppijanumero.callerid=
 kitu.oppijanumero.casUrl=https://virkailija.opintopolku.fi/cas
 kitu.oppijanumero.serviceUrl=https://virkailija.opintopolku.fi/oppijanumerorekisteri-service
 
-kitu.yki.scheduling.enabled=true
+kitu.yki.scheduling.enabled=false
 kitu.yki.scheduling.import.schedule=DAILY|03:00


### PR DESCRIPTION
We get spurious alerts from them since we don't have the integration keys yet.

The alternative would be to disable the log alarm in prod.