### PR TITLE
Remove unused renovate rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,18 +9,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["\\.mise\\.toml$"],
-      "matchStrings": [
-        "(?<depName>[a-zA-Z0-9_-]+)\\s*=\\s*\"ref:(?<currentValue>.*?)\""
-      ],
-      "depNameTemplate": "{{depName}}",
-      "versioningTemplate": "semver",
-      "datasourceTemplate": "github-tags",
-      "packageNameTemplate": "aws/aws-cli",
-      "autoReplaceStringTemplate": "{{depName}} = \"ref:{{newVersion}}\""
-    },
-    {
-      "customType": "regex",
       "fileMatch": ["\\.ts$"],
       "matchStrings": [
         "renovate: datasource=(?<datasource>.+?)\\s+\"(?<depName>\\S+):(?<currentValue>\\S+)\""


### PR DESCRIPTION
We don't need this as we don't build awscli from source anymore.