### PR TITLE
feat(kotoutumiskoulutus): add audit logging

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -30,6 +30,7 @@ kitu.yki.password=${YKI_API_PASSWORD}
 spring.mustache.suffix=.mustache
 
 logging.structured.format.console=ecs
+logging.structured.format.file=ecs
 
 # Uncomment this to debug authentication/authorization issues.
 # Ref: https://docs.spring.io/spring-security/reference/servlet/architecture.html#servlet-logging

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -5,8 +5,9 @@
 
     <appender name="AUDIT_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/audit.log</file>
-        <encoder>
-            <pattern>${LOG_PATTERN}</pattern>
+        <encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
+            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
+            <charset>${FILE_LOG_CHARSET}</charset>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/audit.%d{yyyy-MM-dd}.log</fileNamePattern>

--- a/server/src/test/kotlin/fi/oph/kitu/KituApplicationTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/KituApplicationTests.kt
@@ -10,6 +10,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @SpringBootTest
 @Testcontainers
 class KituApplicationTests {
+    @Suppress("unused")
     companion object {
         @JvmStatic
         @Container

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
@@ -20,6 +20,7 @@ import kotlin.test.assertEquals
 @SpringBootTest
 @Testcontainers
 class KoealustaServiceTests {
+    @Suppress("unused")
     companion object {
         @JvmStatic
         @Container

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
@@ -29,13 +29,14 @@ class YkiServiceTests(
     @Autowired private val ykiSuoritusRepository: YkiSuoritusRepository,
     @Autowired private val ykiArvioijaRepository: YkiArvioijaRepository,
 ) {
+    @Suppress("unused")
     companion object {
         @JvmStatic
         @Container
         @ServiceConnection
         val postgres =
             PostgreSQLContainer("postgres:16")
-                .withUrlParam("stringtype", "unspecified")
+                .withUrlParam("stringtype", "unspecified")!!
     }
 
     @BeforeEach

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
@@ -22,13 +22,14 @@ import kotlin.test.assertTrue
 class YkiSuoritusRepositoryTest(
     @Autowired private val ykiSuoritusRepository: YkiSuoritusRepository,
 ) {
+    @Suppress("unused")
     companion object {
         @JvmStatic
         @Container
         @ServiceConnection
         val postgres =
             PostgreSQLContainer("postgres:16")
-                .withUrlParam("stringtype", "unspecified")
+                .withUrlParam("stringtype", "unspecified")!!
     }
 
     @BeforeEach

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -22,3 +22,4 @@ kitu.yki.username=
 kitu.yki.password=
 
 logging.structured.format.console=ecs
+logging.structured.format.file=ecs


### PR DESCRIPTION
~This implementation is based on the Spring Data EntityCallback API. It does not conform to what's described on https://wiki.eduuni.fi/pages/viewpage.action?pageId=480353910.~

Lokitetaan manuaalisesti KoealustaServicessä, koska Springin EntityCallback-API ei toimi jos Repositoryn tallennusmetodi on itse toteutettu eikä Springin autogeneroima.