### PR TITLE
fix(kotoutumiskoulutus): school oid not null

### DIFF
--- a/server/src/main/resources/db/migration/V22__schooloid_not_null.sql
+++ b/server/src/main/resources/db/migration/V22__schooloid_not_null.sql
@@ -1,0 +1,8 @@
+
+UPDATE koto_suoritus
+    SET school_oid = ''
+    WHERE school_oid IS NULL;
+
+ALTER TABLE koto_suoritus
+    ALTER COLUMN school_oid
+    SET NOT NULL;


### PR DESCRIPTION
Korjaa bugin, kun kälissä avaa Koto -> Suoritukset ja jos school OID on null. 
 - Korjattu lisäämällä tietokantaan tyhjät arvot ja lisäämällä NOT NULL constraint
 - Tässä tapauksessa tämän pitäisi riittää, kun arvoa ei käytetä käyttöliittymässä.
 - Importterin koodissa [schoolOID on jo not null](https://github.com/Opetushallitus/koto-rekisteri/pull/602/files#diff-faff4682eefe6ff89de50f424a06ff8cb86090afe0c24e1ee9b49b54e87e5a01R17), joten nulleja (tai edes tyhjiä arvoja) ei pitäisi olla

TODO
- [x] Pitäisikö schoolOID - kentälle tehdä OID - validointi (eli käyttää OID - tyyppiä?)
    - Kyllä, mutta ei tässä pullarissa 