### PR TITLE
refactor: mapping service

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
@@ -1,0 +1,74 @@
+package fi.oph.kitu.kotoutumiskoulutus
+
+import fi.oph.kitu.kotoutumiskoulutus.KoealustaSuorituksetResponse.User
+import fi.oph.kitu.kotoutumiskoulutus.KoealustaSuorituksetResponse.User.Completion
+import fi.oph.kitu.oppijanumero.OppijanumeroService
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class KoealustaMappingService(
+    private val oppijanumeroService: OppijanumeroService,
+) {
+    fun suorituksetToEntity(suorituksetResponse: KoealustaSuorituksetResponse): List<KielitestiSuoritus> =
+        suorituksetResponse.users.flatMap { user ->
+            val oppijanumero = getOppijanumero(user)
+            user.completions.map { completion ->
+                completionToEntity(
+                    user,
+                    oppijanumero,
+                    completion,
+                )
+            }
+        }
+
+    fun getOppijanumero(user: User) =
+        oppijanumeroService.getOppijanumero(
+            etunimet = user.firstname,
+            sukunimi = user.lastname,
+            hetu = user.SSN,
+            kutsumanimi = user.preferredname,
+        )
+
+    fun getLuetunYmmartaminen(completion: Completion) =
+        completion.results.find { it.name == "luetun ymm\u00e4rt\u00e4minen" }!!
+
+    fun getKuullunYmmartaminen(completion: Completion) =
+        completion.results.find { it.name == "kuullun ymm\u00e4rt\u00e4minen" }!!
+
+    fun getPuhe(completion: Completion) = completion.results.find { it.name == "puhe" }!!
+
+    fun getKirjoittaminen(completion: Completion) = completion.results.find { it.name == "kirjoittaminen" }!!
+
+    fun completionToEntity(
+        user: User,
+        oppijanumero: String,
+        completion: Completion,
+    ): KielitestiSuoritus {
+        val luetunYmmartaminen = getLuetunYmmartaminen(completion)
+        val kuullunYmmartaminen = getKuullunYmmartaminen(completion)
+        val puhe = getPuhe(completion)
+        val kirjoittaminen = getKirjoittaminen(completion)
+
+        return KielitestiSuoritus(
+            firstName = user.firstname,
+            lastName = user.lastname,
+            preferredname = user.preferredname,
+            email = user.email,
+            oppijanumero = oppijanumero,
+            timeCompleted = Instant.ofEpochSecond(completion.timecompleted),
+            courseid = completion.courseid,
+            coursename = completion.coursename,
+            luetunYmmartaminenResultSystem = luetunYmmartaminen.quiz_result_system,
+            luetunYmmartaminenResultTeacher = luetunYmmartaminen.quiz_result_teacher,
+            kuullunYmmartaminenResultSystem = kuullunYmmartaminen.quiz_result_system,
+            kuullunYmmartaminenResultTeacher = kuullunYmmartaminen.quiz_result_teacher,
+            puheResultSystem = puhe.quiz_result_system,
+            puheResultTeacher = puhe.quiz_result_teacher,
+            kirjoittaminenResultSystem = kirjoittaminen.quiz_result_system,
+            kirjottaminenResultTeacher = kirjoittaminen.quiz_result_teacher,
+            totalEvaluationTeacher = completion.total_evaluation_teacher,
+            totalEvaluationSystem = completion.total_evaluation_system,
+        )
+    }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
@@ -11,7 +11,6 @@ import fi.oph.kitu.csvparsing.yki.TutkintokieliDeserializer
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import java.time.LocalDate
-import java.time.OffsetDateTime
 
 @JsonPropertyOrder(
     "arvioijanOppijanumero",
@@ -69,29 +68,6 @@ class SolkiArvioijaResponse(
     @JsonDeserialize(using = TutkintotasotFromStringDeserializer::class)
     val tasot: Iterable<Tutkintotaso>,
 ) {
-    fun toEntity(
-        id: Number? = null,
-        rekisteriintuontiaika: OffsetDateTime? = null,
-    ) = YkiArvioijaEntity(
-        id,
-        rekisteriintuontiaika,
-        arvioijanOppijanumero,
-        henkilotunnus,
-        sukunimi,
-        etunimet,
-        sahkopostiosoite,
-        katuosoite,
-        postinumero,
-        postitoimipaikka,
-        ensimmainenRekisterointipaiva,
-        kaudenAlkupaiva,
-        kaudenPaattymispaiva,
-        jatkorekisterointi,
-        tila,
-        kieli,
-        tasot = tasot.toSet(),
-    )
-
     override fun toString(): String =
         "SolkiArvioijaResponse(arvioijanOppijanumero='$arvioijanOppijanumero', tila=$tila, kieli=$kieli, tasot='$tasot')"
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaMappingService.kt
@@ -1,0 +1,33 @@
+package fi.oph.kitu.yki.arvioijat
+
+import org.springframework.stereotype.Service
+import java.time.OffsetDateTime
+
+@Service
+class YkiArvioijaMappingService {
+    fun convertToEntityIterable(iterable: Iterable<SolkiArvioijaResponse>) = iterable.map { convertToEntity(it) }
+
+    fun convertToEntity(
+        response: SolkiArvioijaResponse,
+        id: Number? = null,
+        rekisteriintuontiaika: OffsetDateTime? = null,
+    ) = YkiArvioijaEntity(
+        id,
+        rekisteriintuontiaika,
+        response.arvioijanOppijanumero,
+        response.henkilotunnus,
+        response.sukunimi,
+        response.etunimet,
+        response.sahkopostiosoite,
+        response.katuosoite,
+        response.postinumero,
+        response.postitoimipaikka,
+        response.ensimmainenRekisterointipaiva,
+        response.kaudenAlkupaiva,
+        response.kaudenPaattymispaiva,
+        response.jatkorekisterointi,
+        response.tila,
+        response.kieli,
+        tasot = response.tasot.toSet(),
+    )
+}

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
@@ -116,39 +116,4 @@ data class YkiSuoritusCsv(
     @JsonProperty("tarkistusarvioinninKasittelyPvm")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     val tarkistusarvioinninKasittelyPvm: LocalDate?,
-) {
-    fun toEntity(id: Int? = null) =
-        YkiSuoritusEntity(
-            id,
-            suorittajanOID.toString(),
-            hetu,
-            sukupuoli,
-            sukunimi,
-            etunimet,
-            kansalaisuus,
-            katuosoite,
-            postinumero,
-            postitoimipaikka,
-            email,
-            suoritusID,
-            lastModified,
-            tutkintopaiva,
-            tutkintokieli,
-            tutkintotaso,
-            jarjestajanOID.toString(),
-            jarjestajanNimi,
-            arviointipaiva,
-            tekstinYmmartaminen,
-            kirjoittaminen,
-            rakenteetJaSanasto,
-            puheenYmmartaminen,
-            puhuminen,
-            yleisarvosana,
-            tarkistusarvioinninSaapumisPvm,
-            tarkistusarvioinninAsiatunnus,
-            tarkistusarvioidutOsakokeet,
-            arvosanaMuuttui,
-            perustelu,
-            tarkistusarvioinninKasittelyPvm,
-        )
-}
+)

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
@@ -5,7 +5,6 @@ import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import org.ietf.jgss.Oid
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
@@ -49,39 +48,5 @@ data class YkiSuoritusEntity(
     val perustelu: String?,
     val tarkistusarvioinninKasittelyPvm: LocalDate?,
 ) {
-    fun toYkiSuoritusCsv(): YkiSuoritusCsv =
-        YkiSuoritusCsv(
-            suorittajanOID = Oid(suorittajanOID),
-            hetu = hetu,
-            sukupuoli = sukupuoli,
-            sukunimi = sukunimi,
-            etunimet = etunimet,
-            kansalaisuus = kansalaisuus,
-            katuosoite = katuosoite,
-            postinumero = postinumero,
-            postitoimipaikka = postitoimipaikka,
-            email = email,
-            suoritusID = suoritusId,
-            lastModified = lastModified,
-            tutkintopaiva = tutkintopaiva,
-            tutkintokieli = tutkintokieli,
-            tutkintotaso = tutkintotaso,
-            jarjestajanOID = Oid(jarjestajanTunnusOid),
-            jarjestajanNimi = jarjestajanNimi,
-            arviointipaiva = arviointipaiva,
-            tekstinYmmartaminen = tekstinYmmartaminen,
-            kirjoittaminen = kirjoittaminen,
-            rakenteetJaSanasto = rakenteetJaSanasto,
-            puheenYmmartaminen = puheenYmmartaminen,
-            puhuminen = puhuminen,
-            yleisarvosana = yleisarvosana,
-            tarkistusarvioinninSaapumisPvm = tarkistusarvioinninSaapumisPvm,
-            tarkistusarvioinninAsiatunnus = tarkistusarvioinninAsiatunnus,
-            tarkistusarvioidutOsakokeet = tarkistusarvioidutOsakokeet,
-            arvosanaMuuttui = arvosanaMuuttui,
-            perustelu = perustelu,
-            tarkistusarvioinninKasittelyPvm = tarkistusarvioinninKasittelyPvm,
-        )
-
     companion object
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
@@ -1,0 +1,82 @@
+package fi.oph.kitu.yki.suoritukset
+
+import org.ietf.jgss.Oid
+import org.springframework.stereotype.Service
+
+@Service
+class YkiSuoritusMappingService {
+    fun convertToEntityIterable(iterable: Iterable<YkiSuoritusCsv>) = iterable.map { convertToEntity(it) }
+
+    fun convertToEntity(
+        csv: YkiSuoritusCsv,
+        id: Int? = null,
+    ) = YkiSuoritusEntity(
+        id,
+        csv.suorittajanOID.toString(),
+        csv.hetu,
+        csv.sukupuoli,
+        csv.sukunimi,
+        csv.etunimet,
+        csv.kansalaisuus,
+        csv.katuosoite,
+        csv.postinumero,
+        csv.postitoimipaikka,
+        csv.email,
+        csv.suoritusID,
+        csv.lastModified,
+        csv.tutkintopaiva,
+        csv.tutkintokieli,
+        csv.tutkintotaso,
+        csv.jarjestajanOID.toString(),
+        csv.jarjestajanNimi,
+        csv.arviointipaiva,
+        csv.tekstinYmmartaminen,
+        csv.kirjoittaminen,
+        csv.rakenteetJaSanasto,
+        csv.puheenYmmartaminen,
+        csv.puhuminen,
+        csv.yleisarvosana,
+        csv.tarkistusarvioinninSaapumisPvm,
+        csv.tarkistusarvioinninAsiatunnus,
+        csv.tarkistusarvioidutOsakokeet,
+        csv.arvosanaMuuttui,
+        csv.perustelu,
+        csv.tarkistusarvioinninKasittelyPvm,
+    )
+
+    fun convertToResponseIterable(iterable: Iterable<YkiSuoritusEntity>) = iterable.map { convertToResponse(it) }
+
+    fun convertToResponse(entity: YkiSuoritusEntity): YkiSuoritusCsv =
+        YkiSuoritusCsv(
+            suorittajanOID = Oid(entity.suorittajanOID),
+            hetu = entity.hetu,
+            sukupuoli = entity.sukupuoli,
+            sukunimi = entity.sukunimi,
+            etunimet = entity.etunimet,
+            kansalaisuus = entity.kansalaisuus,
+            katuosoite = entity.katuosoite,
+            postinumero = entity.postinumero,
+            postitoimipaikka = entity.postitoimipaikka,
+            email = entity.email,
+            suoritusID = entity.suoritusId,
+            lastModified = entity.lastModified,
+            tutkintopaiva = entity.tutkintopaiva,
+            tutkintokieli = entity.tutkintokieli,
+            tutkintotaso = entity.tutkintotaso,
+            jarjestajanOID = Oid(entity.jarjestajanTunnusOid),
+            jarjestajanNimi = entity.jarjestajanNimi,
+            arviointipaiva = entity.arviointipaiva,
+            tekstinYmmartaminen = entity.tekstinYmmartaminen,
+            kirjoittaminen = entity.kirjoittaminen,
+            rakenteetJaSanasto = entity.rakenteetJaSanasto,
+            puheenYmmartaminen = entity.puheenYmmartaminen,
+            puhuminen = entity.puhuminen,
+            yleisarvosana = entity.yleisarvosana,
+            tarkistusarvioinninSaapumisPvm = entity.tarkistusarvioinninSaapumisPvm,
+            tarkistusarvioinninAsiatunnus = entity.tarkistusarvioinninAsiatunnus,
+            tarkistusarvioidutOsakokeet = entity.tarkistusarvioidutOsakokeet,
+            arvosanaMuuttui = entity.arvosanaMuuttui,
+            perustelu = entity.perustelu,
+            tarkistusarvioinninKasittelyPvm = entity.tarkistusarvioinninKasittelyPvm,
+        )
+}

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -8,7 +8,6 @@ import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import fi.oph.kitu.yki.arvioijat.SolkiArvioijaResponse
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv
-import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
 import org.ietf.jgss.Oid
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -141,41 +140,41 @@ class CsvParsingTest {
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         val parser = CsvParser(MockEvent(), useHeader = true)
-        val entity =
-            YkiSuoritusEntity(
-                id = null,
-                suorittajanOID = "1.2.246.562.24.20281155246",
-                hetu = "010180-9026",
-                sukupuoli = Sukupuoli.N,
-                sukunimi = "Öhmana-Testi",
-                etunimet = "Ranja Testi",
-                kansalaisuus = "EST",
-                katuosoite = "Testikuja 5",
-                postinumero = "40100",
-                postitoimipaikka = "Testilä",
-                email = "testi@testi.fi",
-                suoritusId = 183424,
-                lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
-                tutkintokieli = Tutkintokieli.FIN,
-                tutkintotaso = Tutkintotaso.YT,
-                jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
-                jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
-                tekstinYmmartaminen = 5,
-                kirjoittaminen = 4,
-                rakenteetJaSanasto = 3,
-                puheenYmmartaminen = 1,
-                puhuminen = 2,
-                yleisarvosana = 3,
-                tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
-                tarkistusarvioinninAsiatunnus = "123123",
-                tarkistusarvioidutOsakokeet = 2,
-                arvosanaMuuttui = true,
-                perustelu = "Tarkistusarvioinnin testi",
-                tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
+        val writable =
+            listOf(
+                YkiSuoritusCsv(
+                    suorittajanOID = Oid("1.2.246.562.24.20281155246"),
+                    hetu = "010180-9026",
+                    sukupuoli = Sukupuoli.N,
+                    sukunimi = "Öhmana-Testi",
+                    etunimet = "Ranja Testi",
+                    kansalaisuus = "EST",
+                    katuosoite = "Testikuja 5",
+                    postinumero = "40100",
+                    postitoimipaikka = "Testilä",
+                    email = "testi@testi.fi",
+                    suoritusID = 183424,
+                    lastModified = Instant.parse("2024-10-30T13:53:56Z"),
+                    tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
+                    tutkintokieli = Tutkintokieli.FIN,
+                    tutkintotaso = Tutkintotaso.YT,
+                    jarjestajanOID = Oid("1.2.246.562.10.14893989377"),
+                    jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
+                    arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
+                    tekstinYmmartaminen = 5,
+                    kirjoittaminen = 4,
+                    rakenteetJaSanasto = 3,
+                    puheenYmmartaminen = 1,
+                    puhuminen = 2,
+                    yleisarvosana = 3,
+                    tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
+                    tarkistusarvioinninAsiatunnus = "123123",
+                    tarkistusarvioidutOsakokeet = 2,
+                    arvosanaMuuttui = true,
+                    perustelu = "Tarkistusarvioinnin testi",
+                    tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
+                ),
             )
-        val writable = listOf(entity.toYkiSuoritusCsv())
         val outputStream = ByteArrayOutputStream()
         parser.streamDataAsCsv(outputStream, writable)
         val expectedCsv =
@@ -192,41 +191,41 @@ class CsvParsingTest {
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
         val parser = CsvParser(MockEvent(), useHeader = true)
-        val entity =
-            YkiSuoritusEntity(
-                id = null,
-                suorittajanOID = "1.2.246.562.24.20281155246",
-                hetu = "010180-9026",
-                sukupuoli = Sukupuoli.N,
-                sukunimi = "Öhmana-Testi",
-                etunimet = "Ranja Testi",
-                kansalaisuus = "EST",
-                katuosoite = "Testikuja 5",
-                postinumero = "40100",
-                postitoimipaikka = "Testilä",
-                email = null,
-                suoritusId = 183424,
-                lastModified = Instant.parse("2024-10-30T13:53:56Z"),
-                tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
-                tutkintokieli = Tutkintokieli.FIN,
-                tutkintotaso = Tutkintotaso.YT,
-                jarjestajanTunnusOid = "1.2.246.562.10.14893989377",
-                jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
-                arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
-                tekstinYmmartaminen = null,
-                kirjoittaminen = null,
-                rakenteetJaSanasto = null,
-                puheenYmmartaminen = null,
-                puhuminen = null,
-                yleisarvosana = null,
-                tarkistusarvioinninSaapumisPvm = null,
-                tarkistusarvioinninAsiatunnus = null,
-                tarkistusarvioidutOsakokeet = null,
-                arvosanaMuuttui = null,
-                perustelu = null,
-                tarkistusarvioinninKasittelyPvm = null,
+        val writable =
+            listOf(
+                YkiSuoritusCsv(
+                    suorittajanOID = Oid("1.2.246.562.24.20281155246"),
+                    hetu = "010180-9026",
+                    sukupuoli = Sukupuoli.N,
+                    sukunimi = "Öhmana-Testi",
+                    etunimet = "Ranja Testi",
+                    kansalaisuus = "EST",
+                    katuosoite = "Testikuja 5",
+                    postinumero = "40100",
+                    postitoimipaikka = "Testilä",
+                    email = null,
+                    suoritusID = 183424,
+                    lastModified = Instant.parse("2024-10-30T13:53:56Z"),
+                    tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
+                    tutkintokieli = Tutkintokieli.FIN,
+                    tutkintotaso = Tutkintotaso.YT,
+                    jarjestajanOID = Oid("1.2.246.562.10.14893989377"),
+                    jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
+                    arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
+                    tekstinYmmartaminen = null,
+                    kirjoittaminen = null,
+                    rakenteetJaSanasto = null,
+                    puheenYmmartaminen = null,
+                    puhuminen = null,
+                    yleisarvosana = null,
+                    tarkistusarvioinninSaapumisPvm = null,
+                    tarkistusarvioinninAsiatunnus = null,
+                    tarkistusarvioidutOsakokeet = null,
+                    arvosanaMuuttui = null,
+                    perustelu = null,
+                    tarkistusarvioinninKasittelyPvm = null,
+                ),
             )
-        val writable = listOf(entity.toYkiSuoritusCsv())
         val outputStream = ByteArrayOutputStream()
         parser.streamDataAsCsv(outputStream, writable)
 

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
@@ -97,10 +97,7 @@ class KoealustaServiceTests {
                 restClientBuilder = mockRestClientBuilder,
                 kielitestiSuoritusRepository = kielitestiSuoritusRepository,
                 jacksonObjectMapper = objectMapper,
-                oppijanumeroService =
-                    OppijanumeroServiceMock(
-                        "123",
-                    ),
+                mappingService = KoealustaMappingService(OppijanumeroServiceMock("123")),
             )
 
         koealustaService.koealustaToken = "token"

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
@@ -1,6 +1,8 @@
 package fi.oph.kitu.yki
 
+import fi.oph.kitu.yki.arvioijat.YkiArvioijaMappingService
 import fi.oph.kitu.yki.arvioijat.YkiArvioijaRepository
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusMappingService
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -65,7 +67,9 @@ class YkiServiceTests(
             YkiService(
                 solkiRestClient = mockRestClientBuilder.build(),
                 suoritusRepository = ykiSuoritusRepository,
+                suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
+                arvioijaMapper = YkiArvioijaMappingService(),
             )
 
         // Act
@@ -97,7 +101,9 @@ class YkiServiceTests(
             YkiService(
                 solkiRestClient = mockRestClientBuilder.build(),
                 suoritusRepository = ykiSuoritusRepository,
+                suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
+                arvioijaMapper = YkiArvioijaMappingService(),
             )
 
         // Act
@@ -131,7 +137,9 @@ class YkiServiceTests(
             YkiService(
                 solkiRestClient = mockRestClientBuilder.build(),
                 suoritusRepository = ykiSuoritusRepository,
+                suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
+                arvioijaMapper = YkiArvioijaMappingService(),
             )
 
         // Act
@@ -181,7 +189,9 @@ class YkiServiceTests(
             YkiService(
                 solkiRestClient = mockRestClientBuilder.build(),
                 suoritusRepository = ykiSuoritusRepository,
+                suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
+                arvioijaMapper = YkiArvioijaMappingService(),
             )
 
         assertDoesNotThrow {
@@ -224,7 +234,9 @@ class YkiServiceTests(
             YkiService(
                 solkiRestClient = mockRestClientBuilder.build(),
                 suoritusRepository = ykiSuoritusRepository,
+                suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
+                arvioijaMapper = YkiArvioijaMappingService(),
             )
 
         assertDoesNotThrow {


### PR DESCRIPTION
Suggestion: Instead of mapping inside a class, we dedicate mappings to a mapping service.

This is just a POC:
 - Only done with koealusta, but similar pattern could be used in yki as well.
 - Tests fails, because the POC is not implemented at tests yet.
 - Notice that base is not main