### PR TITLE
feat(koto): use oppijanumero instead of oid

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/LoggerExtensions.kt
@@ -58,6 +58,14 @@ inline fun <reified T> LoggingEventBuilder.addResponse(
         .addKeyValue("$endpoint.response.headers", response.headers)
         .addKeyValue("$endpoint.response.body", response.body)
 
+fun LoggingEventBuilder.addCondition(
+    key: String,
+    condition: Boolean,
+): Boolean {
+    this.addKeyValue(key, condition)
+    return condition
+}
+
 fun LoggingEventBuilder.addIsDuplicateKeyException(ex: Exception): LoggingEventBuilder {
     val isDuplicateKeyException = ex is DuplicateKeyException || ex.cause is DuplicateKeyException
     this.addKeyValue("isDuplicateKeyException", isDuplicateKeyException)

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
@@ -71,7 +71,7 @@ class OppijanumeroServiceImpl(
                         ),
                     ).header("Content-Type", "application/json")
 
-            // no need to log sendRequest, because there are request and reponse logging inside casAuthenticatedService.
+            // no need to log sendRequest, because there are request and response logging inside casAuthenticatedService.
             val httpResponse = casAuthenticatedService.sendRequest(httpRequest)
             val code = httpResponse.statusCode()
             if (code != 200) {

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
@@ -41,12 +41,12 @@ class OppijanumeroServiceImpl(
         oppijanumero: String?,
     ): String =
         logger.atInfo().withEvent("getOppijanumero") { event ->
-            require(etunimet.isEmpty()) { "etunimet cannot be empty" }
-            require(hetu.isEmpty()) { "hetu cannot be empty" }
-            require(sukunimi.isEmpty()) { "sukunimi cannot be empty" }
-            require(kutsumanimi.isEmpty()) { "kutsumanimi cannot be empty" }
+            require(etunimet.isNotEmpty()) { "etunimet cannot be empty" }
+            require(hetu.isNotEmpty()) { "hetu cannot be empty" }
+            require(sukunimi.isNotEmpty()) { "sukunimi cannot be empty" }
+            require(kutsumanimi.isNotEmpty()) { "kutsumanimi cannot be empty" }
 
-            if (event.addCondition(key = "requestHasOppijamumero", condition = oppijanumero != null)) {
+            if (event.addCondition(key = "requestHasOppijanumero", condition = oppijanumero != null)) {
                 return@withEvent oppijanumero.toString()
             }
 

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
@@ -2,7 +2,6 @@ package fi.oph.kitu.kotoutumiskoulutus
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.oph.kitu.oppijanumero.OppijanumeroServiceMock
-import fi.oph.kitu.oppijanumero.YleistunnisteHaeResponse
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -100,8 +99,7 @@ class KoealustaServiceTests {
                 jacksonObjectMapper = objectMapper,
                 oppijanumeroService =
                     OppijanumeroServiceMock(
-                        statusCode = 200,
-                        response = YleistunnisteHaeResponse("123", "123"),
+                        "123",
                     ),
             )
 

--- a/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceMock.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceMock.kt
@@ -1,8 +1,13 @@
 package fi.oph.kitu.oppijanumero
 
 class OppijanumeroServiceMock(
-    private val statusCode: Int,
-    private val response: YleistunnisteHaeResponse,
+    private val oppijanumero: String,
 ) : OppijanumeroService {
-    override fun yleistunnisteHae(request: YleistunnisteHaeRequest) = Pair(statusCode, response)
+    override fun getOppijanumero(
+        etunimet: String,
+        hetu: String,
+        kutsumanimi: String,
+        sukunimi: String,
+        oppijanumero: String?,
+    ): String = this.oppijanumero
 }


### PR DESCRIPTION
 - Helpointa lukea varmaan katsomalla ensin vanha toteutus ja sitten uusi.
 - Toteutettu refaktoroimalla yleisTunnisteHae - metodi, se on uudelleenimetty getOppijanumero.
 - Lisätty samalla metodiin lokitusta
 - Jos code quality:stä haluaa nillittää, niin tuossa metodissa tehdään nyt kaksi asiaa, oid tarkastus ja kutsu `/yleistunniste/hae` - endpointtiin. Vois olla siistimpi, että ne on eri metodeissa, mutta en jaksanut miettiä sitä.
 - [lisätty](https://github.com/Opetushallitus/koto-rekisteri/pull/521/commits/b3d0b9ecfc45351b58f25edba800fd6f330f76ac) `event.addCondition` - helpperi, jota käytän niin, että se lokittaa aina attribuutin, ja jos se on `true`, niin lopetetaan metodin suorittaminen. Tarkoituksena lyhentää koodirivien määrää.