### PR TITLE
feat: allow slackbot to read service logs

### DIFF
--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -35,7 +35,7 @@ export class EnvironmentStage extends Stage {
       env: { ...env, region: "us-east-1" },
     })
 
-    new SlackBotStack(this, "SlackBot", {
+    const slackBotStack = new SlackBotStack(this, "SlackBot", {
       env,
       slackChannelName: "koto-rekisteri-alerts",
       slackChannelId: "C07QPSYBY7L",
@@ -86,6 +86,8 @@ export class EnvironmentStage extends Stage {
       image: props.serviceImage,
       alarmSnsTopic: alarmsStack.alarmSnsTopic,
     })
+
+    logGroupsStack.serviceLogGroup.grantRead(slackBotStack.channelConfiguration)
 
     new Route53HealthChecksStack(this, "Route53HealthChecks", {
       env: { ...env, region: "us-east-1" },


### PR DESCRIPTION
Tämä sallii lokien lukemisen Slackista, mikä voi mahdollistaa entistä laajemman joukon ihmisiä jotka pääsevät käsiksi kyseisiin lokeihin. Halutaanko tätä? Voidaanko rajata alerts-kanavalle pääsy? 