### PR TITLE
fix: use a custom HTTP access logger, again

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -32,6 +32,7 @@
         <flyway.version>11.0.0</flyway.version>
         <springdoc.version>2.7.0</springdoc.version>
         <jackson.version>2.18.1</jackson.version>
+        <opentelemetry-semconv.version>1.28.0-alpha</opentelemetry-semconv.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -41,6 +42,11 @@
                 <version>2.29.20</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.44.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -81,17 +87,6 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>${flyway.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>dev.akkinoc.spring.boot</groupId>
-            <artifactId>logback-access-spring-boot-starter</artifactId>
-            <version>4.4.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-coyote</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -166,6 +161,20 @@
             <groupId>io.rocketbase.extension</groupId>
             <artifactId>db-scheduler-log-spring-boot-starter</artifactId>
             <version>0.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${opentelemetry-semconv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv-incubating</artifactId>
+            <version>${opentelemetry-semconv.version}</version>
         </dependency>
         <dependency>
             <groupId>no.bekk.db-scheduler-ui</groupId>

--- a/server/src/main/kotlin/fi/oph/kitu/logging/AccessLoggingConfiguration.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/AccessLoggingConfiguration.kt
@@ -1,0 +1,34 @@
+package fi.oph.kitu.logging
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Configuration
+class AccessLoggingConfiguration {
+    @Bean
+    fun logFilter(): OncePerRequestFilter =
+        object : OncePerRequestFilter() {
+            private val logger = LoggerFactory.getLogger(javaClass)
+
+            override fun doFilterInternal(
+                request: HttpServletRequest,
+                response: HttpServletResponse,
+                filterChain: FilterChain,
+            ) {
+                try {
+                    filterChain.doFilter(request, response)
+                } finally {
+                    logger
+                        .atInfo()
+                        .addServletResponse(response)
+                        .addServletRequest(request)
+                        .log("HTTP ${request.method} ${request.requestURL}")
+                }
+            }
+        }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
@@ -1,10 +1,33 @@
 package fi.oph.kitu.logging
 
 import fi.oph.kitu.PeerService
+import io.opentelemetry.semconv.HttpAttributes
+import io.opentelemetry.semconv.UrlAttributes
+import io.opentelemetry.semconv.UserAgentAttributes
+import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.spi.LoggingEventBuilder
 import org.springframework.dao.DuplicateKeyException
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import java.net.http.HttpResponse
+
+fun LoggingEventBuilder.addServletRequest(request: HttpServletRequest): LoggingEventBuilder =
+    add(
+        UrlAttributes.URL_PATH.toString() to request.requestURI,
+        UrlAttributes.URL_QUERY.toString() to request.queryString,
+        UrlAttributes.URL_SCHEME.toString() to (request.scheme ?: "http"),
+        HttpAttributes.HTTP_REQUEST_METHOD.toString() to request.method,
+        UserAgentAttributes.USER_AGENT_ORIGINAL.toString() to request.getHeader(HttpHeaders.USER_AGENT),
+    )
+
+fun LoggingEventBuilder.addServletResponse(response: HttpServletResponse): LoggingEventBuilder =
+    add(
+        HttpAttributes.HTTP_RESPONSE_STATUS_CODE.toString() to response.status,
+        HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.toString() to
+            response.getHeader(HttpHeaders.CONTENT_LENGTH),
+    )
 
 inline fun <reified T> LoggingEventBuilder.addResponse(
     response: HttpResponse<T>,

--- a/server/src/main/resources/logback-access.xml
+++ b/server/src/main/resources/logback-access.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <appender name="asdf" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashAccessEncoder"/>
-    </appender>
-
-    <appender-ref ref="asdf"/>
-</configuration>


### PR DESCRIPTION
logback-access doesn't support Spring's native structured logging. Let's implement our own logger at the Spring request/response lifecycle level instead.

Example:

```json
{
  "@timestamp": "2024-11-25T15:27:59.090332Z",
  "ecs.version": "8.11",
  "http.request.method": "GET",
  "http.response.body.size": null,
  "http.response.status_code": 200,
  "log.level": "INFO",
  "log.logger": "fi.oph.kitu.logging.AccessLoggingConfiguration$logFilter$1",
  "message": "HTTP GET http://localhost:8080/yki/arvioijat",
  "process.pid": 11369,
  "process.thread.name": "http-nio-8080-exec-3",
  "service.name": "kitu",
  "url.path": null,
  "url.query": "continue",
  "url.scheme": "http",
  "user_agent.original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Safari/605.1.15"
}
```