### PR TITLE
WIP: refactor: logging

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
@@ -100,7 +100,7 @@ class KoealustaService(
 
             event
                 .add("request.token" to koealustaToken)
-                .addResponse(response, PeerService.Koealusta)
+                .addResponse(PeerService.Koealusta, "webservice", response)
 
             if (response.body == null) {
                 return@withEvent from

--- a/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
@@ -7,23 +7,29 @@ import org.springframework.http.ResponseEntity
 import java.net.http.HttpResponse
 
 inline fun <reified T> LoggingEventBuilder.addResponse(
-    response: HttpResponse<T>,
     peerService: PeerService,
+    endpoint: String,
+    response: HttpResponse<T>,
 ): LoggingEventBuilder =
-    this
-        .addKeyValue("response.status", response.statusCode())
-        .addKeyValue("response.headers", response.headers().toString())
-        .addKeyValue("response.body", response.body().toString())
-        .addKeyValue("peer.service", peerService.value)
+    addResponse<T>(peerService, endpoint, response.statusCode(), response.headers(), response.body())
 
 inline fun <reified T> LoggingEventBuilder.addResponse(
-    response: ResponseEntity<T>,
     peerService: PeerService,
+    endpoint: String,
+    response: ResponseEntity<T>,
+): LoggingEventBuilder = addResponse<T>(peerService, endpoint, response.statusCode, response.headers, response.body)
+
+inline fun <reified T> LoggingEventBuilder.addResponse(
+    peerService: PeerService,
+    endpoint: String,
+    responseStatus: Any,
+    responseHeaders: Any,
+    responseBody: Any?,
 ): LoggingEventBuilder =
     this
-        .addKeyValue("response.status", response.statusCode)
-        .addKeyValue("response.headers", response.headers)
-        .addKeyValue("response.body", response.body)
+        .addKeyValue("$peerService.$endpoint.response.status", responseStatus)
+        .addKeyValue("$peerService.$endpoint.response.headers", responseHeaders)
+        .addKeyValue("$peerService.$endpoint.response.body", responseBody)
         .addKeyValue("peer.service", peerService.value)
 
 inline fun <reified T> LoggingEventBuilder.addResponse(

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
@@ -34,14 +34,20 @@ class CasAuthenticatedService(
             .header("CSRF", "CSRF")
             .header("Cookie", "CSRF=CSRF")
         val response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(response, PeerService.Oppijanumero).log()
+        logger.atInfo().addResponse(PeerService.Oppijanumero, "yleistunniste.hae", response).log()
 
         if (isLoginToCas(response)) {
             // Oppijanumerorekisteri ohjaa CAS kirjautumissivulle, jos autentikaatiota
             // ei ole tehty. Luodaan uusi CAS ticket ja yritetään uudelleen.
             authenticateToCas() // gets JSESSIONID Cookie and it will be used in the next request below
             val authenticatedResponse = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
-            logger.atInfo().addResponse(authenticatedResponse, PeerService.Oppijanumero).log()
+            logger
+                .atInfo()
+                .addResponse(
+                    PeerService.Oppijanumero,
+                    "yleistunnistunniste.hae",
+                    authenticatedResponse,
+                ).log()
 
             return authenticatedResponse
         } else if (response.statusCode() == 401) {
@@ -49,7 +55,7 @@ class CasAuthenticatedService(
             // HUOM! Oppijanumerorekisteri vastaa HTTP 401 myös jos käyttöoikeudet eivät riitä.
             authenticateToCas() // gets JSESSIONID Cookie and it will be used in the next request below
             val authenticatedResponse = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
-            logger.atInfo().addResponse(authenticatedResponse, PeerService.Oppijanumero).log()
+            logger.atInfo().addResponse(PeerService.Oppijanumero, "yleistunniste.hae", authenticatedResponse).log()
             return authenticatedResponse
         } else if (response.statusCode() != 200) {
             throw RuntimeException("Unexpected HTTP status code: ${response.statusCode()}")

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
@@ -36,7 +36,7 @@ class CasService(
                 .method("GET", HttpRequest.BodyPublishers.noBody())
                 .build()
         val authResponse = httpClient.send(authRequest, HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(authResponse, PeerService.Oppijanumero).log()
+        logger.atInfo().addResponse(PeerService.Oppijanumero, "j_spring_cas_security_check", authResponse).log()
     }
 
     fun getServiceTicket(ticketGrantingTicket: String): String {
@@ -51,7 +51,7 @@ class CasService(
                 .build()
 
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(response, PeerService.Cas).log()
+        logger.atInfo().addResponse(PeerService.Cas, "v1.tickets.withticket", response).log()
 
         if (response.statusCode() != 200) {
             throw RuntimeException("Unexpected status code: ${response.statusCode()} and message: ${response.body()}")
@@ -74,7 +74,7 @@ class CasService(
 
         // Step 3 - Get the response
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-        logger.atInfo().addResponse(response, PeerService.Cas).log()
+        logger.atInfo().addResponse(PeerService.Cas, "v1.tickets", response).log()
 
         val statusCode = response.statusCode()
         val body = response.body()

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -47,7 +47,7 @@ class YkiService(
                     .retrieve()
                     .toEntity<String>()
 
-            event.addResponse(response, PeerService.Solki)
+            event.addResponse(PeerService.Solki, "suoritukset", response)
 
             val suoritukset = response.body?.asCsv<SolkiSuoritusResponse>() ?: listOf()
 


### PR DESCRIPTION
refactor logging more. Waiting for #365

Muutokset:  lisätty `endpoint` addResponse metodiin.

esim:
```kotlin
// How to use
logger.atInfo().addResponse(PeerService.Oppijanumero, "yleistunniste.hae", authenticatedResponse).log()
```

Ja se on nyt jotakuinkin näin:
```kotlin
// Implementations
inline fun <reified T> LoggingEventBuilder.addResponse(
    peerService: PeerService,
    endpoint: String,
    response: HttpResponse<T>,
): LoggingEventBuilder = addResponse<T>(peerService, endpoint, response.headers(), response.body())


inline fun <reified T> LoggingEventBuilder.addResponse(
    peerService: PeerService,
    endpoint: String,
    responseHeaders: Any,
    responseBody: Any?,
): LoggingEventBuilder =
    this
        .addKeyValue("$peerService.$endpoint.response.headers", responseHeaders)
        .addKeyValue("$peerService.$endpoint.response.body", responseBody)
        .addKeyValue("peer.service", peerService.value)
```