### PR TITLE
Koski service for sendig YKI suoritus to KOSKI

### DIFF
--- a/infra/lib/service-stack.ts
+++ b/infra/lib/service-stack.ts
@@ -122,11 +122,11 @@ export class ServiceStack extends Stack {
               "kielitesti-token",
             ),
           ),
-          OPPIJANUMERO_PASSWORD: aws_ecs.Secret.fromSecretsManager(
+          PALVELUKAYTTAJA_PASSWORD: aws_ecs.Secret.fromSecretsManager(
             aws_secretsmanager.Secret.fromSecretNameV2(
               this,
-              "OppijanumeroPassword",
-              "oppijanumero-password",
+              "PalvelukayttajaPassword",
+              "palvelukayttaja-password",
             ),
           ),
           YKI_API_PASSWORD: aws_ecs.Secret.fromSecretsManager(

--- a/scripts/check_env-vars.sh
+++ b/scripts/check_env-vars.sh
@@ -23,7 +23,7 @@ is_env_variable_exported() {
 amount=0
 
 is_env_variable_exported "KIELITESTI_TOKEN" || amount=$((amount + 1))
-is_env_variable_exported "OPPIJANUMERO_PASSWORD" || amount=$((amount + 1))
+is_env_variable_exported "PALVELUKAYTTAJA_PASSWORD" || amount=$((amount + 1))
 is_env_variable_exported "YKI_API_USER" || amount=$((amount + 1))
 is_env_variable_exported "YKI_API_PASSWORD" || amount=$((amount + 1))
 

--- a/scripts/ensure_aws_secrets.sh
+++ b/scripts/ensure_aws_secrets.sh
@@ -12,7 +12,7 @@ get_secret() {
 require_dev_aws_session
 
 export "KIELITESTI_TOKEN"="$(get_secret "kielitesti-token")"; echo "KIELITESTI_TOKEN exported"
-export "OPPIJANUMERO_PASSWORD"="$(get_secret "oppijanumero-password")"; echo "OPPIJANUMERO_PASSWORD exported"
+export "PALVELUKAYTTAJA_PASSWORD"="$(get_secret "palvelukayttaja-password")"; echo "PALVELUKAYTTAJA_PASSWORD exported"
 export "YKI_API_USER"="$(get_secret "yki-api-user")"; echo "YKI_API_USER exported"
 export "YKI_API_PASSWORD"="$(get_secret "yki-api-password")"; echo "YKI_API_PASSWORD exported"
 

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequest.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequest.kt
@@ -38,6 +38,7 @@ data class KoskiRequest(
             val toimipiste: Organisaatio,
             val vahvistus: Vahvistus,
             val osasuoritukset: List<Osasuoritus>,
+            val yleisarvosana: Koodisto.Koodiviite?,
         ) {
             data class KoulutusModuuli(
                 val tunniste: Koodisto.Koodiviite,

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
@@ -65,6 +65,7 @@ class KoskiRequestMapper {
                                                 ),
                                         ),
                                     osasuoritukset = convertYkiSuoritusToKoskiOsasuoritukset(ykiSuoritus),
+                                    yleisarvosana = ykiSuoritus.yleisarvosana?.let { Koodisto.YkiArvosana.fromInt(it) },
                                 ),
                             ),
                     ),

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
@@ -13,8 +13,10 @@ import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.LahdeJarjestelmanId
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.Tila
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.Tila.OpiskeluoikeusJakso
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
+import org.springframework.stereotype.Service
 import java.time.LocalDate
 
+@Service
 class KoskiRequestMapper {
     fun ykiSuoritusToKoskiRequest(ykiSuoritus: YkiSuoritusEntity): KoskiRequest =
         KoskiRequest(

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiResponse.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiResponse.kt
@@ -1,0 +1,25 @@
+package fi.oph.kitu.koski
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+data class KoskiResponse(
+    val henkilö: KoskiRequest.Henkilo,
+    val opiskeluoikeudet: List<OpiskeluoikeusResponse>,
+) {
+    data class OpiskeluoikeusResponse(
+        val oid: String,
+        val versionumero: Int,
+        val lähdejärjestelmänId: LahdeJarjestelmanId,
+    )
+
+    data class LahdeJarjestelmanId(
+        val id: String,
+        val lähdejärjestelmä: Lahdejarjestelma,
+    ) {
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        data class Lahdejarjestelma(
+            val koodiarvo: String,
+            val koodistoUri: String,
+        )
+    }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRestClientConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRestClientConfig.kt
@@ -1,0 +1,29 @@
+package fi.oph.kitu.koski
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import java.util.Base64
+
+@Configuration
+class KoskiRestClientConfig {
+    @Value("\${kitu.koski.baseUrl}")
+    private lateinit var koskiBaseUrl: String
+
+    @Value("\${kitu.palvelukayttaja.username}")
+    private lateinit var user: String
+
+    @Value("\${kitu.palvelukayttaja.password}")
+    private lateinit var password: String
+
+    @Bean("koskiRestClient")
+    fun restClient(): RestClient {
+        val basicAuthToken = Base64.getEncoder().encodeToString("$user:$password".toByteArray())
+        return RestClient
+            .builder()
+            .baseUrl(koskiBaseUrl)
+            .defaultHeader("Authorization", "Basic $basicAuthToken")
+            .build()
+    }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
@@ -1,0 +1,30 @@
+package fi.oph.kitu.koski
+
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.toEntity
+
+@Service
+class KoskiService(
+    @Qualifier("koskiRestClient")
+    private val koskiRestClient: RestClient,
+    private val koskiRequestMapper: KoskiRequestMapper,
+) {
+    fun sendYkiSuoritusToKoski(ykiSuoritusEntity: YkiSuoritusEntity): KoskiResponse {
+        val koskiRequest = koskiRequestMapper.ykiSuoritusToKoskiRequest(ykiSuoritusEntity)
+        val koskiResponse =
+            koskiRestClient
+                .put()
+                .uri("oppija")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(koskiRequest)
+                .retrieve()
+                .toEntity<KoskiResponse>()
+
+        return koskiResponse.body!!
+    }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/CasService.kt
@@ -17,10 +17,10 @@ class CasService(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Value("\${kitu.oppijanumero.username}")
+    @Value("\${kitu.palvelukayttaja.username}")
     private lateinit var onrUsername: String
 
-    @Value("\${kitu.oppijanumero.password}")
+    @Value("\${kitu.palvelukayttaja.password}")
     private lateinit var onrPassword: String
 
     @Value("\${kitu.oppijanumero.casUrl}")

--- a/server/src/main/resources/application-e2e.properties
+++ b/server/src/main/resources/application-e2e.properties
@@ -12,7 +12,7 @@ kitu.opintopolkuHostname=virkailija.untuvaopintopolku.fi
 kitu.kotoutumiskoulutus.koealusta.wstoken=
 kitu.kotoutumiskoulutus.koealusta.baseurl=
 
-kitu.oppijanumero.password=
+kitu.palvelukayttaja.password=
 kitu.oppijanumero.casUrl=https://virkailija.untuvaopintopolku.fi/cas
 kitu.oppijanumero.service.url=https://virkailija.untuvaopintopolku.fi/oppijanumerorekisteri-service
 
@@ -20,3 +20,5 @@ kitu.yki.username=
 kitu.yki.password=
 kitu.yki.scheduling.enabled=false
 kitu.yki.baseUrl=
+
+kitu.koski.baseUrl=

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -17,3 +17,5 @@ kitu.yki.scheduling.enabled=true
 kitu.yki.scheduling.import.schedule=FIXED_DELAY|60s
 kitu.yki.scheduling.importArvioijat.schedule=FIXED_DELAY|60s
 kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/yki-sp/oph/
+
+kitu.koski.baseUrl=https://untuvaopintopolku.fi/koski/api/

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -20,4 +20,6 @@ kitu.yki.baseUrl=https://yki.jyu.fi/yki-sp/oph/
 kitu.yki.scheduling.import.schedule=DAILY|03:00
 kitu.yki.scheduling.importArvioijat.schedule=DAILY|03:00
 
+kitu.koski.baseUrl=https://opintopolku.fi/koski/api/
+
 otel.resource.providers.aws.enabled=true

--- a/server/src/main/resources/application-qa.properties
+++ b/server/src/main/resources/application-qa.properties
@@ -19,4 +19,6 @@ kitu.yki.scheduling.import.schedule=DAILY|03:00
 kitu.yki.scheduling.importArvioijat.schedule=DAILY|03:00
 kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/yki-sp/oph/
 
+kitu.koski.baseUrl=https://testiopintopolku.fi/koski/api/
+
 otel.resource.providers.aws.enabled=true

--- a/server/src/main/resources/application-untuva.properties
+++ b/server/src/main/resources/application-untuva.properties
@@ -19,4 +19,6 @@ kitu.yki.scheduling.import.schedule=DAILY|03:00
 kitu.yki.scheduling.importArvioijat.schedule=DAILY|03:00
 kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/yki-sp/oph/
 
+kitu.koski.baseUrl=https://untuvaopintopolku.fi/koski/api/
+
 otel.resource.providers.aws.enabled=true

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -10,7 +10,7 @@ server.error.whitelabel.enabled=false
 kitu.kotoutumiskoulutus.koealusta.wstoken=${KIELITESTI_TOKEN}
 kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=false
 
-kitu.palvelukayttaja.password=${OPPIJANUMERO_PASSWORD}
+kitu.palvelukayttaja.password=${PALVELUKAYTTAJA_PASSWORD}
 kitu.palvelukayttaja.username=koto-rekisteri
 kitu.oppijanumero.callerid=1.2.246.562.10.00000000001.koto-rekisteri
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -10,8 +10,8 @@ server.error.whitelabel.enabled=false
 kitu.kotoutumiskoulutus.koealusta.wstoken=${KIELITESTI_TOKEN}
 kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=false
 
-kitu.oppijanumero.password=${OPPIJANUMERO_PASSWORD}
-kitu.oppijanumero.username=koto-rekisteri
+kitu.palvelukayttaja.password=${OPPIJANUMERO_PASSWORD}
+kitu.palvelukayttaja.username=koto-rekisteri
 kitu.oppijanumero.callerid=1.2.246.562.10.00000000001.koto-rekisteri
 
 db-scheduler.enabled=true

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiRequestMapperTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiRequestMapperTest.kt
@@ -44,4 +44,33 @@ class KoskiRequestMapperTest {
         val koskiRequestJson = objectMapper.writeValueAsString(koskiRequest)
         assertEquals(expectedJson, koskiRequestJson)
     }
+
+    @Test
+    fun `map yki suoritus with yleisarvosana to koski request`() {
+        val suoritus =
+            generateRandomYkiSuoritusEntity().copy(
+                suorittajanOID = "1.2.246.562.24.12345678910",
+                suoritusId = 123456,
+                tutkintopaiva = LocalDate.of(2025, 1, 1),
+                arviointipaiva = LocalDate.of(2025, 1, 3),
+                tutkintotaso = Tutkintotaso.PT,
+                tutkintokieli = Tutkintokieli.ENG,
+                jarjestajanTunnusOid = "1.2.246.562.10.12345678910",
+                tekstinYmmartaminen = 2,
+                kirjoittaminen = 2,
+                puheenYmmartaminen = 2,
+                puhuminen = 2,
+                rakenteetJaSanasto = null,
+                yleisarvosana = 2,
+            )
+        val koskiRequest = koskiRequestMapper.ykiSuoritusToKoskiRequest(suoritus)
+        val expectedJson =
+            objectMapper
+                .readValue(
+                    ClassPathResource("./koski-request-with-yleisarvosana.json").file,
+                    JsonNode::class.java,
+                ).toString()
+        val koskiRequestJson = objectMapper.writeValueAsString(koskiRequest)
+        assertEquals(expectedJson, koskiRequestJson)
+    }
 }

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
@@ -1,0 +1,83 @@
+package fi.oph.kitu.koski
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import fi.oph.kitu.mock.generateRandomYkiSuoritusEntity
+import fi.oph.kitu.yki.Tutkintokieli
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@SpringBootTest
+@Testcontainers
+class KoskiServiceTest(
+    @Autowired private val koskiRequestMapper: KoskiRequestMapper,
+) {
+    private val objectMapper = jacksonObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+
+    @Suppress("unused")
+    companion object {
+        @JvmStatic
+        @Container
+        @ServiceConnection
+        val postgres =
+            PostgreSQLContainer("postgres:16")
+                .withUrlParam("stringtype", "unspecified")!!
+    }
+
+    @Test
+    fun `test sending koski request`() {
+        // Arrange
+        val expectedResponse =
+            """
+            {
+              "henkilö": {
+                "oid": "1.2.246.562.24.20281155246"
+              },
+              "opiskeluoikeudet": [
+                {
+                  "oid": "1.2.246.562.15.50209741037",
+                  "versionumero": 1,
+                  "lähdejärjestelmänId": {
+                    "id": "183424",
+                    "lähdejärjestelmä": {
+                      "koodiarvo": "kielitutkintorekisteri",
+                      "nimi": {
+                        "fi": "Kielitutkintorekisteri"
+                      },
+                      "koodistoUri": "lahdejarjestelma",
+                      "koodistoVersio": 1
+                    }
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        val mockRestClientBuilder = RestClient.builder()
+        val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
+        mockServer
+            .expect(requestTo("oppija"))
+            .andRespond(
+                withSuccess(
+                    expectedResponse,
+                    MediaType.APPLICATION_JSON,
+                ),
+            )
+
+        val service = KoskiService(mockRestClientBuilder.build(), koskiRequestMapper)
+        val suoritus = generateRandomYkiSuoritusEntity().copy(tutkintokieli = Tutkintokieli.ENG)
+        val response = service.sendYkiSuoritusToKoski(suoritus)
+        assertEquals(objectMapper.readValue(expectedResponse, KoskiResponse::class.java), response)
+    }
+}

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -10,8 +10,8 @@ kitu.kotoutumiskoulutus.koealusta.wstoken=
 kitu.kotoutumiskoulutus.koealusta.baseurl=http://localhost:8080/dev/koto/
 kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=false
 
-kitu.oppijanumero.username=koto-rekisteri
-kitu.oppijanumero.password=
+kitu.palvelukayttaja.username=koto-rekisteri
+kitu.palvelukayttaja.password=
 kitu.oppijanumero.callerid=
 kitu.oppijanumero.casUrl=
 kitu.oppijanumero.service.url=http://localhost:8080/oppijanumero-service
@@ -19,6 +19,8 @@ kitu.oppijanumero.service.url=http://localhost:8080/oppijanumero-service
 kitu.yki.baseUrl=
 kitu.yki.username=
 kitu.yki.password=
+
+kitu.koski.baseUrl=
 
 logging.structured.format.console=ecs
 logging.structured.format.file=ecs

--- a/server/src/test/resources/koski-request-with-yleisarvosana.json
+++ b/server/src/test/resources/koski-request-with-yleisarvosana.json
@@ -144,7 +144,7 @@
               ]
             }
           ],
-          "yleisarvosana": null
+          "yleisarvosana": { "koodiarvo": "2", "koodistoUri": "ykiarvosana" }
         }
       ]
     }


### PR DESCRIPTION
- `KoskiService` yki-suoritusten lähettämiseksi Koskeen
- Ei vielä toteutusta suoritusten lähettämiseen käytännössä
- Kosken käyttämiseen sama palvelukäyttäjätunnus kuin Oppijanumerorekisterin käyttöön, joten muutettu propertieseista `kitu.oppijanumero.username` ja `kitu.oppijanumero.password` -> `kitu.palvelukayttaja.username` ja `kitu.palvelukayttaja.password`