### PR TITLE
Run koealusta imports only every hour instead of every minute on untuva

### DIFF
--- a/server/src/main/resources/application-untuva.properties
+++ b/server/src/main/resources/application-untuva.properties
@@ -7,7 +7,7 @@ spring.datasource.password=${DATABASE_PASSWORD}
 
 kitu.kotoutumiskoulutus.koealusta.baseurl=https://kielitesti.mmg.fi
 kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=true
-kitu.kotoutumiskoulutus.koealusta.scheduling.import.schedule=FIXED_DELAY|60s
+kitu.kotoutumiskoulutus.koealusta.scheduling.import.schedule=FIXED_DELAY|1h
 
 kitu.oppijanumero.casUrl=https://virkailija.untuvaopintopolku.fi/cas
 kitu.oppijanumero.service.url=https://virkailija.untuvaopintopolku.fi/oppijanumerorekisteri-service


### PR DESCRIPTION
Right now we run every minute, which means our log error alarm has been red for the past few weeks. With this change we should see better when errors happen.