### PR TITLE
Fix CSV export date and timestamp formatting and header order

### DIFF
--- a/e2e/tests/yki-suoritukset.spec.ts
+++ b/e2e/tests/yki-suoritukset.spec.ts
@@ -46,7 +46,7 @@ describe('"YKI Suoritukset" -page', () => {
 
     const csvContent = await fs.readFile(path!, "utf8")
     expect(csvContent).toContain(
-      'arviointipaiva,arvosanaMuuttui,email,etunimet,hetu,id,jarjestajanNimi,jarjestajanTunnusOid,kansalaisuus,katuosoite,kirjoittaminen,lastModified,perustelu,postinumero,postitoimipaikka,puheenYmmartaminen,puhuminen,rakenteetJaSanasto,sukunimi,sukupuoli,suorittajanOID,suoritusId,"tarkistusarvioidutOsakokeet","tarkistusarvioinninAsiatunnus","tarkistusarvioinninKasittelyPvm","tarkistusarvioinninSaapumisPvm",tekstinYmmartaminen,tutkintokieli,tutkintopaiva,tutkintotaso,yleisarvosana\n',
+      'suorittajanOID,hetu,sukupuoli,sukunimi,etunimet,kansalaisuus,katuosoite,postinumero,postitoimipaikka,email,suoritusID,lastModified,tutkintopaiva,tutkintokieli,tutkintotaso,jarjestajanOID,jarjestajanNimi,arviointipaiva,tekstinYmmartaminen,kirjoittaminen,rakenteetJaSanasto,puheenYmmartaminen,puhuminen,yleisarvosana,"tarkistusarvioinninSaapumisPvm","tarkistusarvioinninAsiatunnus","tarkistusarvioidutOsakokeet",arvosanaMuuttui,perustelu,"tarkistusarvioinninKasittelyPvm"\n',
     ) // Validate headers
   })
 })

--- a/server/src/main/kotlin/fi/oph/kitu/ResultSetExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ResultSetExtensions.kt
@@ -1,7 +1,5 @@
 package fi.oph.kitu
 
-import java.sql.Date
-import java.sql.PreparedStatement
 import java.sql.ResultSet
 
 fun ResultSet.getNullableDouble(columnLabel: String): Double? =
@@ -12,14 +10,3 @@ fun ResultSet.getNullableInt(columnLabel: String): Int? =
 
 fun ResultSet.getNullableBoolean(columnLabel: String): Boolean? =
     if (this.getObject(columnLabel) != null) this.getBoolean(columnLabel) else null
-
-fun PreparedStatement.setNullableDate(
-    parameterIndex: Int,
-    date: java.util.Date?,
-) {
-    if (date != null) {
-        this.setDate(parameterIndex, Date(date.time))
-    } else {
-        this.setObject(parameterIndex, null)
-    }
-}

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvMapping.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvMapping.kt
@@ -1,9 +1,11 @@
 package fi.oph.kitu.csvparsing
 
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.dataformat.csv.CsvSchema
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import fi.oph.kitu.logging.add
+import org.ietf.jgss.Oid
 import org.slf4j.LoggerFactory
 import org.slf4j.spi.LoggingEventBuilder
 import kotlin.reflect.full.findAnnotation
@@ -27,6 +29,9 @@ inline fun <reified T> getCsvMapper(): CsvMapper {
     val csvMapper = builder.build()
 
     csvMapper.registerModule(JavaTimeModule())
+    val oidSerializerModule = SimpleModule()
+    oidSerializerModule.addSerializer(Oid::class.java, OidSerializer())
+    csvMapper.registerModule(oidSerializerModule)
 
     return csvMapper
 }

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidSerializer.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidSerializer.kt
@@ -1,0 +1,16 @@
+package fi.oph.kitu.csvparsing
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import org.ietf.jgss.Oid
+
+class OidSerializer : JsonSerializer<Oid>() {
+    override fun serialize(
+        oid: Oid?,
+        jsonGenerator: JsonGenerator?,
+        serializerProvider: SerializerProvider?,
+    ) {
+        jsonGenerator?.writeString(oid?.toString())
+    }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -9,7 +9,7 @@ import fi.oph.kitu.logging.addResponse
 import fi.oph.kitu.logging.withEvent
 import fi.oph.kitu.yki.arvioijat.SolkiArvioijaResponse
 import fi.oph.kitu.yki.arvioijat.YkiArvioijaRepository
-import fi.oph.kitu.yki.suoritukset.SolkiSuoritusResponse
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -49,7 +49,7 @@ class YkiService(
 
             event.addResponse(response, PeerService.Solki)
 
-            val suoritukset = response.body?.asCsv<SolkiSuoritusResponse>() ?: listOf()
+            val suoritukset = response.body?.asCsv<YkiSuoritusCsv>() ?: listOf()
 
             if (dryRun != true) {
                 val res = suoritusRepository.saveAll(suoritukset.map { it.toEntity() })
@@ -89,9 +89,9 @@ class YkiService(
         logger.atInfo().withEvent("yki.getSuorituksetCsv") { event ->
             val data = if (includeVersionHistory) suoritusRepository.findAll() else suoritusRepository.findAllDistinct()
             event.add("dataCount" to data.count())
-
+            val writableData = data.map { it.toYkiSuoritusCsv() }
             val outputStream = ByteArrayOutputStream()
-            data.writeAsCsv(outputStream, CsvArgs(useHeader = true))
+            writableData.writeAsCsv(outputStream, CsvArgs(useHeader = true))
 
             return@withEvent outputStream
         }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
@@ -9,8 +9,8 @@ import fi.oph.kitu.csvparsing.BooleanFromNumericDeserializer
 import fi.oph.kitu.csvparsing.Features
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
+import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.util.Date
 
 @JsonPropertyOrder(
     "arvioijanOppijanumero",
@@ -49,13 +49,13 @@ class SolkiArvioijaResponse(
     val postitoimipaikka: String,
     @JsonProperty("ensimmainenRekisterointipaiva")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val ensimmainenRekisterointipaiva: Date,
+    val ensimmainenRekisterointipaiva: LocalDate,
     @JsonProperty("kaudenAlkupaiva")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val kaudenAlkupaiva: Date?,
+    val kaudenAlkupaiva: LocalDate?,
     @JsonProperty("kaudenPaattymispaiva")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val kaudenPaattymispaiva: Date?,
+    val kaudenPaattymispaiva: LocalDate?,
     @JsonProperty("jatkorekisterointi")
     @JsonDeserialize(using = BooleanFromNumericDeserializer::class)
     val jatkorekisterointi: Boolean,

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaEntity.kt
@@ -6,8 +6,8 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.util.Date
 
 @Table(name = "yki_arvioija")
 class YkiArvioijaEntity(
@@ -22,9 +22,9 @@ class YkiArvioijaEntity(
     val katuosoite: String,
     val postinumero: String,
     val postitoimipaikka: String,
-    val ensimmainenRekisterointipaiva: Date,
-    val kaudenAlkupaiva: Date?,
-    val kaudenPaattymispaiva: Date?,
+    val ensimmainenRekisterointipaiva: LocalDate,
+    val kaudenAlkupaiva: LocalDate?,
+    val kaudenPaattymispaiva: LocalDate?,
     val jatkorekisterointi: Boolean,
     val tila: Number,
     @Enumerated(EnumType.STRING)

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaRepository.kt
@@ -1,14 +1,13 @@
 package fi.oph.kitu.yki.arvioijat
 
-import fi.oph.kitu.setNullableDate
 import fi.oph.kitu.yki.Tutkintotaso
 import fi.oph.kitu.yki.getTutkintokieli
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.CrudRepository
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
-import java.sql.Date
 import java.sql.ResultSet
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 interface CustomYkiArvioijaRepository {
@@ -59,9 +58,9 @@ class CustomYkiArvioijaRepositoryImpl : CustomYkiArvioijaRepository {
             ps.setString(6, arvioija.katuosoite)
             ps.setString(7, arvioija.postinumero)
             ps.setString(8, arvioija.postitoimipaikka)
-            ps.setDate(9, Date(arvioija.ensimmainenRekisterointipaiva.time))
-            ps.setNullableDate(10, arvioija.kaudenAlkupaiva)
-            ps.setNullableDate(11, arvioija.kaudenPaattymispaiva)
+            ps.setObject(9, arvioija.ensimmainenRekisterointipaiva)
+            ps.setObject(10, arvioija.kaudenAlkupaiva)
+            ps.setObject(11, arvioija.kaudenPaattymispaiva)
             ps.setBoolean(12, arvioija.jatkorekisterointi)
             ps.setInt(13, arvioija.tila.toInt())
             ps.setString(14, arvioija.kieli.toString())
@@ -103,9 +102,9 @@ class CustomYkiArvioijaRepositoryImpl : CustomYkiArvioijaRepository {
                     rs.getString("katuosoite"),
                     rs.getString("postinumero"),
                     rs.getString("postitoimipaikka"),
-                    rs.getDate("ensimmainen_rekisterointipaiva"),
-                    rs.getDate("kauden_alkupaiva"),
-                    rs.getDate("kauden_paattymispaiva"),
+                    rs.getObject("ensimmainen_rekisterointipaiva", LocalDate::class.java),
+                    rs.getObject("kauden_alkupaiva", LocalDate::class.java),
+                    rs.getObject("kauden_paattymispaiva", LocalDate::class.java),
                     rs.getBoolean("jatkorekisterointi"),
                     rs.getInt("tila"),
                     rs.getTutkintokieli("kieli"),

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
@@ -47,7 +47,7 @@ import java.util.Date
     "tarkistusarvioinninKasittelyPvm",
 )
 @Features(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-data class SolkiSuoritusResponse(
+data class YkiSuoritusCsv(
     @JsonProperty("suorittajanOID")
     val suorittajanOID: Oid,
     @JsonProperty("hetu")
@@ -71,7 +71,7 @@ data class SolkiSuoritusResponse(
     @JsonProperty("suoritusID")
     val suoritusID: Int,
     @JsonProperty("lastModified")
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssX")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssX", timezone = "UTC")
     val lastModified: Instant,
     @JsonProperty("tutkintopaiva")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
@@ -12,7 +12,7 @@ import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import org.ietf.jgss.Oid
 import java.time.Instant
-import java.util.Date
+import java.time.LocalDate
 
 @JsonPropertyOrder(
     "suorittajanOID",
@@ -75,7 +75,7 @@ data class YkiSuoritusCsv(
     val lastModified: Instant,
     @JsonProperty("tutkintopaiva")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val tutkintopaiva: Date,
+    val tutkintopaiva: LocalDate,
     @JsonProperty("tutkintokieli")
     val tutkintokieli: Tutkintokieli,
     @JsonProperty("tutkintotaso")
@@ -86,7 +86,7 @@ data class YkiSuoritusCsv(
     val jarjestajanNimi: String,
     @JsonProperty("arviointipaiva")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val arviointipaiva: Date,
+    val arviointipaiva: LocalDate,
     @JsonProperty("tekstinYmmartaminen")
     val tekstinYmmartaminen: Double?,
     @JsonProperty("kirjoittaminen")
@@ -101,7 +101,7 @@ data class YkiSuoritusCsv(
     val yleisarvosana: Double?,
     @JsonProperty("tarkistusarvioinninSaapumisPvm")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val tarkistusarvioinninSaapumisPvm: Date?,
+    val tarkistusarvioinninSaapumisPvm: LocalDate?,
     @JsonProperty("tarkistusarvioinninAsiatunnus")
     val tarkistusarvioinninAsiatunnus: String?,
     @JsonProperty("tarkistusarvioidutOsakokeet")
@@ -113,7 +113,7 @@ data class YkiSuoritusCsv(
     val perustelu: String?,
     @JsonProperty("tarkistusarvioinninKasittelyPvm")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val tarkistusarvioinninKasittelyPvm: Date?,
+    val tarkistusarvioinninKasittelyPvm: LocalDate?,
 ) {
     fun toEntity(id: Int? = null) =
         YkiSuoritusEntity(

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
@@ -5,6 +5,7 @@ import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import org.ietf.jgss.Oid
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
@@ -48,5 +49,39 @@ data class YkiSuoritusEntity(
     val perustelu: String?,
     val tarkistusarvioinninKasittelyPvm: Date?,
 ) {
+    fun toYkiSuoritusCsv(): YkiSuoritusCsv =
+        YkiSuoritusCsv(
+            suorittajanOID = Oid(suorittajanOID),
+            hetu = hetu,
+            sukupuoli = sukupuoli,
+            sukunimi = sukunimi,
+            etunimet = etunimet,
+            kansalaisuus = kansalaisuus,
+            katuosoite = katuosoite,
+            postinumero = postinumero,
+            postitoimipaikka = postitoimipaikka,
+            email = email,
+            suoritusID = suoritusId,
+            lastModified = lastModified,
+            tutkintopaiva = tutkintopaiva,
+            tutkintokieli = tutkintokieli,
+            tutkintotaso = tutkintotaso,
+            jarjestajanOID = Oid(jarjestajanTunnusOid),
+            jarjestajanNimi = jarjestajanNimi,
+            arviointipaiva = arviointipaiva,
+            tekstinYmmartaminen = tekstinYmmartaminen,
+            kirjoittaminen = kirjoittaminen,
+            rakenteetJaSanasto = rakenteetJaSanasto,
+            puheenYmmartaminen = puheenYmmartaminen,
+            puhuminen = puhuminen,
+            yleisarvosana = yleisarvosana,
+            tarkistusarvioinninSaapumisPvm = tarkistusarvioinninSaapumisPvm,
+            tarkistusarvioinninAsiatunnus = tarkistusarvioinninAsiatunnus,
+            tarkistusarvioidutOsakokeet = tarkistusarvioidutOsakokeet,
+            arvosanaMuuttui = arvosanaMuuttui,
+            perustelu = perustelu,
+            tarkistusarvioinninKasittelyPvm = tarkistusarvioinninKasittelyPvm,
+        )
+
     companion object
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
@@ -9,7 +9,7 @@ import org.ietf.jgss.Oid
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
-import java.util.Date
+import java.time.LocalDate
 
 @Table(name = "yki_suoritus")
 data class YkiSuoritusEntity(
@@ -28,26 +28,26 @@ data class YkiSuoritusEntity(
     val email: String?,
     val suoritusId: Int,
     val lastModified: Instant,
-    val tutkintopaiva: Date,
+    val tutkintopaiva: LocalDate,
     @Enumerated(EnumType.STRING)
     val tutkintokieli: Tutkintokieli,
     @Enumerated(EnumType.STRING)
     val tutkintotaso: Tutkintotaso,
     val jarjestajanTunnusOid: String,
     val jarjestajanNimi: String,
-    val arviointipaiva: Date,
+    val arviointipaiva: LocalDate,
     val tekstinYmmartaminen: Double?,
     val kirjoittaminen: Double?,
     val rakenteetJaSanasto: Double?,
     val puheenYmmartaminen: Double?,
     val puhuminen: Double?,
     val yleisarvosana: Double?,
-    val tarkistusarvioinninSaapumisPvm: Date?,
+    val tarkistusarvioinninSaapumisPvm: LocalDate?,
     val tarkistusarvioinninAsiatunnus: String?,
     val tarkistusarvioidutOsakokeet: Int?,
     val arvosanaMuuttui: Boolean?,
     val perustelu: String?,
-    val tarkistusarvioinninKasittelyPvm: Date?,
+    val tarkistusarvioinninKasittelyPvm: LocalDate?,
 ) {
     fun toYkiSuoritusCsv(): YkiSuoritusCsv =
         YkiSuoritusCsv(

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
@@ -3,7 +3,6 @@ package fi.oph.kitu.yki.suoritukset
 import fi.oph.kitu.getNullableBoolean
 import fi.oph.kitu.getNullableDouble
 import fi.oph.kitu.getNullableInt
-import fi.oph.kitu.setNullableDate
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
@@ -11,9 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.CrudRepository
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
-import java.sql.Date
 import java.sql.ResultSet
 import java.sql.Timestamp
+import java.time.LocalDate
 
 interface CustomYkiSuoritusRepository {
     fun <S : YkiSuoritusEntity?> saveAll(suoritukset: Iterable<S>): Iterable<S>
@@ -84,24 +83,24 @@ class CustomYkiSuoritusRepositoryImpl : CustomYkiSuoritusRepository {
             ps.setString(10, suoritus.email)
             ps.setInt(11, suoritus.suoritusId)
             ps.setTimestamp(12, Timestamp(suoritus.lastModified.toEpochMilli()))
-            ps.setDate(13, Date(suoritus.tutkintopaiva.time))
+            ps.setObject(13, suoritus.tutkintopaiva)
             ps.setString(14, suoritus.tutkintokieli.toString())
             ps.setString(15, suoritus.tutkintotaso.toString())
             ps.setString(16, suoritus.jarjestajanTunnusOid)
             ps.setString(17, suoritus.jarjestajanNimi)
-            ps.setDate(18, Date(suoritus.arviointipaiva.time))
+            ps.setObject(18, suoritus.arviointipaiva)
             ps.setObject(19, suoritus.tekstinYmmartaminen)
             ps.setObject(20, suoritus.kirjoittaminen)
             ps.setObject(21, suoritus.rakenteetJaSanasto)
             ps.setObject(22, suoritus.puheenYmmartaminen)
             ps.setObject(23, suoritus.puhuminen)
             ps.setObject(24, suoritus.yleisarvosana)
-            ps.setNullableDate(25, suoritus.tarkistusarvioinninSaapumisPvm)
+            ps.setObject(25, suoritus.tarkistusarvioinninSaapumisPvm)
             ps.setObject(26, suoritus.tarkistusarvioinninAsiatunnus)
             ps.setObject(27, suoritus.tarkistusarvioidutOsakokeet)
             ps.setObject(28, suoritus.arvosanaMuuttui)
             ps.setObject(29, suoritus.perustelu)
-            ps.setNullableDate(30, suoritus.tarkistusarvioinninKasittelyPvm)
+            ps.setObject(30, suoritus.tarkistusarvioinninKasittelyPvm)
         }
         val findAllQuerySql =
             """
@@ -205,24 +204,24 @@ fun YkiSuoritusEntity.Companion.fromResultSet(rs: ResultSet): YkiSuoritusEntity 
         rs.getString("email"),
         rs.getInt("suoritus_id"),
         rs.getTimestamp("last_modified").toInstant(),
-        rs.getDate("tutkintopaiva"),
+        rs.getObject("tutkintopaiva", LocalDate::class.java),
         Tutkintokieli.valueOf(rs.getString("tutkintokieli")),
         Tutkintotaso.valueOf(rs.getString("tutkintotaso")),
         rs.getString("jarjestajan_tunnus_oid"),
         rs.getString("jarjestajan_nimi"),
-        rs.getDate("arviointipaiva"),
+        rs.getObject("arviointipaiva", LocalDate::class.java),
         rs.getNullableDouble("tekstin_ymmartaminen"),
         rs.getNullableDouble("kirjoittaminen"),
         rs.getNullableDouble("rakenteet_ja_sanasto"),
         rs.getNullableDouble("puheen_ymmartaminen"),
         rs.getNullableDouble("puhuminen"),
         rs.getNullableDouble("yleisarvosana"),
-        rs.getDate("tarkistusarvioinnin_saapumis_pvm"),
+        rs.getObject("tarkistusarvioinnin_saapumis_pvm", LocalDate::class.java),
         rs.getString("tarkistusarvioinnin_asiatunnus"),
         rs.getNullableInt("tarkistusarvioidut_osakokeet"),
         rs.getNullableBoolean("arvosana_muuttui"),
         rs.getString("perustelu"),
-        rs.getDate("tarkistusarvioinnin_kasittely_pvm"),
+        rs.getObject("tarkistusarvioinnin_kasittely_pvm", LocalDate::class.java),
     )
 
 @Repository

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -3,9 +3,11 @@ package fi.oph.kitu.csvparsing
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
-import fi.oph.kitu.yki.suoritukset.SolkiSuoritusResponse
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
 import org.ietf.jgss.Oid
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
 import java.time.Instant
 import kotlin.test.assertEquals
@@ -18,7 +20,7 @@ class CsvParsingTest {
             """
             "1.2.246.562.24.20281155246","010180-9026","N","Öhmana-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
             """.trimIndent()
-        val suoritus = csv.asCsv<SolkiSuoritusResponse>()[0]
+        val suoritus = csv.asCsv<YkiSuoritusCsv>()[0]
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = SimpleDateFormat(datePattern)
         assertEquals(Oid("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
@@ -51,5 +53,105 @@ class CsvParsingTest {
         assertEquals(false, suoritus.arvosanaMuuttui)
         assertEquals("", suoritus.perustelu)
         assertNull(suoritus.tarkistusarvioinninKasittelyPvm)
+    }
+
+    @Test
+    fun `test writing csv`() {
+        val datePattern = "yyyy-MM-dd"
+        val dateFormatter = SimpleDateFormat(datePattern)
+        val entity =
+            YkiSuoritusEntity(
+                id = null,
+                suorittajanOID = "1.2.246.562.24.20281155246",
+                hetu = "010180-9026",
+                sukupuoli = Sukupuoli.N,
+                sukunimi = "Öhmana-Testi",
+                etunimet = "Ranja Testi",
+                kansalaisuus = "EST",
+                katuosoite = "Testikuja 5",
+                postinumero = "40100",
+                postitoimipaikka = "Testilä",
+                email = "testi@testi.fi",
+                suoritusId = 183424,
+                lastModified = Instant.parse("2024-10-30T13:53:56Z"),
+                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintokieli = Tutkintokieli.FIN,
+                tutkintotaso = Tutkintotaso.YT,
+                jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
+                jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
+                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                tekstinYmmartaminen = 5.0,
+                kirjoittaminen = 4.0,
+                rakenteetJaSanasto = 3.0,
+                puheenYmmartaminen = 1.0,
+                puhuminen = 2.0,
+                yleisarvosana = 3.0,
+                tarkistusarvioinninSaapumisPvm = dateFormatter.parse("2024-10-01"),
+                tarkistusarvioinninAsiatunnus = "123123",
+                tarkistusarvioidutOsakokeet = 2,
+                arvosanaMuuttui = true,
+                perustelu = "Tarkistusarvioinnin testi",
+                tarkistusarvioinninKasittelyPvm = dateFormatter.parse("2024-10-15"),
+            )
+        val writable = listOf(entity.toYkiSuoritusCsv())
+        val outputStream = ByteArrayOutputStream()
+        writable.writeAsCsv(outputStream, CsvArgs(useHeader = true))
+        val expectedCsv =
+            """
+            suorittajanOID,hetu,sukupuoli,sukunimi,etunimet,kansalaisuus,katuosoite,postinumero,postitoimipaikka,email,suoritusID,lastModified,tutkintopaiva,tutkintokieli,tutkintotaso,jarjestajanOID,jarjestajanNimi,arviointipaiva,tekstinYmmartaminen,kirjoittaminen,rakenteetJaSanasto,puheenYmmartaminen,puhuminen,yleisarvosana,"tarkistusarvioinninSaapumisPvm","tarkistusarvioinninAsiatunnus","tarkistusarvioidutOsakokeet",arvosanaMuuttui,perustelu,"tarkistusarvioinninKasittelyPvm"
+            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,testi@testi.fi,183424,2024-10-30T13:53:56Z,2024-08-31,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-13,5.0,4.0,3.0,1.0,2.0,3.0,2024-09-30,123123,2,true,"Tarkistusarvioinnin testi",2024-10-14
+
+            """.trimIndent()
+        assertEquals(expectedCsv, outputStream.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `null values are written correctly to csv`() {
+        val datePattern = "yyyy-MM-dd"
+        val dateFormatter = SimpleDateFormat(datePattern)
+        val entity =
+            YkiSuoritusEntity(
+                id = null,
+                suorittajanOID = "1.2.246.562.24.20281155246",
+                hetu = "010180-9026",
+                sukupuoli = Sukupuoli.N,
+                sukunimi = "Öhmana-Testi",
+                etunimet = "Ranja Testi",
+                kansalaisuus = "EST",
+                katuosoite = "Testikuja 5",
+                postinumero = "40100",
+                postitoimipaikka = "Testilä",
+                email = null,
+                suoritusId = 183424,
+                lastModified = Instant.parse("2024-10-30T13:53:56Z"),
+                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintokieli = Tutkintokieli.FIN,
+                tutkintotaso = Tutkintotaso.YT,
+                jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
+                jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
+                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                tekstinYmmartaminen = null,
+                kirjoittaminen = null,
+                rakenteetJaSanasto = null,
+                puheenYmmartaminen = null,
+                puhuminen = null,
+                yleisarvosana = null,
+                tarkistusarvioinninSaapumisPvm = null,
+                tarkistusarvioinninAsiatunnus = null,
+                tarkistusarvioidutOsakokeet = null,
+                arvosanaMuuttui = null,
+                perustelu = null,
+                tarkistusarvioinninKasittelyPvm = null,
+            )
+        val writable = listOf(entity.toYkiSuoritusCsv())
+        val outputStream = ByteArrayOutputStream()
+        writable.writeAsCsv(outputStream, CsvArgs(useHeader = true))
+        val expectedCsv =
+            """
+            suorittajanOID,hetu,sukupuoli,sukunimi,etunimet,kansalaisuus,katuosoite,postinumero,postitoimipaikka,email,suoritusID,lastModified,tutkintopaiva,tutkintokieli,tutkintotaso,jarjestajanOID,jarjestajanNimi,arviointipaiva,tekstinYmmartaminen,kirjoittaminen,rakenteetJaSanasto,puheenYmmartaminen,puhuminen,yleisarvosana,"tarkistusarvioinninSaapumisPvm","tarkistusarvioinninAsiatunnus","tarkistusarvioidutOsakokeet",arvosanaMuuttui,perustelu,"tarkistusarvioinninKasittelyPvm"
+            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,,183424,2024-10-30T13:53:56Z,2024-08-31,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-13,,,,,,,,,,,,
+
+            """.trimIndent()
+        assertEquals(expectedCsv, outputStream.toString(Charsets.UTF_8))
     }
 }

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -8,8 +8,9 @@ import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
 import org.ietf.jgss.Oid
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
-import java.text.SimpleDateFormat
 import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -22,7 +23,7 @@ class CsvParsingTest {
             """.trimIndent()
         val suoritus = csv.asCsv<YkiSuoritusCsv>()[0]
         val datePattern = "yyyy-MM-dd"
-        val dateFormatter = SimpleDateFormat(datePattern)
+        val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         assertEquals(Oid("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
         assertEquals("010180-9026", suoritus.hetu)
         assertEquals(Sukupuoli.N, suoritus.sukupuoli)
@@ -35,12 +36,12 @@ class CsvParsingTest {
         assertEquals("testi@testi.fi", suoritus.email)
         assertEquals(183424, suoritus.suoritusID)
         assertEquals(Instant.parse("2024-10-30T13:53:56Z"), suoritus.lastModified)
-        assertEquals("2024-09-01", dateFormatter.format(suoritus.tutkintopaiva))
+        assertEquals("2024-09-01", suoritus.tutkintopaiva.format(dateFormatter))
         assertEquals(Tutkintokieli.FIN, suoritus.tutkintokieli)
         assertEquals(Tutkintotaso.YT, suoritus.tutkintotaso)
         assertEquals(Oid("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
         assertEquals("Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus", suoritus.jarjestajanNimi)
-        assertEquals("2024-11-14", dateFormatter.format(suoritus.arviointipaiva))
+        assertEquals("2024-11-14", suoritus.arviointipaiva.format(dateFormatter))
         assertEquals(5.0, suoritus.tekstinYmmartaminen)
         assertEquals(5.0, suoritus.kirjoittaminen)
         assertNull(suoritus.rakenteetJaSanasto)
@@ -58,7 +59,7 @@ class CsvParsingTest {
     @Test
     fun `test writing csv`() {
         val datePattern = "yyyy-MM-dd"
-        val dateFormatter = SimpleDateFormat(datePattern)
+        val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         val entity =
             YkiSuoritusEntity(
                 id = null,
@@ -74,24 +75,24 @@ class CsvParsingTest {
                 email = "testi@testi.fi",
                 suoritusId = 183424,
                 lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                 tutkintokieli = Tutkintokieli.FIN,
                 tutkintotaso = Tutkintotaso.YT,
                 jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
                 jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                 tekstinYmmartaminen = 5.0,
                 kirjoittaminen = 4.0,
                 rakenteetJaSanasto = 3.0,
                 puheenYmmartaminen = 1.0,
                 puhuminen = 2.0,
                 yleisarvosana = 3.0,
-                tarkistusarvioinninSaapumisPvm = dateFormatter.parse("2024-10-01"),
+                tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
                 tarkistusarvioinninAsiatunnus = "123123",
                 tarkistusarvioidutOsakokeet = 2,
                 arvosanaMuuttui = true,
                 perustelu = "Tarkistusarvioinnin testi",
-                tarkistusarvioinninKasittelyPvm = dateFormatter.parse("2024-10-15"),
+                tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
             )
         val writable = listOf(entity.toYkiSuoritusCsv())
         val outputStream = ByteArrayOutputStream()
@@ -99,7 +100,7 @@ class CsvParsingTest {
         val expectedCsv =
             """
             suorittajanOID,hetu,sukupuoli,sukunimi,etunimet,kansalaisuus,katuosoite,postinumero,postitoimipaikka,email,suoritusID,lastModified,tutkintopaiva,tutkintokieli,tutkintotaso,jarjestajanOID,jarjestajanNimi,arviointipaiva,tekstinYmmartaminen,kirjoittaminen,rakenteetJaSanasto,puheenYmmartaminen,puhuminen,yleisarvosana,"tarkistusarvioinninSaapumisPvm","tarkistusarvioinninAsiatunnus","tarkistusarvioidutOsakokeet",arvosanaMuuttui,perustelu,"tarkistusarvioinninKasittelyPvm"
-            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,testi@testi.fi,183424,2024-10-30T13:53:56Z,2024-08-31,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-13,5.0,4.0,3.0,1.0,2.0,3.0,2024-09-30,123123,2,true,"Tarkistusarvioinnin testi",2024-10-14
+            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,testi@testi.fi,183424,2024-10-30T13:53:56Z,2024-09-01,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5.0,4.0,3.0,1.0,2.0,3.0,2024-10-01,123123,2,true,"Tarkistusarvioinnin testi",2024-10-15
 
             """.trimIndent()
         assertEquals(expectedCsv, outputStream.toString(Charsets.UTF_8))
@@ -108,7 +109,7 @@ class CsvParsingTest {
     @Test
     fun `null values are written correctly to csv`() {
         val datePattern = "yyyy-MM-dd"
-        val dateFormatter = SimpleDateFormat(datePattern)
+        val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         val entity =
             YkiSuoritusEntity(
                 id = null,
@@ -124,12 +125,12 @@ class CsvParsingTest {
                 email = null,
                 suoritusId = 183424,
                 lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                 tutkintokieli = Tutkintokieli.FIN,
                 tutkintotaso = Tutkintotaso.YT,
                 jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
                 jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                 tekstinYmmartaminen = null,
                 kirjoittaminen = null,
                 rakenteetJaSanasto = null,
@@ -149,7 +150,7 @@ class CsvParsingTest {
         val expectedCsv =
             """
             suorittajanOID,hetu,sukupuoli,sukunimi,etunimet,kansalaisuus,katuosoite,postinumero,postitoimipaikka,email,suoritusID,lastModified,tutkintopaiva,tutkintokieli,tutkintotaso,jarjestajanOID,jarjestajanNimi,arviointipaiva,tekstinYmmartaminen,kirjoittaminen,rakenteetJaSanasto,puheenYmmartaminen,puhuminen,yleisarvosana,"tarkistusarvioinninSaapumisPvm","tarkistusarvioinninAsiatunnus","tarkistusarvioidutOsakokeet",arvosanaMuuttui,perustelu,"tarkistusarvioinninKasittelyPvm"
-            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,,183424,2024-10-30T13:53:56Z,2024-08-31,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-13,,,,,,,,,,,,
+            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,,183424,2024-10-30T13:53:56Z,2024-09-01,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,,,,,,,,,,,,
 
             """.trimIndent()
         assertEquals(expectedCsv, outputStream.toString(Charsets.UTF_8))

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
@@ -10,8 +10,9 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import java.text.SimpleDateFormat
 import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -38,7 +39,7 @@ class YkiSuoritusRepositoryTest(
     @Test
     fun `suoritus is saved correctly`() {
         val datePattern = "yyyy-MM-dd"
-        val dateFormatter = SimpleDateFormat(datePattern)
+        val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         val suoritus =
             YkiSuoritusEntity(
                 id = null,
@@ -54,24 +55,24 @@ class YkiSuoritusRepositoryTest(
                 email = "testi@testi.fi",
                 suoritusId = 183424,
                 lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                 tutkintokieli = Tutkintokieli.FIN,
                 tutkintotaso = Tutkintotaso.YT,
                 jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
                 jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                 tekstinYmmartaminen = 5.0,
                 kirjoittaminen = 4.0,
                 rakenteetJaSanasto = 3.0,
                 puheenYmmartaminen = 1.0,
                 puhuminen = 2.0,
                 yleisarvosana = 3.0,
-                tarkistusarvioinninSaapumisPvm = dateFormatter.parse("2024-10-01"),
+                tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
                 tarkistusarvioinninAsiatunnus = "123123",
                 tarkistusarvioidutOsakokeet = 2,
                 arvosanaMuuttui = true,
                 perustelu = "Tarkistusarvioinnin testi",
-                tarkistusarvioinninKasittelyPvm = dateFormatter.parse("2024-10-15"),
+                tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
             )
         val savedSuoritukset = ykiSuoritusRepository.saveAll(listOf(suoritus)).toList()
         assertEquals(suoritus, savedSuoritukset[0].copy(id = null))
@@ -80,7 +81,7 @@ class YkiSuoritusRepositoryTest(
     @Test
     fun `suoritus with null values is saved correctly`() {
         val datePattern = "yyyy-MM-dd"
-        val dateFormatter = SimpleDateFormat(datePattern)
+        val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         val suoritus =
             YkiSuoritusEntity(
                 id = null,
@@ -96,12 +97,12 @@ class YkiSuoritusRepositoryTest(
                 email = null,
                 suoritusId = 183424,
                 lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                 tutkintokieli = Tutkintokieli.FIN,
                 tutkintotaso = Tutkintotaso.YT,
                 jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
                 jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                 tekstinYmmartaminen = null,
                 kirjoittaminen = null,
                 rakenteetJaSanasto = null,
@@ -122,7 +123,7 @@ class YkiSuoritusRepositoryTest(
     @Test
     fun `findAllDistinct returns the latest suoritus of same suoritusId`() {
         val datePattern = "yyyy-MM-dd"
-        val dateFormatter = SimpleDateFormat(datePattern)
+        val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         val suoritus =
             YkiSuoritusEntity(
                 id = null,
@@ -138,12 +139,12 @@ class YkiSuoritusRepositoryTest(
                 email = "testi@testi.fi",
                 suoritusId = 183424,
                 lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                 tutkintokieli = Tutkintokieli.FIN,
                 tutkintotaso = Tutkintotaso.YT,
                 jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
                 jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                 tekstinYmmartaminen = 1.0,
                 kirjoittaminen = 1.0,
                 rakenteetJaSanasto = 1.0,
@@ -172,12 +173,12 @@ class YkiSuoritusRepositoryTest(
                 email = "testi@testi.fi",
                 suoritusId = 123456,
                 lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = dateFormatter.parse("2024-09-01"),
+                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                 tutkintokieli = Tutkintokieli.ENG,
                 tutkintotaso = Tutkintotaso.YT,
                 jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
                 jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = dateFormatter.parse("2024-11-14"),
+                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                 tekstinYmmartaminen = 1.0,
                 kirjoittaminen = 1.0,
                 rakenteetJaSanasto = 1.0,
@@ -200,12 +201,12 @@ class YkiSuoritusRepositoryTest(
                 puheenYmmartaminen = 1.0,
                 puhuminen = 2.0,
                 yleisarvosana = 3.0,
-                tarkistusarvioinninSaapumisPvm = dateFormatter.parse("2024-10-01"),
+                tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
                 tarkistusarvioinninAsiatunnus = "123123",
                 tarkistusarvioidutOsakokeet = 2,
                 arvosanaMuuttui = true,
                 perustelu = "Tarkistusarvioinnin testi",
-                tarkistusarvioinninKasittelyPvm = dateFormatter.parse("2024-10-15"),
+                tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
             )
         ykiSuoritusRepository.saveAll(listOf(suoritus, suoritus2, updatedSuoritus))
         val suoritukset = ykiSuoritusRepository.findAllDistinct().toList()


### PR DESCRIPTION
- Uudelleennimetty `SolkiSuoritusResponse`, koska sitä käytetään tässä myös csv:n luonnissa eikä nimi ollut enää niin kuvaava (en halunnut luoda uutta luokkaa csv:n luomista varten, koska ainakin tässä vaiheessa se olisi identtinen tämän olemassaolevan luokan kanssa)
   - Voidaan miettiä uudelleen, jos halutaan että csv-export eroaa siitä mitä meille rajapinnasta tulee
- csv:n sarakkeet tulevat nyt samassa järjestyksessä, kuin Solkin YKI-rajapinnassa, eivätkä enää aakkosjärjestyksessä
- Aikaleimat ja päivämäärät parsitaan samassa muodossa meidän csv-exportiin kuin mitä ne ovat Solkin YKI-rajapinnassa