### PR TITLE
Validate received school (organization) OIDs

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/Oid.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/Oid.kt
@@ -1,0 +1,18 @@
+package fi.oph.kitu
+
+import org.ietf.jgss.GSSException
+
+data class Oid(
+    private val value: org.ietf.jgss.Oid,
+) {
+    companion object {
+        fun valueOf(source: String): Oid? =
+            try {
+                Oid(org.ietf.jgss.Oid(source))
+            } catch (_: GSSException) {
+                null
+            }
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/server/src/main/kotlin/fi/oph/kitu/jdbc/JdbcCustomConfiguration.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/jdbc/JdbcCustomConfiguration.kt
@@ -1,0 +1,13 @@
+package fi.oph.kitu.jdbc
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration
+
+@Configuration
+class JdbcCustomConfiguration : AbstractJdbcConfiguration() {
+    override fun userConverters(): MutableList<*> =
+        mutableListOf(
+            StringToOidConverter(),
+            OidToStringConverter(),
+        )
+}

--- a/server/src/main/kotlin/fi/oph/kitu/jdbc/OidToStringConverter.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/jdbc/OidToStringConverter.kt
@@ -1,0 +1,10 @@
+package fi.oph.kitu.jdbc
+
+import fi.oph.kitu.Oid
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.WritingConverter
+
+@WritingConverter
+class OidToStringConverter : Converter<Oid, String> {
+    override fun convert(source: Oid): String = source.toString()
+}

--- a/server/src/main/kotlin/fi/oph/kitu/jdbc/StringToOidConverter.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/jdbc/StringToOidConverter.kt
@@ -1,0 +1,10 @@
+package fi.oph.kitu.jdbc
+
+import fi.oph.kitu.Oid
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.ReadingConverter
+
+@ReadingConverter
+class StringToOidConverter : Converter<String, Oid> {
+    override fun convert(source: String): Oid? = Oid.valueOf(source)
+}

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritus.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritus.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.kotoutumiskoulutus
 
+import fi.oph.kitu.Oid
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
@@ -14,7 +15,7 @@ data class KielitestiSuoritus(
     val oppijanumero: String,
     val email: String,
     val timeCompleted: Instant,
-    val schoolOid: String,
+    val schoolOid: Oid,
     val courseid: Int,
     val coursename: String,
     val luetunYmmartaminenResultSystem: String,

--- a/server/src/main/resources/db/migration/V23__add_oid_type.sql
+++ b/server/src/main/resources/db/migration/V23__add_oid_type.sql
@@ -1,0 +1,11 @@
+-- Domain for ITU and ISO/IEC standard OIDs
+CREATE DOMAIN iso_oid AS TEXT
+    CHECK (
+        -- Require format with one or more non-empty numeric strings, separated by periods.
+        -- No other characters allowed.
+        regexp_like(value, '^(?:\d+\.)*\d+$')
+    );
+
+-- Domain aliases to differentiate between Organization and Person OIDs
+CREATE DOMAIN organisaatio_oid AS iso_oid;
+CREATE DOMAIN henkilo_oid AS iso_oid;

--- a/server/src/main/resources/db/migration/V24__alter_school_oid_to_use_organisaatio_oid_type.sql
+++ b/server/src/main/resources/db/migration/V24__alter_school_oid_to_use_organisaatio_oid_type.sql
@@ -1,0 +1,8 @@
+ALTER TABLE koto_suoritus
+    ALTER COLUMN school_oid SET DATA TYPE organisaatio_oid USING
+        CASE
+            -- Use a placeholder value instead of an empty value
+            WHEN school_oid = '' THEN '1.2.246.562.10.1234567890'::organisaatio_oid
+            -- In common cases, just cast to the new type
+            ELSE school_oid::organisaatio_oid
+        END;

--- a/server/src/test/kotlin/fi/oph/kitu/DBIsoOidTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/DBIsoOidTest.kt
@@ -1,0 +1,103 @@
+package fi.oph.kitu
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.jdbc.core.JdbcTemplate
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+@SpringBootTest
+@Testcontainers
+class DBIsoOidTest(
+    @Autowired private val jdbcTemplate: JdbcTemplate,
+) {
+    @Suppress("unused")
+    companion object {
+        @JvmStatic
+        @Container
+        @ServiceConnection
+        val postgres = PostgreSQLContainer("postgres:16")
+    }
+
+    @BeforeEach
+    fun nukeDb() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS oid_test")
+        jdbcTemplate.execute(
+            """
+            |CREATE TABLE oid_test (
+            |    raw iso_oid NOT NULL,
+            |    henkilo henkilo_oid NOT NULL,
+            |    organisaatio organisaatio_oid NOT NULL
+            |)
+            """.trimMargin(),
+        )
+    }
+
+    private fun insert(oid: String) {
+        jdbcTemplate.execute(
+            """
+                |INSERT INTO oid_test (raw, henkilo, organisaatio) VALUES (
+                |    '$oid',
+                |    '$oid',
+                |    '$oid'
+                |)
+            """.trimMargin(),
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = ["", ".", "oid", "o.i.d", "1.", "1..2", "1.2..3.4", "a.b.c.d.e.f.g.h", "1.2.246.562.10.1234567890."],
+    )
+    fun `inserting a malformed OID fails`(malformed: String) {
+        assertThrows<DataIntegrityViolationException> {
+            insert(malformed)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = ["1.2.246.562.10.1234567890", "1", "1.2", "1.2.3.4.5.6.7.8.0"],
+    )
+    fun `inserting a valid OID succeeds`(valid: String) {
+        assertDoesNotThrow {
+            insert(valid)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = ["1.2.246.562.10.1234567890", "1", "1.2", "1.2.3.4.5.6.7.8.0"],
+    )
+    fun `inserted OIDs can be successfully read`(oid: String) {
+        insert(oid)
+
+        val results =
+            jdbcTemplate.query("SELECT * FROM oid_test") { rs, _ ->
+                TestRow(
+                    rs.getString("raw"),
+                    rs.getString("henkilo"),
+                    rs.getString("organisaatio"),
+                )
+            }
+
+        assertContentEquals(listOf(TestRow(oid, oid, oid)), results)
+        assertEquals(1, results.size)
+    }
+
+    data class TestRow(
+        val raw: String,
+        val henkilo: String = raw,
+        val organisaatio: String = raw,
+    )
+}

--- a/server/src/test/kotlin/fi/oph/kitu/OidTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/OidTest.kt
@@ -1,0 +1,33 @@
+package fi.oph.kitu
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class OidTest {
+    private val validOidString = "1.2.246.562.10.1234567890"
+    private val nonValidOidString = "definitely.not.a.valid.oid.string"
+
+    @Test
+    fun `parsing correctly formatted string as OID succeeds`() {
+        assertNotNull(Oid.valueOf(validOidString))
+    }
+
+    @Test
+    fun `parsing incorrectly formatted string as OID returns NULL`() {
+        assertNull(Oid.valueOf(nonValidOidString))
+    }
+
+    @Test
+    fun `converting OID to string yields a correctly formatted OID string`() {
+        assertEquals(validOidString, Oid.valueOf(validOidString).toString())
+    }
+
+    @Test
+    fun `implicit toString yields a correctly formatted OID string`() {
+        val oid = Oid.valueOf(validOidString)
+        val string = "$oid"
+        assertEquals(validOidString, string)
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
@@ -1,6 +1,7 @@
 package fi.oph.kitu.kotoutumiskoulutus
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import fi.oph.kitu.Oid
 import fi.oph.kitu.oppijanumero.OppijanumeroServiceMock
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -57,7 +58,7 @@ class KoealustaServiceTests {
                             {
                               "courseid": 32,
                               "coursename": "Integraatio testaus",
-                              "schoolOID": "",
+                              "schoolOID": "1.2.246.562.10.1234567890",
                               "results": [
                                 {
                                   "name": "luetun ymm\u00e4rt\u00e4minen",
@@ -124,6 +125,10 @@ class KoealustaServiceTests {
         assertEquals(
             expected = "Integraatio testaus",
             actual = mervi.coursename,
+        )
+        assertEquals(
+            expected = Oid.valueOf("1.2.246.562.10.1234567890"),
+            actual = mervi.schoolOid,
         )
     }
 }


### PR DESCRIPTION
Lisää tuen OID:en validoinnille sekä tietokannan, että sovelluksen tasolla ja toteuttaa näitä käyttäen validaation koealustan suoritusten tuonnin `schooldOID`-kentälle.

Tietokannan tasolla validaatio on toteutettu `DOMAIN`-tyypillä `iso_oid`, jonka `CHECK` suorittaa yksinkertaisen naiivin Regex-pohjaisen tarkistuksen. Tälle domainille on kaksi aliasta, `henkilo_oid` ja `organisaatio_oid`, jotta eri "tyyppiset" OID:t on helpompi eriyttää toisistaan. Näin `school_oid`:lle voidaan antaa tyypiksi `organisaatio_oid` ja esim. oppijanumeroille tmv voidaan myöhemmässä PR:ssa päivittää tyypiksi `henkilo_oid`.

Sovellustason validaatiota varten on toteutettu `Oid`-dataluokka. Tämän alustava toteutus on yksinkertainen "fasadi" (facade) suhteellisen satunnaisesti valikoituneeseen riippuvuuksien kautta saatavilla olevaan `org.ietf.jgss.Oid`-luokan ympärille. Päädyin tähän toteutustapaan, koska standardimuotoisen OID:n parsiminen vaikutti työläältä, mutta suora riippuvuus jonkin kirjaston tarjoamaan OID-tyyppiin on herkästi ylläpidon kannalta painajainen pitkällä aikavälillä. Fasadi enkapsuloi kirjastoriippuvuuden yhteen luokkaan, suurilta osin poistaen ylläpidolliset huolenaiheet.

Sekä tietokantaan luodun `iso_oid`-tyypin validaatiotarkistukselle, sekä `Oid`-dataluokan parsinnalle on toteutettu muutama yksikkötesti, joten asiat ovat jo melko toimivalla tolalla näiden osalta. Myös koealustan suoritustietojen tuontia on kokeiltu paikallisesti, mutta tämä ei etene tietokantaan tallennukseen asti, testiympäristön datassa olevien validaatiovirheiden vuoksi. Mutta ainakin validaation virhetapaukset on näin voitu todentaa toimiviksi.

Jälkimmäinen puolisko itse pihvistä on saada myös `CrudRepository`-pohjaiset repositorioluokat ymmärtämään miten `data class Oid` muunnetaan sellaiseen muotoon, että tietokanta hyväksyy sen `iso_oid`:ksi (ja sama toiseen suuntaan). Tätä varten on toteutettuna `Converter<Oid, String>` ja `Converter<String, Oid>`. Nopealla testailulla vaikuttaisi, että converter luokkien toteutus ja rekisteröinti `AbstractJdbcConfiguration`:lla riittää ja generoitu `.saveAll` osaa nyt hanskata muunnokset oikein.