### PR TITLE
feat(yki): allow saving yki suoritukset if some data has errors

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -1,6 +1,8 @@
 package fi.oph.kitu.csvparsing
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import fi.oph.kitu.logging.add
+import org.slf4j.spi.LoggingEventBuilder
 
 class InvalidFormatCsvExportError(
     lineNumber: Int,
@@ -27,5 +29,21 @@ abstract class CsvExportError(
     init {
         keyValues.add(Pair("lineNumber", lineNumber))
         keyValues.add(Pair("exception", exception))
+    }
+}
+
+class CsvExportException(
+    val errors: Iterable<CsvExportError>,
+    message: String? = "Unable to convert string to csv, because the string had ${errors.count()} error(s).",
+    cause: Throwable? = null,
+) : Throwable(message, cause)
+
+fun LoggingEventBuilder.addErrors(exception: CsvExportException) {
+    // add all errors to log
+    exception.errors.forEachIndexed { i, error ->
+        this.add("serialization.error[$i].index" to i)
+        for (kvp in error.keyValues) {
+            this.add("serialization.error[$i].${kvp.first}" to kvp.second)
+        }
     }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -32,15 +32,9 @@ abstract class CsvExportError(
     }
 }
 
-class CsvExportException(
-    val errors: Iterable<CsvExportError>,
-    message: String? = "Unable to convert string to csv, because the string had ${errors.count()} error(s).",
-    cause: Throwable? = null,
-) : Throwable(message, cause)
-
-fun LoggingEventBuilder.addErrors(exception: CsvExportException) {
+fun LoggingEventBuilder.addErrors(errors: Iterable<CsvExportError>) {
     // add all errors to log
-    exception.errors.forEachIndexed { i, error ->
+    errors.forEachIndexed { i, error ->
         this.add("serialization.error[$i].index" to i)
         for (kvp in error.keyValues) {
             this.add("serialization.error[$i].${kvp.first}" to kvp.second)

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -24,6 +24,7 @@ db-scheduler-ui.log-limit=1000
 kitu.yki.scheduling.enabled=false
 kitu.yki.scheduling.import.schedule=-
 kitu.yki.scheduling.importArvioijat.schedule=-
+kitu.yki.import.suoritukset.ontinue-on-error=true
 kitu.yki.username=${YKI_API_USER}
 kitu.yki.password=${YKI_API_PASSWORD}
 


### PR DESCRIPTION
Halutaanko edes tätä

Pihvi:
* Tallentaa ainoastaan validit rivit tietokantaan.
* Virheelliset rivit lokitetaan
* Jos halutaan tuoda sama data uudestaan, ajatuksena on nukettaa vanha data.
  * Tällöin koodi taas tallentaa ainoastaan validit rivit. 

Olennainen koodi.
`CsvParser.kt / convertCsvToResult.kt`:
```kotlin
fun <T> convertCsvtToResults(csvString: String): Iterable<Result<T>> {
  val csvMapper = getCsvMapper<T>()
  val iterator = csvMapper
      .readerFor(T::class.java)
      .with(getSchema<T>(csvMapper))
      .readValues<T?>(csvString)

  val data = mutableListOf<Result<T>>()
    while (iterator.hasNext()) {
      // iterator.nextValue palauttaa virheen tai heittää virheen.
     // Se wrapataan runCatching avulla Result:ksi.
      data.add(runCatching { iterator.nextValue() })
    }

  return data
}
```

Sen lisäksi on tulosten käsittelyä varten oma virheenkäsittely
```kotlin

// CsvParser.kt 
// Extension metodi Iterable<Result<T>:lle 
// eli samalle tyypille joka generoidaan yllä.
fun <T> Iterable<Result<T>>.foldWithErrors(
    continueOnError: Boolean,
    action: (Iterable<CsvExportError>) -> Unit,
): List<T> {
    // Tallennetaan virheet errors - muuttujaan
    val errors = mutableListOf<CsvExportError>()

    // data lista
    val data = mutableListOf<T>()
    
    // käydään läpi koko iterable.
    this.forEachIndexed { index, result ->
        result

            // Jos Result.failure, 
            // niin lisätän sellaiset rivit listalta errors - listaan
            .onFailure { e ->
                when (e) {
                    is InvalidFormatException -> 
                      errors.add(
                        InvalidFormatCsvExportError(index, e)
                      )
                    else -> 
                      errors.add(SimpleCsvExportError(index, e))
                }
            }

             // Lisätään kaikki onnisuneet rivit data - listaan
            .onSuccess { row -> data.add(row) }

        // Sen jälkeen, jos on virheitä, tehdään virheen käsittely
        if (errors.isNotEmpty()) {
             // custom-toiminto, minkä voi itse määrittää
             // Tätä käytetään siihen,
             // ettei lokitusta tarvitse määrittää tässä metodissa.
             action(errors)
            
            // Heitetään virhe jos continueOnError == false
            // Muussa tapauksessa mennään eteenpäin, 
            // eli palautetaan lopuksi data.
            if (!continueOnError) {
                throw RuntimeException(
                    "Unable to convert string to csv, because " +
                    "the string had ${errors.count()} error(s).",
                )
            }
        }
    }

    return data
}

```

Ja näitä käytetään lopuksi
YkiService.kt´ - sisällä (sekä `importYkiSuoritukset`, että `importYkiArvioijat`), esim:

```kotlin
// YkiService.kt / importYkiSuoritukset
val arvioijat =
  parser
    .convertCsvtToResults<SolkiArvioijaResponse>(
      response.body ?: throw Error.EmptyArvioijatResponse(),
    ).foldWithErrors(importSuorituksetContinueOnError) {
      event.addErrors(it)
    }
```