### PR TITLE
chore(deps): update otel semconv to 1.30.0

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -32,7 +32,7 @@
         <flyway.version>11.3.1</flyway.version>
         <springdoc.version>2.8.3</springdoc.version>
         <jackson.version>2.18.2</jackson.version>
-        <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
+        <opentelemetry-semconv.version>1.30.0-rc.1</opentelemetry-semconv.version>
         <opentelemetry.instrumentation.version>2.12.0</opentelemetry.instrumentation.version>
     </properties>
     <dependencyManagement>
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv-incubating</artifactId>
-            <version>${opentelemetry-semconv.version}</version>
+            <version>1.30.0-alpha-rc.1</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>


### PR DESCRIPTION
Erikoisesti incubating-paketin versio on erilaisessa muodossa, joten ei voida käyttää samaa propertyä enää.