### PR TITLE
fix: enable RDS performance insights on writer instance

### DIFF
--- a/infra/lib/db-stack.ts
+++ b/infra/lib/db-stack.ts
@@ -19,7 +19,9 @@ export class DbStack extends cdk.Stack {
         version: aws_rds.AuroraPostgresEngineVersion.VER_16_4,
       }),
       vpc: props.vpc,
-      writer: aws_rds.ClusterInstance.serverlessV2("writer"),
+      writer: aws_rds.ClusterInstance.serverlessV2("writer", {
+        enablePerformanceInsights: props.productionQuality,
+      }),
       storageEncrypted: true,
       defaultDatabaseName: props.databaseName,
       enableDataApi: true,

--- a/infra/lib/db-stack.ts
+++ b/infra/lib/db-stack.ts
@@ -26,7 +26,12 @@ export class DbStack extends cdk.Stack {
       defaultDatabaseName: props.databaseName,
       enableDataApi: true,
       ...(props.productionQuality && {
-        readers: [aws_rds.ClusterInstance.serverlessV2("reader")],
+        readers: [
+          aws_rds.ClusterInstance.serverlessV2("reader", {
+            enablePerformanceInsights: props.productionQuality,
+            scaleWithWriter: true,
+          }),
+        ],
         deletionProtection: true,
         enablePerformanceInsights: true,
       }),


### PR DESCRIPTION
This should silence this warning: `[Warning at /Prod/Database/DbStack] Performance Insights is enabled on cluster 'DbStack' at cluster level, but disabled for instance 'writer'. However, Performance Insights for this instance will also be automatically enabled if enabled at cluster level. [ack: @aws-cdk/aws-rds:instancePerformanceInsightsOverridden]`