### PR TITLE
[ci skip] ignore .mise.local.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ build/
 # For Prettier specifically
 cdk.out/
 .next/
+
+### Mise ###
+.mise.local.toml


### PR DESCRIPTION
Main is protected so can't push this there directly.

Having local overrides is a bit of an oxymoron for why Mise exists in the first place. However, asdf-awscli build has been broken on Arch for a while now, and I just cannot be bothered to fix it. Local overrides allow me to default to pre-built binaries, so that's an easy way out.

There are some hard-to-debug issues with the aws-cli build script, possibly related to Python version, but these didn't go away with any usual quick fixes I attempted. When enforcing python version via Mise didn't seem to affect the build script python version either, I threw in the towel and just decided to live with it.

Easiest way out is just to use pre-built binaries on Arch, which is easily done by enforcing the non-"ref:" version via a mise.local.toml. This requires me to manually update my local .mise.local.toml every time awscli updates, but that's arguably better than a broken Mise config from which I need to manually drop the "ref:" prefix and be careful to not commit the change.