### PR TITLE
fix: db-scheduler-ui run/rerun triggers

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
@@ -30,8 +30,9 @@ class WebSecurityConfig {
         environment: Environment,
     ): SecurityFilterChain {
         http
-            .csrf { csrf -> csrf.ignoringRequestMatchers("/api/*") }
-            .logout {
+            .csrf { csrf ->
+                csrf.ignoringRequestMatchers("/api/*", "/db-scheduler-api/**")
+            }.logout {
                 it.logoutSuccessUrl(casConfig.getCasLogoutUrl())
                 it.logoutUrl("/logout")
                 it.logoutRequestMatcher(AntPathRequestMatcher("/logout", "GET"))


### PR DESCRIPTION
Muutin toteutuksen nyt niin että otetaan CSRF-suoja pois päältä näiltä API-endpointeilta. 