### PR TITLE
Use binary release of awscli

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,9 +3,6 @@ SPRING_PROFILES_ACTIVE = 'local'
 KOTLIN_POST_PROCESS_FILE = "ktlint -F"
 AWS_PROFILE = "oph-ktr-dev"
 
-[alias]
-awscli = "asdf:MetricMike/asdf-awscli"
-
 [tools]
 node = "22.14.0"
 "npm:prettier" = "3.3.3"


### PR DESCRIPTION
Ongelmat:

- awscli päivittyy päivittäin, mikä on paljon churnia lokaaliympäristössä
- käännämme itse awsclin (`ref`-määre versionumerossa) koska binääriversiosta on vain x86-64-julkaisu, ja puristeina emme ole halunneet käyttää Rosetta-x86-emulaatiota mäkeillä

Ratkaisu:

Ajateltiin ensin siirtää `awscli`-riippuvuus kokonaan pois juuresta ja `infra`-hakemiston alle, mutta tajusin että kehitysympäristön skriptit käyttävät sitä. Jotta elämä olisi vähän helpompaa kuitenkin, palataan tässä PR:ssä käyttämään esikäännettyä x86-64-versiota awsclistä. 