### PR TITLE
chore(server): treat deprecations as errors

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -261,6 +261,7 @@
                     <args>
                         <arg>-Xjsr305=strict</arg>
                         <arg>-Xlint:deprecation</arg>
+                        <arg>-Xreport-deprecated</arg>
                     </args>
                     <compilerPlugins>
                         <plugin>spring</plugin>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -260,6 +260,7 @@
                 <configuration>
                     <args>
                         <arg>-Xjsr305=strict</arg>
+                        <arg>-Xlint:deprecation</arg>
                     </args>
                     <compilerPlugins>
                         <plugin>spring</plugin>


### PR DESCRIPTION
Kotlin ei suostu kääntämään jos käytetään koodissa deprekoituja metodeita. -> käännösvirhe, ei päästä CI:ssäkään myöskään läpi.

Tämän voi toteuttaa kahdella eri argumentilla kotlin plugarille. En ole varma kumpi on parempi, joten laitoin tähän molemmat
```xml
                        <arg>-Xlint:deprecation</arg>
                        <arg>-Xreport-deprecated</arg>
```