### PR TITLE
Fix change yki arvosana muuttui data type

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import fi.oph.kitu.csvparsing.Features
-import fi.oph.kitu.csvparsing.yki.BooleanFromNumericDeserializer
 import fi.oph.kitu.csvparsing.yki.TutkintokieliDeserializer
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
@@ -109,8 +108,7 @@ data class YkiSuoritusCsv(
     @JsonProperty("tarkistusarvioidutOsakokeet")
     val tarkistusarvioidutOsakokeet: Int?,
     @JsonProperty("arvosanaMuuttui")
-    @JsonDeserialize(using = BooleanFromNumericDeserializer::class)
-    val arvosanaMuuttui: Boolean?,
+    val arvosanaMuuttui: Int?,
     @JsonProperty("perustelu")
     val perustelu: String?,
     @JsonProperty("tarkistusarvioinninKasittelyPvm")

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
@@ -44,7 +44,7 @@ data class YkiSuoritusEntity(
     val tarkistusarvioinninSaapumisPvm: LocalDate?,
     val tarkistusarvioinninAsiatunnus: String?,
     val tarkistusarvioidutOsakokeet: Int?,
-    val arvosanaMuuttui: Boolean?,
+    val arvosanaMuuttui: Int?,
     val perustelu: String?,
     val tarkistusarvioinninKasittelyPvm: LocalDate?,
 ) {

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
@@ -43,7 +43,21 @@ data class YkiSuoritusEntity(
     val yleisarvosana: Int?,
     val tarkistusarvioinninSaapumisPvm: LocalDate?,
     val tarkistusarvioinninAsiatunnus: String?,
+    /*
+     * kokonaisluku 0–15, tulkitaan bittimaskina
+     * 1=puhuminen
+     * 2=kirjoittaminen
+     * 4=tekstin ymmärtäminen
+     * 8=puheen ymmärtäminen
+     * */
     val tarkistusarvioidutOsakokeet: Int?,
+    /*
+     * kokonaisluku 0–15, tulkitaan bittimaskina
+     * 1=puhuminen
+     * 2=kirjoittaminen
+     * 4=tekstin ymmärtäminen
+     * 8=puheen ymmärtäminen
+     * */
     val arvosanaMuuttui: Int?,
     val perustelu: String?,
     val tarkistusarvioinninKasittelyPvm: LocalDate?,

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
@@ -216,7 +216,7 @@ fun YkiSuoritusEntity.Companion.fromResultSet(rs: ResultSet): YkiSuoritusEntity 
         rs.getObject("tarkistusarvioinnin_saapumis_pvm", LocalDate::class.java),
         rs.getString("tarkistusarvioinnin_asiatunnus"),
         rs.getObject("tarkistusarvioidut_osakokeet", Integer::class.java)?.toInt(),
-        rs.getObject("arvosana_muuttui", Boolean::class.javaObjectType),
+        rs.getObject("arvosana_muuttui", Integer::class.java)?.toInt(),
         rs.getString("perustelu"),
         rs.getObject("tarkistusarvioinnin_kasittely_pvm", LocalDate::class.java),
     )

--- a/server/src/main/resources/db/migration/V19__change_yki_arvosana_muuttui_type.sql
+++ b/server/src/main/resources/db/migration/V19__change_yki_arvosana_muuttui_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE yki_suoritus
+    ALTER COLUMN arvosana_muuttui SET DATA TYPE INTEGER USING arvosana_muuttui::integer;

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -59,7 +59,7 @@ class CsvParsingTest {
         assertNull(suoritus.tarkistusarvioinninSaapumisPvm)
         assertEquals("", suoritus.tarkistusarvioinninAsiatunnus)
         assertEquals(0, suoritus.tarkistusarvioidutOsakokeet)
-        assertEquals(false, suoritus.arvosanaMuuttui)
+        assertEquals(0, suoritus.arvosanaMuuttui)
         assertEquals("", suoritus.perustelu)
         assertNull(suoritus.tarkistusarvioinninKasittelyPvm)
     }
@@ -170,8 +170,8 @@ class CsvParsingTest {
                     tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
                     tarkistusarvioinninAsiatunnus = "123123",
                     tarkistusarvioidutOsakokeet = 2,
-                    arvosanaMuuttui = true,
-                    perustelu = "Tarkistusarvioinnin testi",
+                    arvosanaMuuttui = 1,
+                    perustelu = "Tarkistusarvioinnin testi\\nJossa rivinvaihto",
                     tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
                 ),
             )
@@ -180,7 +180,7 @@ class CsvParsingTest {
         val expectedCsv =
             """
             suorittajanOID,hetu,sukupuoli,sukunimi,etunimet,kansalaisuus,katuosoite,postinumero,postitoimipaikka,email,suoritusID,lastModified,tutkintopaiva,tutkintokieli,tutkintotaso,jarjestajanOID,jarjestajanNimi,arviointipaiva,tekstinYmmartaminen,kirjoittaminen,rakenteetJaSanasto,puheenYmmartaminen,puhuminen,yleisarvosana,"tarkistusarvioinninSaapumisPvm","tarkistusarvioinninAsiatunnus","tarkistusarvioidutOsakokeet",arvosanaMuuttui,perustelu,"tarkistusarvioinninKasittelyPvm"
-            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,testi@testi.fi,183424,2024-10-30T13:53:56Z,2024-09-01,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,4,3,1,2,3,2024-10-01,123123,2,true,"Tarkistusarvioinnin testi",2024-10-15
+            "1.2.246.562.24.20281155246",010180-9026,N,Öhmana-Testi,"Ranja Testi",EST,"Testikuja 5",40100,Testilä,testi@testi.fi,183424,2024-10-30T13:53:56Z,2024-09-01,FIN,YT,"1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,4,3,1,2,3,2024-10-01,123123,2,1,"Tarkistusarvioinnin testi\nJossa rivinvaihto",2024-10-15
 
             """.trimIndent()
         assertEquals(expectedCsv, outputStream.toString(Charsets.UTF_8))

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -98,6 +98,49 @@ class CsvParsingTest {
     }
 
     @Test
+    fun `test parsing yki suoritus with newlines`() {
+        val parser = CsvParser(MockEvent())
+        val csv =
+            """
+            "1.2.246.562.24.20281155246","010180-9026","N","Öhmana-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,"Tarkistusarvioinnin perustelu\nJossa rivinvaihto",
+            """.trimIndent()
+        val suoritus = parser.convertCsvToData<YkiSuoritusCsv>(csv).first()
+
+        val datePattern = "yyyy-MM-dd"
+        val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
+        assertEquals(Oid("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
+        assertEquals("010180-9026", suoritus.hetu)
+        assertEquals(Sukupuoli.N, suoritus.sukupuoli)
+        assertEquals("Öhmana-Testi", suoritus.sukunimi)
+        assertEquals("Ranja Testi", suoritus.etunimet)
+        assertEquals("EST", suoritus.kansalaisuus)
+        assertEquals("Testikuja 5", suoritus.katuosoite)
+        assertEquals("40100", suoritus.postinumero)
+        assertEquals("Testilä", suoritus.postitoimipaikka)
+        assertEquals("testi@testi.fi", suoritus.email)
+        assertEquals(183424, suoritus.suoritusID)
+        assertEquals(Instant.parse("2024-10-30T13:53:56Z"), suoritus.lastModified)
+        assertEquals("2024-09-01", suoritus.tutkintopaiva.format(dateFormatter))
+        assertEquals(Tutkintokieli.FIN, suoritus.tutkintokieli)
+        assertEquals(Tutkintotaso.YT, suoritus.tutkintotaso)
+        assertEquals(Oid("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
+        assertEquals("Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus", suoritus.jarjestajanNimi)
+        assertEquals("2024-11-14", suoritus.arviointipaiva.format(dateFormatter))
+        assertEquals(5, suoritus.tekstinYmmartaminen)
+        assertEquals(5, suoritus.kirjoittaminen)
+        assertNull(suoritus.rakenteetJaSanasto)
+        assertEquals(5, suoritus.puheenYmmartaminen)
+        assertEquals(5, suoritus.puhuminen)
+        assertNull(suoritus.yleisarvosana)
+        assertNull(suoritus.tarkistusarvioinninSaapumisPvm)
+        assertEquals("", suoritus.tarkistusarvioinninAsiatunnus)
+        assertEquals(0, suoritus.tarkistusarvioidutOsakokeet)
+        assertEquals(0, suoritus.arvosanaMuuttui)
+        assertEquals("Tarkistusarvioinnin perustelu\\nJossa rivinvaihto", suoritus.perustelu)
+        assertNull(suoritus.tarkistusarvioinninKasittelyPvm)
+    }
+
+    @Test
     fun `parsing errors are logged `() {
         val event = MockEvent()
         val parser = CsvParser(event)

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
@@ -70,7 +70,7 @@ class YkiSuoritusRepositoryTest(
                 tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
                 tarkistusarvioinninAsiatunnus = "123123",
                 tarkistusarvioidutOsakokeet = 2,
-                arvosanaMuuttui = true,
+                arvosanaMuuttui = 1,
                 perustelu = "Tarkistusarvioinnin testi",
                 tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
             )
@@ -204,7 +204,7 @@ class YkiSuoritusRepositoryTest(
                 tarkistusarvioinninSaapumisPvm = LocalDate.parse("2024-10-01", dateFormatter),
                 tarkistusarvioinninAsiatunnus = "123123",
                 tarkistusarvioidutOsakokeet = 2,
-                arvosanaMuuttui = true,
+                arvosanaMuuttui = 4,
                 perustelu = "Tarkistusarvioinnin testi",
                 tarkistusarvioinninKasittelyPvm = LocalDate.parse("2024-10-15", dateFormatter),
             )


### PR DESCRIPTION
> Arvosanan muutos: rajapintakuvauksessa oli virhe, sisältö on bittimaski kuten kohdassa tarkistusarvioinnin osakokeet. Uusi määrittely:
> tarkistusarvioinnissa muuttuneet arvosanat/osakokeet (kokonaisluku 0–15, tulkitaan bittimaskina 1=pu, 2=ki, 4=ty, 8=py)