### PR TITLE
fix: YKI suoritus import always fetches everything

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiScheduledTasks.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiScheduledTasks.kt
@@ -22,8 +22,8 @@ class YkiScheduledTasks {
     fun dailyImport(ykiService: YkiService): Task<Instant?> =
         Tasks
             .recurring("YKI-import", ExtendedSchedules.parse(ykiImportSchedule), Instant::class.java)
-            .initialData(null)
-            .execute { taskInstance, _ -> ykiService.importYkiSuoritukset(taskInstance.data) }
+            .initialData(Instant.EPOCH)
+            .executeStateful { taskInstance, _ -> ykiService.importYkiSuoritukset(taskInstance.data) }
 
     @Bean
     fun arvioijatImport(ykiService: YkiService): Task<Void> =

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -44,22 +44,18 @@ class YkiService(
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     fun importYkiSuoritukset(
-        from: Instant? = null,
+        from: Instant,
         lastSeen: LocalDate? = null,
         dryRun: Boolean? = null,
-    ): Instant? =
+    ): Instant =
         logger
             .atInfo()
             .withEventAndPerformanceCheck { event ->
                 val parser = CsvParser(event)
                 event.add("dryRun" to dryRun, "lastSeen" to lastSeen)
 
-                val url =
-                    if (from != null) {
-                        "suoritukset?m=${DateTimeFormatter.ISO_INSTANT.format(from)}"
-                    } else {
-                        "suoritukset"
-                    }
+                val url = "suoritukset?m=${DateTimeFormatter.ISO_INSTANT.format(from)}"
+
                 val response =
                     solkiRestClient
                         .get()

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
@@ -22,6 +22,7 @@ import org.springframework.web.client.RestClient
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.Instant
 import java.time.OffsetDateTime
 import kotlin.test.assertEquals
 
@@ -56,7 +57,7 @@ class YkiServiceTests(
         val mockRestClientBuilder = RestClient.builder()
         val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
         mockServer
-            .expect(requestTo("suoritukset"))
+            .expect(requestTo("suoritukset?m=1970-01-01T00:00:00Z"))
             .andRespond(
                 withSuccess(
                     """
@@ -81,7 +82,7 @@ class YkiServiceTests(
             )
 
         // Act
-        ykiService.importYkiSuoritukset(null, null, false)
+        ykiService.importYkiSuoritukset(Instant.EPOCH, null, false)
 
         // Assert
         val suoritukset = ykiSuoritusRepository.findAll()
@@ -97,7 +98,7 @@ class YkiServiceTests(
         val mockRestClientBuilder = RestClient.builder()
         val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
         mockServer
-            .expect(requestTo("suoritukset"))
+            .expect(requestTo("suoritukset?m=1970-01-01T00:00:00Z"))
             .andRespond(
                 withSuccess(
                     """
@@ -120,8 +121,7 @@ class YkiServiceTests(
             )
 
         // Act
-        ykiService.importYkiSuoritukset(null, null, false)
-
+        ykiService.importYkiSuoritukset(Instant.EPOCH, null, false)
         val suoritukset = ykiSuoritusRepository.findAll()
         assertEquals(0, suoritukset.count())
 
@@ -135,7 +135,7 @@ class YkiServiceTests(
         val mockRestClientBuilder = RestClient.builder()
         val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
         mockServer
-            .expect(requestTo("suoritukset"))
+            .expect(requestTo("suoritukset?m=1970-01-01T00:00:00Z"))
             .andRespond(
                 withSuccess(
                     """
@@ -160,7 +160,7 @@ class YkiServiceTests(
             )
 
         // Act
-        val from = ykiService.importYkiSuoritukset(null, null, false)
+        val from = ykiService.importYkiSuoritukset(Instant.EPOCH, null, false)
 
         // Assert
         val firstSuoritukset = ykiSuoritusRepository.findAll()


### PR DESCRIPTION
Pieni bugi `YkiScheduledTasks`:ssa aiheutti sen, ettei suoritusten tuonnin eräajon viimeisintä aikaleimaa tallennettu tietokantaan ajon päättyessä. Koska aikaleiman oletusarvo oli `null`, ja tämän tulkittiin tarkoittavan "aikojen alusta asti", eräajo käytännössä toi joka kerralla kaikki suoritukset uudelleen.

Tuonti on toteutettu siten, että duplikaatit jätetään huomiotta. Näinollen bugista ei aiheutunut mitään muuta haittaa, kuin hieman lisääntynyttä liikennettä ja hieman tuhlattua suoritinaikaa.