### PR TITLE
Make deploys faster

### DIFF
--- a/infra/lib/service-stack.ts
+++ b/infra/lib/service-stack.ts
@@ -1,4 +1,11 @@
-import { aws_ecs, aws_secretsmanager, Stack, StackProps } from "aws-cdk-lib"
+import * as cdk from "aws-cdk-lib"
+import {
+  aws_ecs,
+  aws_secretsmanager,
+  Duration,
+  Stack,
+  StackProps,
+} from "aws-cdk-lib"
 import {
   Certificate,
   CertificateValidation,
@@ -27,7 +34,6 @@ import { ITopic } from "aws-cdk-lib/aws-sns"
 import { Construct } from "constructs"
 import { ManagedPolicy } from "aws-cdk-lib/aws-iam"
 import * as s3 from "aws-cdk-lib/aws-s3"
-import * as cdk from "aws-cdk-lib"
 
 export interface ServiceStackProps extends StackProps {
   auditLogGroup: ILogGroup
@@ -147,6 +153,7 @@ export class ServiceStack extends Stack {
       },
       cpu: 1024,
       memoryLimitMiB: 2048,
+      healthCheckGracePeriod: Duration.seconds(15),
       circuitBreaker: {
         enable: true,
         rollback: true,
@@ -158,6 +165,25 @@ export class ServiceStack extends Stack {
       certificate,
       sslPolicy: SslPolicy.RECOMMENDED_TLS,
     })
+
+    // The default target group health check for ALBs is {healthyThresholdCount: 5, interval: Duration.seconds(30)}.
+    // This means that a deployment takes at least 5*30 seconds = 2 minutes 30 seconds per container.
+    // Let's go faster.
+    this.service.targetGroup.configureHealthCheck({
+      enabled: true,
+      healthyThresholdCount: 2,
+      interval: Duration.seconds(5),
+    })
+
+    // The default load balancer configuration waits 300 seconds (5 minutes) before moving a container to UNUSED state.
+    // This means that a deployment can take 300 seconds to wait for a container to shut down.
+    // This value should be low enough that deployments are fast, and high enough that any large file transfers succeed.
+    // This only affects connections that are open when a new deployment occurs.
+    // Let's go faster.
+    this.service.loadBalancer.setAttribute(
+      "deregistration_delay.timeout_seconds",
+      "5",
+    )
 
     this.service.taskDefinition.addContainer("AwsOtelCollector", {
       image: ContainerImage.fromRegistry(


### PR DESCRIPTION
It currently takes ~four and a half minutes to deploy the koto-rekisteri container to each environment. We can make that faster by fiddling with the load balancer configuration, which by default is very conservative.

Changed settings:
- [New container health check](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-healthcheck.html): from 5 OK responses every 30 seconds to 2 OKs in 5 seconds.
- [New container grace period](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration): how long ECS ignores the health checks of a newly started container (to let slow applications start) changed from 60 seconds (CDK default) to 15 seconds.
- [Old container deregistration delay](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-connection-draining.html): open connections are forcibly closed in 5 seconds instead of the default of 300 seconds.