### PR TITLE
feat(yki): safer error handling table

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -4,28 +4,34 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException
 
 class InvalidFormatCsvExportError(
     lineNumber: Int,
+    context: String?,
     exception: InvalidFormatException,
-) : CsvExportError(lineNumber, exception) {
+) : CsvExportError(lineNumber, context, exception) {
     init {
-        keyValues.add(Pair("value", exception.value))
-        keyValues.add(Pair("path", exception.path))
-        keyValues.add(Pair("targetType", exception.targetType))
+        keyValues.addAll(
+            listOf(
+                "value" to exception.value,
+                "path" to exception.path,
+                "targetType" to exception.targetType,
+            ),
+        )
     }
 }
 
 class SimpleCsvExportError(
     lineNumber: Int,
+    context: String?,
     exception: Throwable,
-) : CsvExportError(lineNumber, exception)
+) : CsvExportError(lineNumber, context, exception)
 
 abstract class CsvExportError(
     lineNumber: Int,
+    val context: String?,
     exception: Throwable,
 ) {
-    val keyValues = mutableListOf<Pair<String, Any>>()
-
-    init {
-        keyValues.add(Pair("lineNumber", lineNumber))
-        keyValues.add(Pair("exception", exception))
-    }
+    val keyValues =
+        mutableListOf<Pair<String, Any>>(
+            "lineNumber" to lineNumber,
+            "exception" to exception,
+        )
 }

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -27,7 +27,7 @@ class SimpleCsvExportError(
 abstract class CsvExportError(
     lineNumber: Int,
     val context: String?,
-    exception: Throwable,
+    val exception: Throwable,
 ) {
     val keyValues =
         mutableListOf<Pair<String, Any>>(

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
@@ -81,12 +81,12 @@ class CsvParser(
     }
 
     /**
-     * Converts retrieved String response into a list that is the type of Body.
+     * Tries to convert retrieved String response into a list that is the type of Body.
      */
-    inline fun <reified T> convertCsvToData(csvString: String): List<T> {
+    inline fun <reified T> tryConvertCsvToData(csvString: String): Result<List<T>> {
         if (csvString.isBlank()) {
             event.add("serialization.isEmptyList" to true)
-            return emptyList()
+            return Result.success(emptyList())
         }
 
         event.add("serialization.isEmptyList" to false)
@@ -112,7 +112,7 @@ class CsvParser(
             }
 
         if (errors.isEmpty()) {
-            return data
+            return Result.success(data)
         }
 
         // add all errors to log
@@ -123,8 +123,15 @@ class CsvParser(
             }
         }
 
-        throw RuntimeException("Unable to convert string to csv, because the string had ${errors.count()} error(s).")
+        return Result.failure(
+            RuntimeException("Unable to convert string to csv, because the string had ${errors.count()} error(s)."),
+        )
     }
+
+    /**
+     * Converts retrieved String response into a list that is the type of Body.
+     */
+    inline fun <reified T> convertCsvToData(csvString: String): List<T> = tryConvertCsvToData<T>(csvString).getOrThrow()
 }
 
 fun <T> MappingIterator<T>.toDataWithErrorHandling(

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -70,9 +70,7 @@ class YkiService(
                 event.addHttpResponse(PeerService.Solki, "suoritukset", response)
 
                 val (suoritukset, errors) = parser.safeConvertCsvToData<YkiSuoritusCsv>(response.body ?: "")
-                if (errors.isNotEmpty()) {
-                    suoritusErrorService.saveErrors(errors)
-                }
+                suoritusErrorService.handleErrors(event, errors)
 
                 event.add("yki.suoritukset.receivedCount" to suoritukset.size)
 

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorEntity.kt
@@ -1,0 +1,16 @@
+package fi.oph.kitu.yki.suoritukset.error
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table(name = "yki_suoritus_error")
+data class YkiSuoritusErrorEntity(
+    @Id
+    val id: Int?,
+    val message: String,
+    val context: String,
+    val exceptionMessage: String,
+    val stackTrace: String,
+    val created: Instant,
+)

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
@@ -1,0 +1,25 @@
+package fi.oph.kitu.yki.suoritukset.error
+
+import fi.oph.kitu.csvparsing.CsvExportError
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class YkiSuoritusErrorMappingService {
+    fun convertToEntityIterable(
+        iterable: Iterable<CsvExportError>,
+        created: Instant = Instant.now(),
+    ) = iterable.map { convertToEntity(it, created) }
+
+    fun convertToEntity(
+        data: CsvExportError,
+        created: Instant = Instant.now(),
+    ) = YkiSuoritusErrorEntity(
+        id = null,
+        message = data::class.simpleName!!,
+        context = data.context!!,
+        exceptionMessage = data.exception.message!!,
+        stackTrace = data.exception.stackTrace!!.toString(),
+        created = created,
+    )
+}

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorRepository.kt
@@ -1,0 +1,7 @@
+package fi.oph.kitu.yki.suoritukset.error
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface YkiSuoritusErrorRepository : CrudRepository<YkiSuoritusErrorEntity, Long>

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorService.kt
@@ -1,0 +1,19 @@
+package fi.oph.kitu.yki.suoritukset.error
+
+import fi.oph.kitu.csvparsing.CsvExportError
+import org.springframework.stereotype.Service
+
+@Service
+class YkiSuoritusErrorService(
+    private val mappingService: YkiSuoritusErrorMappingService,
+    private val repository: YkiSuoritusErrorRepository,
+) {
+    /**
+     * Save errors. Returns list of errors that were saved.
+     */
+    fun saveErrors(errors: List<CsvExportError>): Iterable<YkiSuoritusErrorEntity> {
+        val entities = mappingService.convertToEntityIterable(errors)
+        val savedEntities = repository.saveAll(entities)
+        return savedEntities
+    }
+}

--- a/server/src/main/resources/db/migration/V26__create_yki_suoritus_error_table.sql
+++ b/server/src/main/resources/db/migration/V26__create_yki_suoritus_error_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE yki_suoritus_error
+(
+    id                  SERIAL PRIMARY KEY,
+    message             TEXT        NOT NULL,
+    context             TEXT        NOT NULL,
+    exception_message   TEXT        NULL,
+    stack_trace         TEXT        NULL,
+    created             TIMESTAMP   NOT NULL
+);

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -197,6 +197,24 @@ class CsvParsingTest {
     }
 
     @Test
+    fun `safe parsing returns valid throws`() {
+        val event = MockEvent()
+        val parser = CsvParser(event)
+        val csv =
+            """
+            "1.2.246.562.24.20281155246","010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
+            "1.2.246.562.24.20281155246","INVALID_HETU","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
+            "1.2.246.562.24.20281155246","010180-9026","INVALID_SEX","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
+            "1.2.246.562.24.20281155246","010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
+            """.trimIndent()
+
+        val (data, errors) = parser.safeConvertCsvToData<YkiSuoritusCsv>(csv)
+
+        assertTrue(data.size == 3)
+        assertTrue(errors.size == 1)
+    }
+
+    @Test
     fun `test writing csv`() {
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)

--- a/server/src/test/kotlin/fi/oph/kitu/logging/MockEvent.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/logging/MockEvent.kt
@@ -100,3 +100,12 @@ class MockEvent : LoggingEventBuilder {
         logs.add(p0?.get() ?: defaultLogValue)
     }
 }
+
+fun <T> Iterable<T>.only(predicate: (T) -> Boolean): T {
+    val found = this.filter(predicate)
+    if (found.size != 1) {
+        throw IllegalStateException("List must have only 1 element, but it had ${found.size} element(s).")
+    }
+
+    return found.first()
+}

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
@@ -1,0 +1,116 @@
+package fi.oph.kitu.yki
+
+import fi.oph.kitu.csvparsing.CsvExportError
+import fi.oph.kitu.csvparsing.SimpleCsvExportError
+import fi.oph.kitu.logging.MockEvent
+import fi.oph.kitu.logging.only
+import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorEntity
+import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorRepository
+import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.lang.RuntimeException
+import java.time.Instant
+import kotlin.test.assertEquals
+
+// import java.util.
+
+@SpringBootTest
+@Testcontainers
+class YkiSuoritusErrorTests(
+    @Autowired private val repository: YkiSuoritusErrorRepository,
+    @Autowired private val service: YkiSuoritusErrorService,
+) {
+    @Suppress("unused")
+    companion object {
+        @JvmStatic
+        @Container
+        @ServiceConnection
+        val postgres =
+            PostgreSQLContainer("postgres:16")
+                .withUrlParam("stringtype", "unspecified")!!
+    }
+
+    @BeforeEach
+    fun nukeDb() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `no csv errors will truncate errors`() {
+        // Arrange
+        val event = MockEvent()
+        val errors = emptyList<CsvExportError>()
+        repository.save(
+            // Existing error
+            YkiSuoritusErrorEntity(
+                id = null,
+                message = "old error",
+                context = "1,2,3",
+                exceptionMessage = "OldErrorException",
+                stackTrace = "123",
+                created = Instant.parse("2025-03-06T10:50:00.00Z"),
+            ),
+        )
+
+        // Act
+        service.handleErrors(event, errors)
+
+        // Assert
+        val errorsInDatabase = repository.findAll()
+        assertEquals(0, errorsInDatabase.count())
+
+        val (_, errorSize) = event.keyValues.only { kvp -> kvp.first == "errors.size" }
+        assertEquals(0, errorSize)
+
+        val (_, truncate) = event.keyValues.only { kvp -> kvp.first == "errors.truncate" }
+        assertEquals(true, truncate)
+    }
+
+    @Test
+    fun `new csv error will be appended to database`() {
+        // Arrange
+        val event = MockEvent()
+        val errors =
+            listOf(
+                SimpleCsvExportError(
+                    lineNumber = 1,
+                    context = "4,5,6",
+                    exception = RuntimeException("test"),
+                ),
+            )
+        repository.save(
+            // Existing error
+            YkiSuoritusErrorEntity(
+                id = null,
+                message = "old error",
+                context = "1,2,3",
+                exceptionMessage = "OldErrorException",
+                stackTrace = "123",
+                created = Instant.parse("2025-03-06T10:50:00.00Z"),
+            ),
+        )
+
+        // Act
+        service.handleErrors(event, errors)
+
+        // Assert
+        val errorsInDatabase = repository.findAll()
+        assertEquals(2, errorsInDatabase.count())
+
+        val (_, errorSize) = event.keyValues.only { kvp -> kvp.first == "errors.size" }
+        assertEquals(1, errorSize)
+
+        val (_, truncate) = event.keyValues.only { kvp -> kvp.first == "errors.truncate" }
+        assertEquals(false, truncate)
+
+        val (_, addedSize) = event.keyValues.only { kvp -> kvp.first == "errors.addedSize" }
+        assertEquals(1, addedSize)
+    }
+}


### PR DESCRIPTION
YKI suoritus ei pysähdy kokonaan virheeseen virheeseen enää tämän jälkeen.

Oleellisin muutos:
* Virheenkäsittelyn metodi: https://github.com/Opetushallitus/koto-rekisteri/pull/913/files#diff-d75070358c3906f11656f1a8b987ba3a628743c97f7e8fa0fbf6a849baeb9b9dR13-R30

Muita oleellisia asioita:
* lisätty yki/suoritukset - alle sub domain `errors`, missä on kaikki oleellinen boilerplate. 
  * `yki/suoritukset/error/YkiSuoritusErrorEntity.kt` - tietokantataulun - entity luokka
* taulun luontiskripti  `server/src/main/resources/db/migration/V26__create_yki_suoritus_error_table.sql`
* jotta saatu virheet kätevästi ja kaatumatta ulos, lisätty `CsvParser`:iin `convertCsvToData` ohelle `safeConvertCsvToData`, joka palauttaa `Tuple<Data, Error>`. Sitä voi käyttää golang - tyylisesti:

```kotlin
val (suoritukset, errors) = parser.safeConvertCsvToData<YkiSuoritusCsv>(response.body ?: "")
if (errors != null) {
    // Do error handling
}
                
// handle data
```