### PR TITLE
Sort yki suoritukset for UI

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -92,7 +92,12 @@ class YkiService(
     fun generateSuorituksetCsvStream(includeVersionHistory: Boolean): ByteArrayOutputStream =
         logger.atInfo().withEvent("yki.getSuorituksetCsv") { event ->
             val parser = CsvParser(event, useHeader = true)
-            val data = if (includeVersionHistory) suoritusRepository.findAll() else suoritusRepository.findAllDistinct()
+            val data =
+                if (includeVersionHistory) {
+                    suoritusRepository.findAllOrdered()
+                } else {
+                    suoritusRepository.findAllDistinct()
+                }
             event.add("dataCount" to data.count())
             val writableData = suoritusMapper.convertToResponseIterable(data)
             val outputStream = ByteArrayOutputStream()

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiViewController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiViewController.kt
@@ -26,11 +26,9 @@ class YkiViewController(
     ): ModelAndView {
         val suoritukset: List<YkiSuoritusEntity> =
             if (versionHistory == true) {
-                suoritusRepository.findAll().toList()
+                suoritusRepository.findAllOrdered().toList()
             } else {
-                suoritusRepository
-                    .findAllDistinct()
-                    .toList()
+                suoritusRepository.findAllDistinct().toList()
             }
 
         val modelAndView = ModelAndView("yki-suoritukset")


### PR DESCRIPTION
- Järjestää suoritukset käliin ja csv-exportiin tutkintopäivän mukaan.
- `SELECT DISTINCT ON` vaatii, että haku järjestetään ensisijaisesti sen sarakkeen mukaan, minkä perusteella uniikit rivit tunnistetaan, ja `last_modified` pitää olla kriteerinä, jotta tuplariveistä valittaisiin uusin versio
- Halusin, että haku jossa otetaan mukaan myös versiohistoria tulee samassa järjestyksessä kuin ilman versiohistoriaa, joten kaikkien suoritusten haku piti järjestää samalla tavalla kuin vain uusimpien versioiden haku
