### PR TITLE
feat: enable RDS Data API

### DIFF
--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -34,6 +34,7 @@ concurrency:
 
 env:
   TAG: ${{ github.sha }}
+  MISE_PROFILE: ci
 
 jobs:
   run:

--- a/.mise.ci.toml
+++ b/.mise.ci.toml
@@ -1,2 +1,3 @@
 [env]
 SPRING_PROFILES_ACTIVE = 'ci'
+AWS_PROFILE = false

--- a/infra/lib/db-stack.ts
+++ b/infra/lib/db-stack.ts
@@ -21,6 +21,7 @@ export class DbStack extends cdk.Stack {
       writer: aws_rds.ClusterInstance.serverlessV2("writer"),
       storageEncrypted: true,
       defaultDatabaseName: props.databaseName,
+      enableDataApi: true,
     })
   }
 }


### PR DESCRIPTION
This allows us to use the Query Editor in AWS Console to e.g. clear the database when testing imports.

I'm not sure if we need to grant access separately to our IAM role - we use AdministratorAccess right now, which should be able to do anything. We can test this in the test environment, which doesn't have the Data API enabled yet (whereas dev does).