### PR TITLE
feat: add production quality features to rds db

### DIFF
--- a/infra/lib/accounts.ts
+++ b/infra/lib/accounts.ts
@@ -6,6 +6,7 @@ export interface EnvironmentConfig {
   }
   domainName: string
   databaseName: string
+  productionQuality: boolean
 }
 
 // CIDR allocation strategy:
@@ -24,6 +25,7 @@ export const deploymentAccounts = {
     },
     domainName: "kios.untuvaopintopolku.fi",
     databaseName: "kios",
+    productionQuality: false,
   },
   test: {
     name: "qa",
@@ -35,6 +37,7 @@ export const deploymentAccounts = {
     },
     domainName: "kios.testiopintopolku.fi",
     databaseName: "kios",
+    productionQuality: false,
   },
   prod: {
     name: "prod",
@@ -46,6 +49,7 @@ export const deploymentAccounts = {
     },
     domainName: "kios.opintopolku.fi",
     databaseName: "kios",
+    productionQuality: true,
   },
 }
 

--- a/infra/lib/db-stack.ts
+++ b/infra/lib/db-stack.ts
@@ -5,6 +5,7 @@ import { Construct } from "constructs"
 export interface DbStackProps extends cdk.StackProps {
   databaseName: string
   vpc: aws_ec2.IVpc
+  productionQuality: boolean
 }
 
 export class DbStack extends cdk.Stack {
@@ -22,6 +23,11 @@ export class DbStack extends cdk.Stack {
       storageEncrypted: true,
       defaultDatabaseName: props.databaseName,
       enableDataApi: true,
+      ...(props.productionQuality && {
+        readers: [aws_rds.ClusterInstance.serverlessV2("reader")],
+        deletionProtection: true,
+        enablePerformanceInsights: true,
+      }),
     })
   }
 }

--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -70,6 +70,7 @@ export class EnvironmentStage extends Stage {
       env,
       vpc: networkStack.vpc,
       databaseName: environmentConfig.databaseName,
+      productionQuality: environmentConfig.productionQuality,
     })
 
     connectionsStack.databaseSG = dbStack.cluster.connections.securityGroups[0]


### PR DESCRIPTION
Slight issue here related to Aurora clusters and how CDK models them (wrongly): https://github.com/aws/aws-cdk/issues/26726 - this means that if the cluster failovers, our "reader" replica can become the writer. CDK will be confused on the next run (since the writer has disappeared). I'm not sure what CDK will do in that case, we should test it.

## Changes
### Production
```
Resources
[+] AWS::RDS::DBInstance Database/DbStack/reader DbStackreader1001C220
[~] AWS::RDS::DBCluster Database/DbStack DbStackBE19CDA3
 ├─ [+] DeletionProtection
 │   └─ true
 ├─ [+] PerformanceInsightsEnabled
 │   └─ true
 └─ [+] PerformanceInsightsRetentionPeriod
     └─ 7
```