### PR TITLE
feat(.github): add gitleaks to scan leaking secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,16 @@ jobs:
       - name: Check formatting
         run: ./scripts/check-formatting.sh
 
+  leaks:
+    name: Run gitleaks
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
+
   build_image:
     name: Build image
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Ehdotus: Pitäisikö tälläinen ottaa käyttöön? Eli github actioneissa tehtäis skannaus, onko repoon livahtanut salaisuuksia

Salaisuuksien skannaus tehdään `gitleaks` - avulla:
https://github.com/gitleaks/gitleaks

Vaihtoehtoisesti tuon voi leipoa myös git-hookkiin https://pre-commit.com/#install - avulla.


Update:
Tämä voisi olla vielä parempi työkalu salaisuuksien skannailuun
https://github.com/trufflesecurity/trufflehog


Lisäksi, ChatGPT:n mielipiteitä eri vastaavista työkaluista
![image](https://github.com/user-attachments/assets/d2a51942-5771-43f8-804f-48bef391be3f)
![image](https://github.com/user-attachments/assets/c8874ae9-f808-4ddc-9ae4-96366a2c1f09)
