### PR TITLE
Use wrapper-`Oid` everywhere

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
@@ -6,11 +6,10 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.dataformat.csv.CsvSchema
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import fi.oph.kitu.Oid
 import fi.oph.kitu.logging.add
-import org.ietf.jgss.Oid
 import org.slf4j.spi.LoggingEventBuilder
 import java.io.ByteArrayOutputStream
-import java.lang.RuntimeException
 import kotlin.reflect.full.findAnnotation
 
 class CsvParser(
@@ -55,6 +54,7 @@ class CsvParser(
         this.registerModule(JavaTimeModule())
         val oidSerializerModule = SimpleModule()
         oidSerializerModule.addSerializer(Oid::class.java, OidSerializer())
+        oidSerializerModule.addDeserializer(Oid::class.java, OidDeserializer())
         this.registerModule(oidSerializerModule)
 
         return this

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidDeserializer.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidDeserializer.kt
@@ -1,0 +1,16 @@
+package fi.oph.kitu.csvparsing
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import fi.oph.kitu.Oid
+
+class OidDeserializer : JsonDeserializer<Oid>() {
+    override fun deserialize(
+        parser: JsonParser?,
+        context: DeserializationContext?,
+    ): Oid? =
+        parser?.valueAsString?.let {
+            Oid.valueOf(it)
+        }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidSerializer.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidSerializer.kt
@@ -3,7 +3,7 @@ package fi.oph.kitu.csvparsing
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
-import org.ietf.jgss.Oid
+import fi.oph.kitu.Oid
 
 class OidSerializer : JsonSerializer<Oid>() {
     override fun serialize(

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusCsv.kt
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import fi.oph.kitu.Oid
 import fi.oph.kitu.csvparsing.Features
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import fi.oph.kitu.yki.arvioijat.TutkintokieliDeserializer
-import org.ietf.jgss.Oid
 import java.time.Instant
 import java.time.LocalDate
 

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
@@ -1,7 +1,7 @@
 package fi.oph.kitu.yki.suoritukset
 
+import fi.oph.kitu.Oid
 import fi.oph.kitu.yki.Sukupuoli
-import org.ietf.jgss.Oid
 import org.springframework.stereotype.Service
 
 @Service
@@ -49,7 +49,7 @@ class YkiSuoritusMappingService {
 
     fun convertToResponse(entity: YkiSuoritusEntity): YkiSuoritusCsv =
         YkiSuoritusCsv(
-            suorittajanOID = Oid(entity.suorittajanOID),
+            suorittajanOID = Oid.valueOfOrThrow(entity.suorittajanOID),
             hetu = entity.hetu,
             sukupuoli = entity.sukupuoli,
             sukunimi = entity.sukunimi,
@@ -64,7 +64,7 @@ class YkiSuoritusMappingService {
             tutkintopaiva = entity.tutkintopaiva,
             tutkintokieli = entity.tutkintokieli,
             tutkintotaso = entity.tutkintotaso,
-            jarjestajanOID = Oid(entity.jarjestajanTunnusOid),
+            jarjestajanOID = Oid.valueOfOrThrow(entity.jarjestajanTunnusOid),
             jarjestajanNimi = entity.jarjestajanNimi,
             arviointipaiva = entity.arviointipaiva,
             tekstinYmmartaminen = entity.tekstinYmmartaminen,

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -2,13 +2,13 @@ package fi.oph.kitu.csvparsing
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
+import fi.oph.kitu.Oid
 import fi.oph.kitu.logging.MockEvent
 import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import fi.oph.kitu.yki.arvioijat.SolkiArvioijaResponse
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv
-import org.ietf.jgss.Oid
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayOutputStream
@@ -32,7 +32,7 @@ class CsvParsingTest {
 
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
-        assertEquals(Oid("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
+        assertEquals(Oid.valueOf("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
         assertEquals("010180-9026", suoritus.hetu)
         assertEquals(Sukupuoli.N, suoritus.sukupuoli)
         assertEquals("Öhman-Testi", suoritus.sukunimi)
@@ -47,7 +47,7 @@ class CsvParsingTest {
         assertEquals("2024-09-01", suoritus.tutkintopaiva.format(dateFormatter))
         assertEquals(Tutkintokieli.FIN, suoritus.tutkintokieli)
         assertEquals(Tutkintotaso.YT, suoritus.tutkintotaso)
-        assertEquals(Oid("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
+        assertEquals(Oid.valueOf("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
         assertEquals("Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus", suoritus.jarjestajanNimi)
         assertEquals("2024-11-14", suoritus.arviointipaiva.format(dateFormatter))
         assertEquals(5, suoritus.tekstinYmmartaminen)
@@ -126,7 +126,7 @@ class CsvParsingTest {
 
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
-        assertEquals(Oid("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
+        assertEquals(Oid.valueOf("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
         assertEquals("010180-9026", suoritus.hetu)
         assertEquals(Sukupuoli.N, suoritus.sukupuoli)
         assertEquals("Öhman-Testi", suoritus.sukunimi)
@@ -141,7 +141,7 @@ class CsvParsingTest {
         assertEquals("2024-09-01", suoritus.tutkintopaiva.format(dateFormatter))
         assertEquals(Tutkintokieli.FIN, suoritus.tutkintokieli)
         assertEquals(Tutkintotaso.YT, suoritus.tutkintotaso)
-        assertEquals(Oid("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
+        assertEquals(Oid.valueOf("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
         assertEquals("Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus", suoritus.jarjestajanNimi)
         assertEquals("2024-11-14", suoritus.arviointipaiva.format(dateFormatter))
         assertEquals(5, suoritus.tekstinYmmartaminen)
@@ -222,7 +222,7 @@ class CsvParsingTest {
         val writable =
             listOf(
                 YkiSuoritusCsv(
-                    suorittajanOID = Oid("1.2.246.562.24.20281155246"),
+                    suorittajanOID = Oid.valueOfOrThrow("1.2.246.562.24.20281155246"),
                     hetu = "010180-9026",
                     sukupuoli = Sukupuoli.N,
                     sukunimi = "Öhman-Testi",
@@ -237,7 +237,7 @@ class CsvParsingTest {
                     tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                     tutkintokieli = Tutkintokieli.FIN,
                     tutkintotaso = Tutkintotaso.YT,
-                    jarjestajanOID = Oid("1.2.246.562.10.14893989377"),
+                    jarjestajanOID = Oid.valueOfOrThrow("1.2.246.562.10.14893989377"),
                     jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
                     arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                     tekstinYmmartaminen = 5,
@@ -273,7 +273,7 @@ class CsvParsingTest {
         val writable =
             listOf(
                 YkiSuoritusCsv(
-                    suorittajanOID = Oid("1.2.246.562.24.20281155246"),
+                    suorittajanOID = Oid.valueOfOrThrow("1.2.246.562.24.20281155246"),
                     hetu = "010180-9026",
                     sukupuoli = Sukupuoli.N,
                     sukunimi = "Öhman-Testi",
@@ -288,7 +288,7 @@ class CsvParsingTest {
                     tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                     tutkintokieli = Tutkintokieli.FIN,
                     tutkintotaso = Tutkintotaso.YT,
-                    jarjestajanOID = Oid("1.2.246.562.10.14893989377"),
+                    jarjestajanOID = Oid.valueOfOrThrow("1.2.246.562.10.14893989377"),
                     jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
                     arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                     tekstinYmmartaminen = null,


### PR DESCRIPTION
Käytetään samaa `Oid`-tyyppiä kaikkialla. Preferoidaan wrapper-Oidia.

Wrapperin sisällä olevan `org.ietf.jgss.Oid`-tyypin konstruktorissa on ikävä ominaisuus, että se saattaa heittää poikkeuksen, mikäli sille syötetään epäkelpo arvo. Tämä ei kuitenkaan näy konstruktorin metodikontraktissa mitenkään, vaan virhe lentää ns. "hiljaisesti", joten meillä ei ole mitään tyyppitarkistuksen tai staattisen analyysin apuja varoittamaan tästä. Tämä on kovin "käytännöllistä", koska virheenkäsittelystä ei tarvitse koodia tycitellessä välittää, mutta hieman vähemmän käytännöllistä jos virheenkäsittelystä _haluaisi_ välittää.

Molemmat käyttötapaukset on nyt katettu wrapperin kautta. Tycittelyyn on `Oid.valueOfOrThrow(string) -> Oid ` ja virheenkäsittelyä varten `Oid.valueOf(string) -> Oid?`. Wrapperin versiosta mahdollisuus poikkeuksen heittämiseen on eksplisiittisesti näkyvillä (metodin nimessä), joka on hieman pienempi paha kuin allaolevan konstruktorin tapa heittää poikkeus kaikessa hiljaisuudessa.

Wrapperin käyttöön liittyy pientä hassuttelua CSV/JSON-serialisoinnin kanssa ja tarvitaan serialisointiin/deserialisointiin omat palikkansa väliin. `JsonSerializer<Oid>` toteutus meillä oli jo ennestään, mutta testejä varten tarvittiin vielä vastaava `JsonDeserializer<Oid>`.