### PR TITLE
fix(yki): support newlines inside double quotes

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -1,7 +1,6 @@
 package fi.oph.kitu.csvparsing
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
-import java.lang.Exception
 
 class InvalidFormatCsvExportError(
     lineNumber: Int,
@@ -16,12 +15,12 @@ class InvalidFormatCsvExportError(
 
 class SimpleCsvExportError(
     lineNumber: Int,
-    exception: Exception,
+    exception: Throwable,
 ) : CsvExportError(lineNumber, exception)
 
 abstract class CsvExportError(
     lineNumber: Int,
-    exception: Exception,
+    exception: Throwable,
 ) {
     val keyValues = mutableListOf<Pair<String, Any>>()
 

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -67,12 +67,19 @@ class CsvParsingTest {
     @Test
     fun `test line breaks`() {
         val parser = CsvParser(MockEvent())
-        val perustelut = " - Hyvä kielioppi\n - Selkeä puhuminen\n - Ymmärtää hyvin puhetta\n"
+        val perustelut1 = " - Hyvä kielioppi\n - Selkeä puhuminen\n - Ymmärtää hyvin puhetta\n"
+        val perustelut2 = " - Hyvä kielioppi\r\n - Selkeä puhuminen\r\n - Ymmärtää hyvin puhetta\r\n"
+        // you can't use trimIndent here, because the string contains CR (\r)
         val csv =
-            """"1.2.246.562.24.20281155246","010180-9026","N","Öhmana-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,"$perustelut","""
-        val suoritus = parser.convertCsvToData<YkiSuoritusCsv>(csv).first()
+            """"1.2.246.562.24.20281155246","010180-9026","N","Öhmana-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,"$perustelut1",
+"1.2.246.562.24.20281155246","010180-9026","N","Öhmana-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,"$perustelut2","""
+        val suoritukset = parser.convertCsvToData<YkiSuoritusCsv>(csv)
 
-        assertEquals(perustelut, suoritus.perustelu)
+        val suoritus1 = suoritukset.first()
+        assertEquals(perustelut1, suoritus1.perustelu)
+
+        val suoritus2 = suoritukset.last()
+        assertEquals(perustelut2, suoritus2.perustelu)
     }
 
     @Test

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -65,6 +65,17 @@ class CsvParsingTest {
     }
 
     @Test
+    fun `test line breaks`() {
+        val parser = CsvParser(MockEvent())
+        val perustelut = " - Hyvä kielioppi\n - Selkeä puhuminen\n - Ymmärtää hyvin puhetta\n"
+        val csv =
+            """"1.2.246.562.24.20281155246","010180-9026","N","Öhmana-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,"$perustelut","""
+        val suoritus = parser.convertCsvToData<YkiSuoritusCsv>(csv).first()
+
+        assertEquals(perustelut, suoritus.perustelu)
+    }
+
+    @Test
     fun `test legacy language code 10 parsing`() {
         val parser = CsvParser(MockEvent())
         val arvioijaCsv =


### PR DESCRIPTION
Old version

```kotlin
                csvString.split(lineSeparator)
```

obviously don't take into account newlines inside double quotes.