### PR TITLE
chore(deps): update netty to 4.1.118.Final

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -111,6 +111,11 @@
             <artifactId>cloudwatchlogs</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.118.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mustache</artifactId>
         </dependency>


### PR DESCRIPTION
Fixes GHSA-4g8c-wm8x-jfhw, CVE-2025-24970