### PR TITLE
feat: add scheduler UI

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -174,6 +174,16 @@
             <version>14.1.0</version>
         </dependency>
         <dependency>
+            <groupId>io.rocketbase.extension</groupId>
+            <artifactId>db-scheduler-log-spring-boot-starter</artifactId>
+            <version>0.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>no.bekk.db-scheduler-ui</groupId>
+            <artifactId>db-scheduler-ui-starter</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jdbc</artifactId>
         </dependency>

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -19,6 +19,9 @@ kitu.oppijanumero.serviceUrl=https://virkailija.untuvaopintopolku.fi/oppijanumer
 db-scheduler.enabled=true
 db-scheduler.delay-startup-until-context-ready=true
 
+db-scheduler-ui.history=true
+db-scheduler-ui.log-limit=1000
+
 kitu.yki.scheduling.enabled=false
 kitu.yki.scheduling.import.schedule=-
 kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/yki-sp/oph/

--- a/server/src/main/resources/db/migration/V9__create_scheduled_executions_logs_table.sql
+++ b/server/src/main/resources/db/migration/V9__create_scheduled_executions_logs_table.sql
@@ -1,0 +1,19 @@
+create table scheduled_execution_logs
+(
+    id                   BIGINT                   not null primary key,
+    task_name            text                     not null,
+    task_instance        text                     not null,
+    task_data            bytea,
+    picked_by            text,
+    time_started         timestamp with time zone not null,
+    time_finished        timestamp with time zone not null,
+    succeeded            BOOLEAN                  not null,
+    duration_ms          BIGINT                   not null,
+    exception_class      text,
+    exception_message    text,
+    exception_stacktrace text
+);
+
+CREATE INDEX stl_started_idx ON scheduled_execution_logs (time_started);
+CREATE INDEX stl_task_name_idx ON scheduled_execution_logs (task_name);
+CREATE INDEX stl_exception_class_idx ON scheduled_execution_logs (exception_class);


### PR DESCRIPTION
The UI is available at $URL/db-scheduler after CAS authentication.

<img width="1436" alt="Screenshot 2024-11-12 at 16 53 02" src="https://github.com/user-attachments/assets/cad1ddb6-6d70-4153-84e5-66c9c57e567c">
