### PR TITLE
feat: enable container insights in production

### DIFF
--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -88,6 +88,7 @@ export class EnvironmentStage extends Stage {
       databaseName: environmentConfig.databaseName,
       image: props.serviceImage,
       alarmSnsTopic: alarmsStack.alarmSnsTopic,
+      productionQuality: environmentConfig.productionQuality,
     })
 
     new Route53HealthChecksStack(this, "Route53HealthChecks", {


### PR DESCRIPTION
Tämä luo uuden klusterin ja mahdollisesti jättää vanhan roikkumaan, mikä voi johtaa erikoisiin tilanteisiin. Tämä ois hyvä testata erikseen devillä ennen mergeämistä. Tällä hetkellä PR:stä ei voi deployaa ympäristöihin (ja mainin deploy myös yliajaisi ne melko nopeasti) ja meillä ei ole väliaikaisia PR-ympäristöjä. Voisimme periaatteessa luoda väliaikaisia ympäristöjä devitilille jos vaan hoidetaan niiden siivous oikein.

[AWS Container Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html)