### PR TITLE
fix: don't log audit logs to console

### DIFF
--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -15,7 +15,7 @@
         </rollingPolicy>
     </appender>
 
-    <logger name="auditLogger" level="INFO" additivity="true">
+    <logger name="auditLogger" level="INFO" additivity="false">
         <appender-ref ref="AUDIT_LOCAL"/>
     </logger>
 
@@ -32,7 +32,7 @@
             <logGroupName>${AUDIT_LOG_LOG_GROUP_NAME:-}</logGroupName>
         </appender>
 
-        <logger name="auditLogger" level="INFO" additivity="true">
+        <logger name="auditLogger" level="INFO" additivity="false">
             <appender-ref ref="AUDIT_CLOUDWATCH"/>
         </logger>
     </springProfile>


### PR DESCRIPTION
Puuttuu vielä automaattitestit tälle, mutta testasin lokaalisti manuaalisesti että `auditLogger`-lokeja ei tule enää konsoliin.

Ks. https://logback.qos.ch/manual/configuration.html#overridingCumulativity