### PR TITLE
fix: make private `Oid` constructor actually private

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -29,6 +29,8 @@
     <properties>
         <java.version>21</java.version>
         <kotlin.version>2.1.10</kotlin.version>
+        <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
+
         <flyway.version>11.3.4</flyway.version>
         <jackson.version>2.18.3</jackson.version>
         <opentelemetry-semconv.version>1.30.0</opentelemetry-semconv.version>

--- a/server/src/main/kotlin/fi/oph/kitu/Oid.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/Oid.kt
@@ -12,6 +12,8 @@ data class Oid(
             } catch (_: GSSException) {
                 null
             }
+
+        fun valueOfOrThrow(source: String): Oid = valueOf(source)!!
     }
 
     override fun toString(): String = value.toString()

--- a/server/src/main/kotlin/fi/oph/kitu/Oid.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/Oid.kt
@@ -2,7 +2,8 @@ package fi.oph.kitu
 
 import org.ietf.jgss.GSSException
 
-data class Oid(
+@ConsistentCopyVisibility
+data class Oid private constructor(
     private val value: org.ietf.jgss.Oid,
 ) {
     companion object {

--- a/server/src/main/kotlin/fi/oph/kitu/mock/OidGenerator.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/OidGenerator.kt
@@ -1,6 +1,6 @@
 package fi.oph.kitu.mock
 
-import org.ietf.jgss.Oid
+import fi.oph.kitu.Oid
 
 /**
  * Generates random user OID under node class 1.2.246.562.240.
@@ -8,14 +8,11 @@ import org.ietf.jgss.Oid
  * Note: Node class 240 is the correct class for users,
  * but these values should not be used in production.
  */
-fun generateRandomUserOid() =
-    fi.oph.kitu.Oid(
-        Oid(
-            "1.2.246.562.240.${(0..99999999999)
-                .random()
-                .toString()
-                .padStart(11, '0')}",
-        ),
+fun generateRandomUserOid(): Oid =
+    Oid.valueOfOrThrow(
+        "1.2.246.562.240.${
+            (0..99999999999).random().toString().padStart(11, '0')
+        }",
     )
 
 /**
@@ -25,13 +22,8 @@ fun generateRandomUserOid() =
  * but these values should not be used in production.
  */
 fun generateRandomOrganizationOid() =
-    fi.oph.kitu.Oid(
-        Oid(
-            "1.2.246.562.100.${
-                (0..99999999999)
-                    .random()
-                    .toString()
-                    .padStart(11, '0')
-            }",
-        ),
+    Oid.valueOfOrThrow(
+        "1.2.246.562.100.${
+            (0..99999999999).random().toString().padStart(11, '0')
+        }",
     )


### PR DESCRIPTION
Ensimmäinen askel `Oid`-tyyppien käytön parempaan konsistenssiin: vältetään `Oid`-wrapperin instanssien luontia suorilla konstruktorikutsuilla.

Konstruktorin käyttäminen luo suoran riippuvuuden alla olevaan `org.ietf.jgss.Oid`-tyyppiin, ja fakadin tärkein tarkoitus on pitää tällaiset riippuvuudet kapseloituna yhteen paikkaan (= wrapperin sisään). Tämä on tärkeää/hyödyllistä, mikäli alla olevaa Oid-tyyppiä tai sen validaatiota tmv. tarvitsee myöhemmin muuttaa.

Kotlinin dataluokkien `private`-konstruktoreihin liittyy kuitenkin ikävä epäjohdonmukaisuus: automaattisesti generoitu `copy`-konstruktori on julkinen, vaikka kanoninen konstruktori olisi merkitty yksityiseksi. Tämä on muuttumassa tuoreemmissa Kotlin-versioissa, mutta toistaiseksi uusi/tuleva toiminnallisuus on opt-in. Opt-in onnistuu siisteimmin, lisäämällä `ConsistentCopyVisibility` -annotaatio, mutta tämä puolestaan vaatii tuoreehkon Kotlin API version (>2.x).

Vaikka meillä on jo käytössä Kotlin 2.1.x, kääntäjän API-versiota ei ollut valittu, joten oletuksena käytössä on 1.9. Tästä en ole varma, onko kyseessä vain huolimattomuusvirhe, vai onko API version jättäminen oletusarvoon ollut tietoinen valinta, mutta ajantasaisen version käytöstä ei pitäisi olla mitään haittaakaan. Näillä muutoksilla API-versio on nyt sama kuin Kotlin-versio, 2.1.

Varsinainen muutos/korjaus muuttaa kaikki suorat `Oid`-konstruktorikutsut `OidGenerator.kt`:sta käyttämään wrapperin/fakadin parsintametodeja.