### PR TITLE
feat: improve logging and mocking with oppijanumero

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
@@ -11,6 +11,7 @@ inline fun <reified T> LoggingEventBuilder.addResponse(
     peerService: PeerService,
 ): LoggingEventBuilder =
     this
+        .addKeyValue("response.status", response.statusCode())
         .addKeyValue("response.headers", response.headers().toString())
         .addKeyValue("response.body", response.body().toString())
         .addKeyValue("peer.service", peerService.value)
@@ -20,6 +21,7 @@ inline fun <reified T> LoggingEventBuilder.addResponse(
     peerService: PeerService,
 ): LoggingEventBuilder =
     this
+        .addKeyValue("response.status", response.statusCode)
         .addKeyValue("response.headers", response.headers)
         .addKeyValue("response.body", response.body)
         .addKeyValue("peer.service", peerService.value)
@@ -27,12 +29,11 @@ inline fun <reified T> LoggingEventBuilder.addResponse(
 inline fun <reified T> LoggingEventBuilder.addResponse(
     endpoint: String,
     response: ResponseEntity<T>,
-): LoggingEventBuilder {
-    this.addKeyValue("$endpoint.response.headers", response.headers)
-    this.addKeyValue("$endpoint.response.body", response.body)
-
-    return this
-}
+): LoggingEventBuilder =
+    this
+        .addKeyValue("$endpoint.response.status", response.statusCode)
+        .addKeyValue("$endpoint.response.headers", response.headers)
+        .addKeyValue("$endpoint.response.body", response.body)
 
 fun LoggingEventBuilder.addIsDuplicateKeyException(ex: Exception): LoggingEventBuilder {
     val isDuplicateKeyException = ex is DuplicateKeyException || ex.cause is DuplicateKeyException

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasAuthenticatedService.kt
@@ -51,6 +51,8 @@ class CasAuthenticatedService(
             val authenticatedResponse = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
             logger.atInfo().addResponse(authenticatedResponse, PeerService.Oppijanumero).log()
             return authenticatedResponse
+        } else if (response.statusCode() != 200) {
+            throw RuntimeException("Unexpected HTTP status code: ${response.statusCode()}")
         } else {
             return response
         }

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
@@ -25,22 +25,20 @@ class OppijanumeroServiceImpl(
     private var useMockData: Boolean = false
 
     override fun yleistunnisteHae(request: YleistunnisteHaeRequest): Pair<Int, YleistunnisteHaeResponse> {
-        val data =
-            if (useMockData) {
-                YleistunnisteHaeRequest(
-                    etunimet = "Magdalena Testi",
-                    hetu = "010866-9260",
-                    kutsumanimi = "Magdalena",
-                    sukunimi = "Sallinen-Testi",
-                )
-            } else {
-                request
-            }
+        if (useMockData) {
+            return Pair(
+                200,
+                YleistunnisteHaeResponse(
+                    oid = "1.2.246.562.24.33342764709",
+                    oppijanumero = "1.2.246.562.24.33342764709",
+                ),
+            )
+        }
 
         val httpRequest =
             HttpRequest
                 .newBuilder(URI.create("$serviceUrl/yleistunniste/hae"))
-                .POST(toBodyPublisher(data))
+                .POST(toBodyPublisher(request))
                 .header("Content-Type", "application/json")
 
         val httpResponse = casAuthenticatedService.sendRequest(httpRequest)


### PR DESCRIPTION
Muutokset: 
1. Oppijanumero - service voi palauttaa muuta kuin HTTP STATUS 200, esim käyttökatkon aikana. Lisätty tarkastus, että heitetään eksplisiittisesti virhe tälläisissä tilanteissa.
2. Lisätty HTTP status koodi - lokeihin omana keyvalue:na, jotta esim em. virhetilanteet voidaan filtteröidä helpommin
3. ONR mokkaus data aiemmin vain asetti requestiin testikäyttäjän tiedot, jotka lähetettiin ONR:ään. Muutettu, että jos `use-mock-data` - vipu on käytössä, niin ei tehdä pyyntöjä ONR:ään, vaan palautetaan testikäyttäjän tiedot kovakoodatusti rajapinnasta.