### PR TITLE
chore(deps): automerge all minor version updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,17 +2,6 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
-    {
-      "matchFileNames": ["**/pom.xml"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
-    {
-      "matchFileNames": [".mise.toml"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }


### PR DESCRIPTION
We used to automatically merge only certain update types. We haven't seen any problems with it, so let's just auto merge all minor and patch updates, regardless of the dependency type.

Example updates this would auto merge: #790 #789 