### PR TITLE
feat(scripts): source aws secrets in start_local_env.sh

### DIFF
--- a/scripts/ensure_aws_secrets.sh
+++ b/scripts/ensure_aws_secrets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_dir=$( dirname "${BASH_SOURCE[0]}" )
+source "$current_dir/common-functions.sh"
+
+get_secret() {
+  aws secretsmanager get-secret-value --secret-id "$1" --output text --query SecretString
+}
+
+"$current_dir/ensure_aws_profiles.sh"
+require_dev_aws_session
+
+export "KIELITESTI_TOKEN"="$(get_secret "kielitesti-token")"; echo "KIELITESTI_TOKEN exported"
+export "OPPIJANUMERO_PASSWORD"="$(get_secret "oppijanumero-password")"; echo "OPPIJANUMERO_PASSWORD exported"
+export "YKI_API_USER"="$(get_secret "yki-api-user")"; echo "YKI_API_USER exported"
+export "YKI_API_PASSWORD"="$(get_secret "yki-api-password")"; echo "YKI_API_PASSWORD exported"

--- a/scripts/start_local_env.sh
+++ b/scripts/start_local_env.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "$( dirname "${BASH_SOURCE[0]}" )/common-functions.sh"
+scripts_dir=$( dirname "${BASH_SOURCE[0]}" )
+source "$scripts_dir/common-functions.sh"
 
 require_command mise
 
@@ -23,6 +24,8 @@ mise install --quiet  --yes --cd="$REPO_ROOT"
 
 require_command docker
 require_command git
+
+"$scripts_dir/ensure_aws_secrets.sh"
 
 ### Additional options/switches ###
 

--- a/scripts/start_local_env.sh
+++ b/scripts/start_local_env.sh
@@ -25,7 +25,8 @@ mise install --quiet  --yes --cd="$REPO_ROOT"
 require_command docker
 require_command git
 
-"$scripts_dir/ensure_aws_secrets.sh"
+# exports secrets to environment variables
+source "$scripts_dir/ensure_aws_secrets.sh"
 
 ### Additional options/switches ###
 

--- a/scripts/start_local_server.sh
+++ b/scripts/start_local_server.sh
@@ -9,19 +9,9 @@ get_secret() {
 }
 
 require_command humanlog
-require_command aws
-
-configure_aws_sso_profiles
-require_dev_aws_session
 
 require_env SPRING_PROFILES_ACTIVE
 require_env KOTLIN_POST_PROCESS_FILE
 
 cd "$REPO_ROOT"/server
-
-KIELITESTI_TOKEN=$(get_secret kielitesti-token); export KIELITESTI_TOKEN
-OPPIJANUMERO_PASSWORD=$(get_secret oppijanumero-password); export OPPIJANUMERO_PASSWORD
-YKI_API_USER=$(get_secret yki-api-user); export YKI_API_USER
-YKI_API_PASSWORD=$(get_secret yki-api-password); export YKI_API_PASSWORD
-
 ./mvnw spring-boot:run | humanlog --truncate-length 9999

--- a/scripts/test_oppijanumerorekisteri.sh
+++ b/scripts/test_oppijanumerorekisteri.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-curl -s -i \
-    -X POST "https://virkailija.testiopintopolku.fi/cas/v1/tickets" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=$1&password=$2"


### PR DESCRIPTION
In my setup, I usually do not use `start_local_server.sh`, so want to use the variables outside the script. Also, they were not sourced, so they weren't accessible, atleast for idea's debugger.
