### PR TITLE
Security update

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -56,6 +56,22 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -249,6 +249,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Bump commons-compress and logback-core and -classic to fix:

- https://osv.dev/vulnerability/GHSA-4265-ccf5-phj5
- https://osv.dev/vulnerability/GHSA-4g9r-vxhx-9pgx
- https://github.com/advisories/GHSA-6v67-2wr5-gvf4
- https://github.com/advisories/GHSA-6v67-2wr5-gvf4