### PR TITLE
feat: allow running any command with AWS secrets

### DIFF
--- a/scripts/ensure_aws_secrets.sh
+++ b/scripts/ensure_aws_secrets.sh
@@ -15,3 +15,5 @@ export "KIELITESTI_TOKEN"="$(get_secret "kielitesti-token")"; echo "KIELITESTI_T
 export "OPPIJANUMERO_PASSWORD"="$(get_secret "oppijanumero-password")"; echo "OPPIJANUMERO_PASSWORD exported"
 export "YKI_API_USER"="$(get_secret "yki-api-user")"; echo "YKI_API_USER exported"
 export "YKI_API_PASSWORD"="$(get_secret "yki-api-password")"; echo "YKI_API_PASSWORD exported"
+
+exec "$@"

--- a/scripts/start_local_env.sh
+++ b/scripts/start_local_env.sh
@@ -25,9 +25,6 @@ mise install --quiet  --yes --cd="$REPO_ROOT"
 require_command docker
 require_command git
 
-# exports secrets to environment variables
-source "$scripts_dir/ensure_aws_secrets.sh"
-
 # setup playwright
 (cd "$REPO_ROOT"/e2e && npm i && npx playwright install)
 
@@ -40,63 +37,11 @@ else
   readonly SETUP_ONLY="false"
 fi
 
-kotorekisteri_start_tmux() {
-  SESS_NAME=kotorekisteri
-
-  (
-    cd "$REPO_ROOT" || exit 1
-
-    # Use old session if exists
-    set +e
-    tmux has-session -t $SESS_NAME 2>/dev/null
-    HAS_SESSION="$?"
-    set -e
-    if [ "$HAS_SESSION" -eq "0" ]; then
-      info "Attaching to existing tmux session..."
-      tmux attach -t $SESS_NAME
-      # TODO: Instead of return, kill the old session.
-      return
-   fi
-
-    # If there is no session...
-    # Start a new tmux session and detach immediately
-    # Window 0:zsh
-    info "Starting new tmux session..."
-    tmux new-session -d -s $SESS_NAME
-
-    # Window 0:database docker
-    WINDOW="database"
-    tmux rename-window -t $SESS_NAME:0 "$WINDOW"
-    tmux send-keys -t $SESS_NAME:"$WINDOW.0" "$REPO_ROOT/scripts/start_database_docker.sh" C-m
-
-    # Window 1:idea
-    WINDOW="idea"
-    tmux new-window -t $SESS_NAME -n "idea"
-    tmux send-keys -t $SESS_NAME:"idea" "idea $REPO_ROOT" C-m
-
-    # Window 2:springboot
-    WINDOW="springboot"
-    tmux new-window -t $SESS_NAME -n "$WINDOW"
-    tmux send-keys -t $SESS_NAME:"$WINDOW" "$REPO_ROOT/scripts/start_local_server.sh" C-m
-
-    # Window 3:workspace
-    WINDOW="workspace"
-    tmux new-window -t $SESS_NAME -n "$WINDOW"
-    tmux send-keys -t $SESS_NAME:"$WINDOW" "cd $REPO_ROOT" C-m
-    tmux send-keys -t $SESS_NAME:"$WINDOW" "git log --decorate=full --graph --all --oneline" C-m
-    tmux split-window -h -t "${SESSION-}":"$WINDOW"
-    tmux send-keys -t $SESS_NAME:"$WINDOW.1" "cd $REPO_ROOT" C-m
-    tmux send-keys -t $SESS_NAME:"$WINDOW.1" "ls -la" C-m
-    tmux send-keys -t $SESS_NAME:"$WINDOW.1" "git status" C-m
-
-    tmux attach
-  )
-}
-
 if [[ "$SETUP_ONLY" == "true" ]]; then
   info "Setup done."
   exit 0
 fi
 
 require_command tmux
-kotorekisteri_start_tmux
+
+"$scripts_dir"/ensure_aws_secrets.sh "$scripts_dir"/start_tmux.sh

--- a/scripts/start_tmux.sh
+++ b/scripts/start_tmux.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+scripts_dir=$( dirname "${BASH_SOURCE[0]}" )
+source "$scripts_dir/common-functions.sh"
+
+SESS_NAME=kotorekisteri
+
+cd "$REPO_ROOT" || exit 1
+
+# Use old session if exists
+set +e
+tmux has-session -t $SESS_NAME 2>/dev/null
+HAS_SESSION="$?"
+set -e
+if [ "$HAS_SESSION" -eq "0" ]; then
+  info "Attaching to existing tmux session..."
+  tmux attach -t $SESS_NAME
+  # TODO: Instead of return, kill the old session.
+  return
+fi
+
+# If there is no session...
+# Start a new tmux session and detach immediately
+# Window 0:zsh
+info "Starting new tmux session..."
+tmux new-session -d -s $SESS_NAME
+
+# Window 0:database docker
+WINDOW="database"
+tmux rename-window -t $SESS_NAME:0 "$WINDOW"
+tmux send-keys -t $SESS_NAME:"$WINDOW.0" "$REPO_ROOT/scripts/start_database_docker.sh" C-m
+
+# Window 1:idea
+WINDOW="idea"
+tmux new-window -t $SESS_NAME -n "idea"
+tmux send-keys -t $SESS_NAME:"idea" "idea $REPO_ROOT" C-m
+
+# Window 2:springboot
+WINDOW="springboot"
+tmux new-window -t $SESS_NAME -n "$WINDOW"
+tmux send-keys -t $SESS_NAME:"$WINDOW" "$REPO_ROOT/scripts/start_local_server.sh" C-m
+
+# Window 3:workspace
+WINDOW="workspace"
+tmux new-window -t $SESS_NAME -n "$WINDOW"
+tmux send-keys -t $SESS_NAME:"$WINDOW" "cd $REPO_ROOT" C-m
+tmux send-keys -t $SESS_NAME:"$WINDOW" "git log --decorate=full --graph --all --oneline" C-m
+tmux split-window -h -t "${SESSION-}":"$WINDOW"
+tmux send-keys -t $SESS_NAME:"$WINDOW.1" "cd $REPO_ROOT" C-m
+tmux send-keys -t $SESS_NAME:"$WINDOW.1" "ls -la" C-m
+tmux send-keys -t $SESS_NAME:"$WINDOW.1" "git status" C-m
+
+tmux attach


### PR DESCRIPTION
Enables running e.g. `ensure_aws_secrets.sh idea`. Without this change you could run `source ensure_aws_secrets.sh` in bash but other shells (fish) wouldn't work.