### PR TITLE
feat(oppijanumero): add more verbous logging when cas error

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
@@ -13,7 +13,7 @@ class KoealustaMappingService(
     private val oppijanumeroService: OppijanumeroService,
 ) {
     fun convertToEntity(suorituksetResponse: KoealustaSuorituksetResponse): List<KielitestiSuoritus> {
-        val exceptions = mutableListOf<Exception>()
+        val exceptions = mutableListOf<Throwable>()
 
         val suoritukset =
             suorituksetResponse.users.flatMap { user ->

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasException.kt
@@ -1,0 +1,25 @@
+package fi.oph.kitu.oppijanumero
+
+import fi.oph.kitu.logging.add
+import org.slf4j.spi.LoggingEventBuilder
+import java.net.http.HttpResponse
+
+class CasException(
+    val response: HttpResponse<String>,
+    message: String,
+) : Throwable(message)
+
+fun Result<String>.getOrLogAndThrowCasException(event: LoggingEventBuilder): String =
+    this
+        .onFailure { cause ->
+            when (cause) {
+                is CasException ->
+                    event.add(
+                        "cas.response.statusCode" to cause.response.statusCode(),
+                        "cas.response.uri" to cause.response.uri(),
+                        "cas.response.headers" to cause.response.headers(),
+                        "cas.response.body" to cause.response.body(),
+                        "cas.exception.message" to cause.message,
+                    )
+            }
+        }.getOrThrow()

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
@@ -54,7 +54,7 @@ class CasService(
         logger.atInfo().addHttpResponse(PeerService.Cas, request.uri().toString(), response).log()
 
         if (response.statusCode() != 200) {
-            throw RuntimeException("Unexpected status code: ${response.statusCode()} and message: ${response.body()}")
+            throw CasException(response, "Ticket service did not respond with 200 status code.")
         }
 
         val ticket = response.body()
@@ -77,10 +77,9 @@ class CasService(
         logger.atInfo().addHttpResponse(PeerService.Cas, request.uri().toString(), response).log()
 
         val statusCode = response.statusCode()
-        val body = response.body()
 
         if (statusCode != 201) {
-            throw RuntimeException("Ticket granting service responded with status code $statusCode and message $body")
+            throw CasException(response, "Ticket granting service did not respond with 201 status code.")
         }
 
         val location = response.headers().firstValue("Location").get()

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/Oppija.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/Oppija.kt
@@ -1,0 +1,21 @@
+package fi.oph.kitu.oppijanumero
+
+class Oppija(
+    val etunimet: String,
+    val hetu: String,
+    val kutsumanimi: String,
+    val sukunimi: String,
+    val oppijanumero: String? = null,
+    val henkilo_oid: String? = null,
+) {
+    fun withYleistunnisteHaeResponse(response: YleistunnisteHaeResponse) =
+        Oppija(etunimet, hetu, kutsumanimi, sukunimi, response.oppijanumero, henkilo_oid = response.oid)
+
+    fun toYleistunnisteHaeRequest() =
+        YleistunnisteHaeRequest(
+            etunimet,
+            hetu,
+            kutsumanimi,
+            sukunimi,
+        )
+}

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroException.kt
@@ -1,0 +1,7 @@
+package fi.oph.kitu.oppijanumero
+
+class OppijanumeroException(
+    val oppija: Oppija,
+    message: String,
+    cause: Throwable? = null,
+) : Throwable(message, cause)

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroLoggingExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroLoggingExtensions.kt
@@ -11,7 +11,6 @@ fun LoggingEventBuilder.addValidationExceptions(
     oppijanumeroExceptions.forEachIndexed { index, ex ->
         this.add(
             "error.oppijanumero[$index].index" to index,
-            "error.oppijanumero[$index].statusCode" to ex.statusCode,
             "error.oppijanumero[$index].oppija.kutsumanimi" to ex.oppija.kutsumanimi,
             "error.oppijanumero[$index].oppija.etunimet" to ex.oppija.etunimet,
             "error.oppijanumero[$index].oppija.sukunimi" to ex.oppija.sukunimi,


### PR DESCRIPTION
Current logs are not verbous enough to provide the reason for failures when there is something wrong is CAS-flow.