### PR TITLE
refactor: make CsvParser a @Service version 2

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -29,3 +29,9 @@ abstract class CsvExportError(
         keyValues.add(Pair("exception", exception))
     }
 }
+
+class CsvExportException(
+    val errors: Iterable<CsvExportError>,
+    message: String = "There was ${errors.count()} errors during the conversion.",
+    cause: Throwable? = null,
+) : Throwable(message, cause)

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParserExtension.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParserExtension.kt
@@ -63,3 +63,5 @@ class CsvParserExtensionEvent(
         TODO("Not yet implemented")
     }
 }
+
+fun CsvParser.withEvent(event: LoggingEventBuilder) = this.withExtension(CsvParserExtensionEvent(event))

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParserExtension.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParserExtension.kt
@@ -1,0 +1,65 @@
+package fi.oph.kitu.csvparsing
+
+import fi.oph.kitu.logging.add
+import org.slf4j.spi.LoggingEventBuilder
+
+interface CsvParserExtension {
+    fun onInit(parser: CsvParser)
+
+    fun <T> beforeFunctionCall(
+        parser: CsvParser,
+        input: T,
+        type: Class<*>,
+    )
+
+    fun onErrorFunctionCall(
+        parser: CsvParser,
+        exception: CsvExportException,
+    )
+
+    fun afterFunctionCall(parser: CsvParser)
+}
+
+/** Extension for CsvParser to log events. */
+class CsvParserExtensionEvent(
+    val event: LoggingEventBuilder,
+) : CsvParserExtension {
+    override fun onInit(parser: CsvParser) {
+        event.add(
+            "serialization.schema.args.columnSeparator" to parser.columnSeparator.toString(),
+            "serialization.schema.args.lineSeparator" to parser.lineSeparator,
+            "serialization.schema.args.useHeader" to parser.useHeader,
+            "serialization.schema.args.quoteChar" to parser.quoteChar,
+        )
+    }
+
+    private fun logStringInput(string: String) = event.add("serialization.isEmptyList" to string.isBlank())
+
+    override fun <T> beforeFunctionCall(
+        parser: CsvParser,
+        input: T,
+        type: Class<*>,
+    ) {
+        event.add("serialization.schema.args.type" to type.name)
+        when (input) {
+            is String -> logStringInput(input)
+        }
+    }
+
+    override fun onErrorFunctionCall(
+        parser: CsvParser,
+        exception: CsvExportException,
+    ) {
+        // add all errors to log
+        exception.errors.forEachIndexed { i, error ->
+            event.add("serialization.error[$i].index" to i)
+            for (kvp in error.keyValues) {
+                event.add("serialization.error[$i].${kvp.first}" to kvp.second)
+            }
+        }
+    }
+
+    override fun afterFunctionCall(parser: CsvParser) {
+        TODO("Not yet implemented")
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -12,7 +12,6 @@ import org.ietf.jgss.Oid
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayOutputStream
-import java.lang.RuntimeException
 import java.time.Instant
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -23,7 +22,7 @@ import kotlin.test.assertTrue
 class CsvParsingTest {
     @Test
     fun `test yki suoritukset parsing`() {
-        val parser = CsvParser(MockEvent())
+        val parser = CsvParser()
         val csv =
             """
             "1.2.246.562.24.20281155246","010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
@@ -66,7 +65,7 @@ class CsvParsingTest {
 
     @Test
     fun `test line breaks`() {
-        val parser = CsvParser(MockEvent())
+        val parser = CsvParser()
         val perustelut1 = " - Hyvä kielioppi\n - Selkeä puhuminen\n - Ymmärtää hyvin puhetta\n"
         val perustelut2 = " - Hyvä kielioppi\r\n - Selkeä puhuminen\r\n - Ymmärtää hyvin puhetta\r\n"
         // you can't use trimIndent here, because the string contains CR (\r)
@@ -84,7 +83,7 @@ class CsvParsingTest {
 
     @Test
     fun `test legacy language code 10 parsing`() {
-        val parser = CsvParser(MockEvent())
+        val parser = CsvParser()
         val arvioijaCsv =
             """
             "1.2.246.562.24.24941612410","010180-922U","Torvinen-Testi","Anniina Testi","anniina.testi@yki.fi","Testiosoite 7357","00100","HELSINKI",1994-08-01,2019-06-29,2024-06-29,0,0,"10","PT+KT"
@@ -95,7 +94,7 @@ class CsvParsingTest {
 
     @Test
     fun `test legacy language code 11 parsing`() {
-        val parser = CsvParser(MockEvent())
+        val parser = CsvParser()
         val arvioijaCsv =
             """
             "1.2.246.562.24.24941612410","010180-922U","Torvinen-Testi","Anniina Testi","anniina.testi@yki.fi","Testiosoite 7357","00100","HELSINKI",1994-08-01,2019-06-29,2024-06-29,0,0,"11","PT+KT"
@@ -106,7 +105,7 @@ class CsvParsingTest {
 
     @Test
     fun `test legacy language code 12 parsing`() {
-        val parser = CsvParser(MockEvent())
+        val parser = CsvParser()
         val arvioijaCsv =
             """
             "1.2.246.562.24.24941612410","010180-922U","Torvinen-Testi","Anniina Testi","anniina.testi@yki.fi","Testiosoite 7357","00100","HELSINKI",1994-08-01,2019-06-29,2024-06-29,0,0,"12","PT+KT"
@@ -117,7 +116,7 @@ class CsvParsingTest {
 
     @Test
     fun `test parsing yki suoritus with newlines`() {
-        val parser = CsvParser(MockEvent())
+        val parser = CsvParser()
         val csv =
             """
             "1.2.246.562.24.20281155246","010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,"Tarkistusarvioinnin perustelu\nJossa rivinvaihto",
@@ -161,7 +160,7 @@ class CsvParsingTest {
     @Test
     fun `parsing errors are logged `() {
         val event = MockEvent()
-        val parser = CsvParser(event)
+        val parser = CsvParser().withEvent(event)
         val csv =
             """
             "INVALID_OID","010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
@@ -170,7 +169,7 @@ class CsvParsingTest {
             "1.2.246.562.24.20281155246","010180-9026","N","Öhman-Testi","Ranja Testi","INVALID_NATIONALITY","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
             """.trimIndent()
 
-        assertThrows<RuntimeException> {
+        assertThrows<CsvExportException> {
             parser.convertCsvToData<YkiSuoritusCsv>(csv)
         }
 
@@ -200,7 +199,7 @@ class CsvParsingTest {
     fun `test writing csv`() {
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
-        val parser = CsvParser(MockEvent(), useHeader = true)
+        val parser = CsvParser(useHeader = true)
         val writable =
             listOf(
                 YkiSuoritusCsv(
@@ -251,7 +250,7 @@ class CsvParsingTest {
     fun `null values are written correctly to csv`() {
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
-        val parser = CsvParser(MockEvent(), useHeader = true)
+        val parser = CsvParser(useHeader = true)
         val writable =
             listOf(
                 YkiSuoritusCsv(

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
@@ -1,5 +1,7 @@
 package fi.oph.kitu.yki
 
+import fi.oph.kitu.csvparsing.CsvExportException
+import fi.oph.kitu.csvparsing.CsvParser
 import fi.oph.kitu.yki.arvioijat.YkiArvioijaMappingService
 import fi.oph.kitu.yki.arvioijat.YkiArvioijaRepository
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusMappingService
@@ -19,7 +21,6 @@ import org.springframework.web.client.RestClient
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import java.lang.RuntimeException
 import java.time.OffsetDateTime
 import kotlin.test.assertEquals
 
@@ -71,6 +72,7 @@ class YkiServiceTests(
                 suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
                 arvioijaMapper = YkiArvioijaMappingService(),
+                parser = CsvParser(),
             )
 
         // Act
@@ -105,10 +107,11 @@ class YkiServiceTests(
                 suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
                 arvioijaMapper = YkiArvioijaMappingService(),
+                CsvParser(),
             )
 
         // Act
-        assertThrows<RuntimeException> {
+        assertThrows<CsvExportException> {
             ykiService.importYkiSuoritukset(null, null, false)
         }
         val suoritukset = ykiSuoritusRepository.findAll()
@@ -141,6 +144,7 @@ class YkiServiceTests(
                 suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
                 arvioijaMapper = YkiArvioijaMappingService(),
+                parser = CsvParser(),
             )
 
         // Act
@@ -193,6 +197,7 @@ class YkiServiceTests(
                 suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
                 arvioijaMapper = YkiArvioijaMappingService(),
+                parser = CsvParser(),
             )
 
         assertDoesNotThrow {
@@ -238,6 +243,7 @@ class YkiServiceTests(
                 suoritusMapper = YkiSuoritusMappingService(),
                 arvioijaRepository = ykiArvioijaRepository,
                 arvioijaMapper = YkiArvioijaMappingService(),
+                parser = CsvParser(),
             )
 
         assertDoesNotThrow {


### PR DESCRIPTION
Pullarissa #645 Halutiin CsvParser - luokasta injectable, eli otetaan event pois.

Keksin ongelmaan kaksi erilaista ratkaisua:
 1. https://github.com/Opetushallitus/koto-rekisteri/pull/662
   * CsvParserin luokista on otettu genericsit pois ja sen sijaan typpi annetaan parametrina `type: KClass<*>`.
   * Eventtiä varten on on tehty uusi luokka `CsvParserWithEvent`, joka perii injektoidun `CsvParser`:in. Sen saa generoitua kutsumalla `parser.withEvent(event)`
   * Minusta tässä on huonoa, että genericseja ei voida enää käyttää
   * Hyvä puoli on, etttä event ei ole enää millään tavalla liitetty CsvParseriin
   
   
   2. Tämä pullari:
   * Poistettu `CsvParser`:sta, ja lisätty CsvParseriin uusi `val extensions: List<CsvParserExtension>`
   * Uusi interface
   ```kotlin
   
interface CsvParserExtension {
    fun onInit(parser: CsvParser)

    fun <T> beforeFunctionCall(
        parser: CsvParser,
        input: T,
        type: Class<*>,
    )

    fun onErrorFunctionCall(
        parser: CsvParser,
        exception: CsvExportException,
    )

    fun afterFunctionCall(parser: CsvParser)
}
   ``` 
   * Niissä kohdissa, missä on ennen ollut eventin generoimat lokitukset, on nyt kutsu extensioneille jossa ajetaan kaikki CsvParseriin lisätyt extensionit. 
   * parser on samalla tavalla injektoitu kuin versiossa 1, uusi event-pohjainen luokka saadaan samalla tavalla, eli `parser.withEvent(event)` - kutsulla, joka on wrapperi `parser.withExtension(CsvParserExtensionEvent())`:lle
   
Notes:
Kummassakin on yhtenäistä:
 * CsvParser on @Service
 * kutsumalla ajon aikana `withEvent` - metodia, palautetaan uusi csv-parseri joka sisältää  event eli lokitus-asiat.
  * Se luo siis silloin uuden instanssin käytettäväksi
  * Molemmissa toteutuksissa ajatus on, että CsvParseria voi laajentaa jatkossa niin paljon kuin haluaa, ilman että tarvitseee muokata alkuperäistä `CsvParser` - luokkaa.