### PR TITLE
Import updated arvioija records as separate entries

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/SolkiArvioijaResponse.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/SolkiArvioijaResponse.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.MapperFeature
 import fi.oph.kitu.csvparsing.Features
+import java.time.OffsetDateTime
 
 @JsonPropertyOrder(
     "arvioijanOppijanumero",
@@ -43,21 +44,24 @@ class SolkiArvioijaResponse(
     @JsonProperty("tasot")
     val tasot: String,
 ) {
-    fun toEntity(id: Number? = null) =
-        YkiArvioijaEntity(
-            id,
-            arvioijanOppijanumero,
-            henkilotunnus,
-            sukunimi,
-            etunimet,
-            sahkopostiosoite,
-            katuosoite,
-            postinumero,
-            postitoimipaikka,
-            tila,
-            kieli,
-            tasot = tasot.split("+").map({ taso -> Tutkintotaso.valueOf(taso) }).toSet(),
-        )
+    fun toEntity(
+        id: Number? = null,
+        rekisteriintuontiaika: OffsetDateTime? = null,
+    ) = YkiArvioijaEntity(
+        id,
+        rekisteriintuontiaika,
+        arvioijanOppijanumero,
+        henkilotunnus,
+        sukunimi,
+        etunimet,
+        sahkopostiosoite,
+        katuosoite,
+        postinumero,
+        postitoimipaikka,
+        tila,
+        kieli,
+        tasot = tasot.split("+").map({ taso -> Tutkintotaso.valueOf(taso) }).toSet(),
+    )
 
     override fun toString(): String =
         "SolkiArvioijaResponse(arvioijanOppijanumero='$arvioijanOppijanumero', tila=$tila, kieli=$kieli, tasot='$tasot')"

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiArvioijaEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiArvioijaEntity.kt
@@ -1,16 +1,16 @@
 package fi.oph.kitu.yki
 
-import jakarta.persistence.Column
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
+import java.time.OffsetDateTime
 
 @Table(name = "yki_arvioija")
 class YkiArvioijaEntity(
     @Id
     val id: Number?,
-    @Column(unique = true)
+    val rekisteriintuontiaika: OffsetDateTime?,
     val arvioijanOppijanumero: String,
     val henkilotunnus: String,
     val sukunimi: String,

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.repository.CrudRepository
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
 import java.sql.ResultSet
+import java.time.OffsetDateTime
 
 @Repository
 interface YkiRepository : CrudRepository<YkiSuoritusEntity, Int>
@@ -38,7 +39,7 @@ class CustomYkiArvioijaRepositoryImpl : CustomYkiArvioijaRepository {
                 kieli,
                 tasot
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT ON CONSTRAINT yki_arvioija_oppijanumero_is_unique DO NOTHING;
+            ON CONFLICT ON CONSTRAINT yki_arvioija_is_unique DO NOTHING;
             """.trimIndent()
         jdbcTemplate.batchUpdate(
             sql,
@@ -62,6 +63,7 @@ class CustomYkiArvioijaRepositoryImpl : CustomYkiArvioijaRepository {
             """
             SELECT
                 id,
+                rekisteriintuontiaika,
                 arvioijan_oppijanumero,
                 henkilotunnus,
                 sukunimi,
@@ -79,6 +81,7 @@ class CustomYkiArvioijaRepositoryImpl : CustomYkiArvioijaRepository {
             .query(findAllQuerySql) { rs, _ ->
                 YkiArvioijaEntity(
                     rs.getInt("id"),
+                    rs.getObject("rekisteriintuontiaika", OffsetDateTime::class.java),
                     rs.getString("arvioijan_oppijanumero"),
                     rs.getString("henkilotunnus"),
                     rs.getString("sukunimi"),

--- a/server/src/main/resources/db/migration/V11__allow_persisting_updates_to_yki_arvioija.sql
+++ b/server/src/main/resources/db/migration/V11__allow_persisting_updates_to_yki_arvioija.sql
@@ -1,0 +1,36 @@
+-- Data is to be "versioned", thus multiple rows per oppijanumero are allowed.
+ALTER TABLE yki_arvioija
+    DROP CONSTRAINT yki_arvioija_oppijanumero_is_unique;
+
+ALTER TABLE yki_arvioija
+    -- Add import timestamp to allow identifying the latest entry. Default to
+    -- NOW() in order to make inserting more straightforward.
+    ADD COLUMN rekisteriintuontiaika TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    -- Add constraint for ON CONFLICT DO NOTHING when entries have not changed.
+    -- This makes bulk inserting a breeze, without requiring e.g. triggers for
+    -- detecting/skipping unnecessary inserts.
+    ADD CONSTRAINT yki_arvioija_is_unique UNIQUE (
+         arvioijan_oppijanumero,
+         henkilotunnus,
+         sukunimi,
+         etunimet,
+         sahkopostiosoite,
+         katuosoite,
+         postinumero,
+         postitoimipaikka,
+         tila,
+         kieli,
+         tasot
+    );
+
+-- Mark all existing rows without import timestamps to have been imported NOW().
+-- Some timestamp is required on all rows for marking the row NOT NULL.
+UPDATE yki_arvioija
+    SET rekisteriintuontiaika = NOW()
+WHERE
+    yki_arvioija.rekisteriintuontiaika IS NULL;
+
+-- Finally, set the timestamp as NOT NULL to make sure all future rows have it.
+ALTER TABLE yki_arvioija
+    ALTER COLUMN rekisteriintuontiaika SET NOT NULL;


### PR DESCRIPTION
Muuttaa arvioijien tietojen tuontia siten, että mikäli tiedot ovat päivittyneet, ne lisätään nyt uutena rivinä. Vaihtoehto olisi päällekirjoittaa vanhojen tietojen tilalle, mutta uuden rivin lisääminen on vähemmän peruuttamaton operaatio. Rekisterin käyttötapauksien ollessa vielä hämärän peitossa, myös rekisterin historiatietojen ylläpitäminen tietokannassa on turvallisempi vaihtoehto (päällekirjoitusta ei voi peruuttaa).

Toteutin tämän yksinkertaisesti niin, että `yki_arvioija`:n `UNIQUE` rajoite koskee nyt kaikkia data-sarakkeita, pelkän `arvioijan_oppijanumero` sijaan. Tämä, yhdessä `ON CONFLICT DO NOTHING` kanssa pitäisi saavuttaa se, ettei duplikaatteja rivejä tallenneta, mutta kaikki muuttuneet tiedot persistoidaan.

Jotta uusin rivi olisi helpompaa tunnistaa, lisäsin vielä `yki_arvioija`-tauluun lisäksi sarakkeen `rekisteriintuontiaika`, johon tallennetaan `NOW()`-aikaleima siltä hetkeltä kun rivi tuodaan kantaan.