### PR TITLE
feat(scripts): run otel collector when starting tmux sess

### DIFF
--- a/scripts/start_otel_collector.sh
+++ b/scripts/start_otel_collector.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker run --rm -v "$REPO_ROOT/otel-config.yml":/otel-local-config.yml \
+  -p 4318:4318 -p 55681:55681 \
+  otel/opentelemetry-collector:latest \
+  --config /otel-local-config.yml
+  

--- a/scripts/start_otel_collector.sh
+++ b/scripts/start_otel_collector.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-docker run --rm -v "$REPO_ROOT/otel-config.yml":/otel-local-config.yml \
-  -p 4318:4318 -p 55681:55681 \
-  otel/opentelemetry-collector:latest \
-  --config /otel-local-config.yml
-  

--- a/scripts/start_tmux.sh
+++ b/scripts/start_tmux.sh
@@ -31,21 +31,26 @@ tmux rename-window -t $SESS_NAME:0 "$WINDOW"
 tmux send-keys -t $SESS_NAME:"$WINDOW.0" "$REPO_ROOT/scripts/start_database_docker.sh" C-m
 
 # Window 1: OpenTelemetry collector
-WINDOW="otel-exporter"
+WINDOW="otel-collector"
 tmux new-window -t $SESS_NAME -n "$WINDOW"
-tmux send-keys -t $SESS_NAME:"$WINDOW" "$REPO_ROOT/scripts/start_otel_collector.sh" C-m
+tmux send-keys -t $SESS_NAME:"$WINDOW" "docker compose up collector" C-m
 
-# Window 2:idea
+# Window 2: OpenTelemetry collector
+WINDOW="otel-tracing"
+tmux new-window -t $SESS_NAME -n "$WINDOW"
+tmux send-keys -t $SESS_NAME:"$WINDOW" "docker compose up jaeger"
+
+# Window 3:idea
 WINDOW="idea"
 tmux new-window -t $SESS_NAME -n "idea"
 tmux send-keys -t $SESS_NAME:"idea" "idea $REPO_ROOT" C-m
 
-# Window 3:springboot
+# Window 4:springboot
 WINDOW="springboot"
 tmux new-window -t $SESS_NAME -n "$WINDOW"
 tmux send-keys -t $SESS_NAME:"$WINDOW" "$REPO_ROOT/scripts/start_local_server.sh" C-m
 
-# Window 4:workspace
+# Window 5:workspace
 WINDOW="workspace"
 tmux new-window -t $SESS_NAME -n "$WINDOW"
 tmux send-keys -t $SESS_NAME:"$WINDOW" "cd $REPO_ROOT" C-m

--- a/scripts/start_tmux.sh
+++ b/scripts/start_tmux.sh
@@ -30,24 +30,29 @@ WINDOW="database"
 tmux rename-window -t $SESS_NAME:0 "$WINDOW"
 tmux send-keys -t $SESS_NAME:"$WINDOW.0" "$REPO_ROOT/scripts/start_database_docker.sh" C-m
 
-# Window 1:idea
+# Window 1: OpenTelemetry collector
+WINDOW="otel-exporter"
+tmux new-window -t $SESS_NAME -n "$WINDOW"
+tmux send-keys -t $SESS_NAME:"$WINDOW" "$REPO_ROOT/scripts/start_otel_collector.sh" C-m
+
+# Window 2:idea
 WINDOW="idea"
 tmux new-window -t $SESS_NAME -n "idea"
 tmux send-keys -t $SESS_NAME:"idea" "idea $REPO_ROOT" C-m
 
-# Window 2:springboot
+# Window 3:springboot
 WINDOW="springboot"
 tmux new-window -t $SESS_NAME -n "$WINDOW"
 tmux send-keys -t $SESS_NAME:"$WINDOW" "$REPO_ROOT/scripts/start_local_server.sh" C-m
 
-# Window 3:workspace
+# Window 4:workspace
 WINDOW="workspace"
 tmux new-window -t $SESS_NAME -n "$WINDOW"
 tmux send-keys -t $SESS_NAME:"$WINDOW" "cd $REPO_ROOT" C-m
 tmux send-keys -t $SESS_NAME:"$WINDOW" "git log --decorate=full --graph --all --oneline" C-m
 tmux split-window -h -t "${SESSION-}":"$WINDOW"
 tmux send-keys -t $SESS_NAME:"$WINDOW.1" "cd $REPO_ROOT" C-m
-tmux send-keys -t $SESS_NAME:"$WINDOW.1" "ls -la" C-m
+tmux send-keys -t $SESS_NAME:"$WINDOW.1" "git diff --color | cat" C-m
 tmux send-keys -t $SESS_NAME:"$WINDOW.1" "git status" C-m
 
 tmux attach

--- a/scripts/stop_tmux.sh
+++ b/scripts/stop_tmux.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Check if the script is running inside a tmux session
+if [[ -z "$TMUX" ]]; then
+  echo "Script not running inside a tmux session" >&2
+  exit 1
+fi
+
+# Iterate over current session windows and panes
+tmux list-windows -F '#{window_index}' | while read -r window; do
+  tmux list-panes -t "$window" -F '#{pane_index}' | while read -r pane; do
+    tmux send-keys -t "$window.$pane" C-c
+  done
+done
+
+echo "Waiting 5 seconds before killing the session"
+sleep 5
+
+tmux kill-session


### PR DESCRIPTION
OpenTelemetry collectorille käynnistysskripti, joka ajetaan tmuxin käynnistyksen yhteydessä dockerissa

Lisätty myös skripti tmuxin pysäyttämiseen `gracefully`:sti. Tätä varten mulla on alias `.zshrc`:ssä. Toi on tarkoituksella nimetty eri tavalla kotorekisteri-start-tmux, jotta autocompletion ei matchais stop-komentoon samalla kirjain-alulla.

```shell
 alias stop-kotorekisteri-tmux="$KOTO_REKISTERI/scripts/stop_tmux.sh"
```

