### PR TITLE
Add support for non-ISO legacy languages

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/TutkintokieliDeserializer.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/TutkintokieliDeserializer.kt
@@ -1,0 +1,18 @@
+package fi.oph.kitu.csvparsing
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import fi.oph.kitu.yki.Tutkintokieli
+
+class TutkintokieliDeserializer : JsonDeserializer<Tutkintokieli>() {
+    override fun deserialize(
+        p: JsonParser,
+        ctxt: DeserializationContext,
+    ) = when (p.text) {
+        "10" -> Tutkintokieli.SWE10
+        "11" -> Tutkintokieli.ENG11
+        "12" -> Tutkintokieli.ENG12
+        else -> Tutkintokieli.valueOf(p.text.uppercase())
+    }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/yki/BooleanFromNumericDeserializer.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/yki/BooleanFromNumericDeserializer.kt
@@ -1,4 +1,4 @@
-package fi.oph.kitu.csvparsing
+package fi.oph.kitu.csvparsing.yki
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/yki/TutkintokieliDeserializer.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/yki/TutkintokieliDeserializer.kt
@@ -1,4 +1,4 @@
-package fi.oph.kitu.csvparsing
+package fi.oph.kitu.csvparsing.yki
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext

--- a/server/src/main/kotlin/fi/oph/kitu/yki/Tutkintokieli.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/Tutkintokieli.kt
@@ -2,7 +2,12 @@ package fi.oph.kitu.yki
 
 import java.sql.ResultSet
 
-/** ISO 649-2 Alpha 3 */
+/** ISO 639-2 Alpha 3
+ *  Legacy langugage codes:
+ *  10,Svenska,svenska,Swedish
+ *  11,Kaupallinen englanti,företagsengelska,English for business
+ *  12,Tekninen englanti,teknisk engelska,English for technology
+ *  */
 enum class Tutkintokieli {
     DEU,
     ENG,
@@ -13,6 +18,9 @@ enum class Tutkintokieli {
     SME,
     SPA,
     SWE,
+    SWE10,
+    ENG11,
+    ENG12,
 }
 
 fun ResultSet.getTutkintokieli(columnLabel: String): Tutkintokieli = Tutkintokieli.valueOf(getString(columnLabel))

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import fi.oph.kitu.csvparsing.BooleanFromNumericDeserializer
 import fi.oph.kitu.csvparsing.Features
+import fi.oph.kitu.csvparsing.TutkintokieliDeserializer
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import java.time.LocalDate
@@ -62,6 +63,7 @@ class SolkiArvioijaResponse(
     @JsonProperty("tila")
     val tila: Number,
     @JsonProperty("kieli")
+    @JsonDeserialize(using = TutkintokieliDeserializer::class)
     val kieli: Tutkintokieli,
     @JsonProperty("tasot")
     @JsonDeserialize(using = TutkintotasotFromStringDeserializer::class)

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/SolkiArvioijaResponse.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import fi.oph.kitu.csvparsing.BooleanFromNumericDeserializer
 import fi.oph.kitu.csvparsing.Features
-import fi.oph.kitu.csvparsing.TutkintokieliDeserializer
+import fi.oph.kitu.csvparsing.yki.BooleanFromNumericDeserializer
+import fi.oph.kitu.csvparsing.yki.TutkintokieliDeserializer
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import java.time.LocalDate

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import fi.oph.kitu.csvparsing.BooleanFromNumericDeserializer
 import fi.oph.kitu.csvparsing.Features
-import fi.oph.kitu.csvparsing.TutkintokieliDeserializer
+import fi.oph.kitu.csvparsing.yki.BooleanFromNumericDeserializer
+import fi.oph.kitu.csvparsing.yki.TutkintokieliDeserializer
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import fi.oph.kitu.csvparsing.BooleanFromNumericDeserializer
 import fi.oph.kitu.csvparsing.Features
+import fi.oph.kitu.csvparsing.TutkintokieliDeserializer
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
@@ -77,6 +78,7 @@ data class YkiSuoritusCsv(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     val tutkintopaiva: LocalDate,
     @JsonProperty("tutkintokieli")
+    @JsonDeserialize(using = TutkintokieliDeserializer::class)
     val tutkintokieli: Tutkintokieli,
     @JsonProperty("tutkintotaso")
     val tutkintotaso: Tutkintotaso,

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -3,6 +3,7 @@ package fi.oph.kitu.csvparsing
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
+import fi.oph.kitu.yki.arvioijat.SolkiArvioijaResponse
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
 import org.ietf.jgss.Oid
@@ -54,6 +55,36 @@ class CsvParsingTest {
         assertEquals(false, suoritus.arvosanaMuuttui)
         assertEquals("", suoritus.perustelu)
         assertNull(suoritus.tarkistusarvioinninKasittelyPvm)
+    }
+
+    @Test
+    fun `test legacy language code 10 parsing`() {
+        val arvioijaCsv =
+            """
+            "1.2.246.562.24.24941612410","010180-922U","Torvinen-Testi","Anniina Testi","anniina.testi@yki.fi","Testiosoite 7357","00100","HELSINKI",1994-08-01,2019-06-29,2024-06-29,0,0,"10","PT+KT"
+            """.trimIndent()
+        val arvioija = arvioijaCsv.asCsv<SolkiArvioijaResponse>()[0]
+        assertEquals(Tutkintokieli.SWE10, arvioija.kieli)
+    }
+
+    @Test
+    fun `test legacy language code 11 parsing`() {
+        val arvioijaCsv =
+            """
+            "1.2.246.562.24.24941612410","010180-922U","Torvinen-Testi","Anniina Testi","anniina.testi@yki.fi","Testiosoite 7357","00100","HELSINKI",1994-08-01,2019-06-29,2024-06-29,0,0,"11","PT+KT"
+            """.trimIndent()
+        val arvioija = arvioijaCsv.asCsv<SolkiArvioijaResponse>()[0]
+        assertEquals(Tutkintokieli.ENG11, arvioija.kieli)
+    }
+
+    @Test
+    fun `test legacy language code 12 parsing`() {
+        val arvioijaCsv =
+            """
+            "1.2.246.562.24.24941612410","010180-922U","Torvinen-Testi","Anniina Testi","anniina.testi@yki.fi","Testiosoite 7357","00100","HELSINKI",1994-08-01,2019-06-29,2024-06-29,0,0,"12","PT+KT"
+            """.trimIndent()
+        val arvioija = arvioijaCsv.asCsv<SolkiArvioijaResponse>()[0]
+        assertEquals(Tutkintokieli.ENG12, arvioija.kieli)
     }
 
     @Test


### PR DESCRIPTION
> Tutkintokielissä on historiallisista syistä muutama ei-ISO-muotoinen kielikoodi:
> 10,Svenska,svenska,Swedish
> 11,Kaupallinen englanti,företagsengelska,English for business
> 12,Tekninen englanti,teknisk engelska,English for technology