### PR TITLE
Use standard `Result<T>` for wrapping OID parsing results

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/Oid.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/Oid.kt
@@ -7,15 +7,17 @@ data class Oid private constructor(
     private val value: org.ietf.jgss.Oid,
 ) {
     companion object {
-        fun valueOf(source: String): Oid? =
+        fun parse(source: String): Result<Oid> =
             try {
-                Oid(org.ietf.jgss.Oid(source))
+                Result.success(Oid(org.ietf.jgss.Oid(source)))
             } catch (_: GSSException) {
-                null
+                Result.failure(MalformedOidError(source))
             }
-
-        fun valueOfOrThrow(source: String): Oid = valueOf(source)!!
     }
 
     override fun toString(): String = value.toString()
 }
+
+data class MalformedOidError(
+    val source: String?,
+) : Exception("Malformed Oid \"$source\"")

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidDeserializer.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/OidDeserializer.kt
@@ -11,6 +11,6 @@ class OidDeserializer : JsonDeserializer<Oid>() {
         context: DeserializationContext?,
     ): Oid? =
         parser?.valueAsString?.let {
-            Oid.valueOf(it)
+            Oid.parse(it).getOrNull()
         }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/jdbc/StringToOidConverter.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/jdbc/StringToOidConverter.kt
@@ -6,5 +6,5 @@ import org.springframework.data.convert.ReadingConverter
 
 @ReadingConverter
 class StringToOidConverter : Converter<String, Oid> {
-    override fun convert(source: String): Oid? = Oid.valueOf(source)
+    override fun convert(source: String): Oid? = Oid.parse(source).getOrNull()
 }

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
@@ -208,12 +208,15 @@ class KoealustaMappingService(
         userId: Int,
         oid: String,
     ): Oid =
-        Oid.valueOf(oid)
-            ?: throw Error.Validation.MalformedField(
-                userId,
-                "schoolOID",
-                oid,
-            )
+        Oid
+            .parse(oid)
+            .onFailure {
+                throw Error.Validation.MalformedField(
+                    userId,
+                    "schoolOID",
+                    oid,
+                )
+            }.getOrThrow()
 
     fun completionToEntity(
         user: User,

--- a/server/src/main/kotlin/fi/oph/kitu/mock/OidGenerator.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/OidGenerator.kt
@@ -9,11 +9,12 @@ import fi.oph.kitu.Oid
  * but these values should not be used in production.
  */
 fun generateRandomUserOid(): Oid =
-    Oid.valueOfOrThrow(
-        "1.2.246.562.240.${
-            (0..99999999999).random().toString().padStart(11, '0')
-        }",
-    )
+    Oid
+        .parse(
+            "1.2.246.562.240.${
+                (0..99999999999).random().toString().padStart(11, '0')
+            }",
+        ).getOrThrow()
 
 /**
  * Generates random user OID under node class 1.2.246.562.100.
@@ -22,8 +23,9 @@ fun generateRandomUserOid(): Oid =
  * but these values should not be used in production.
  */
 fun generateRandomOrganizationOid() =
-    Oid.valueOfOrThrow(
-        "1.2.246.562.100.${
-            (0..99999999999).random().toString().padStart(11, '0')
-        }",
-    )
+    Oid
+        .parse(
+            "1.2.246.562.100.${
+                (0..99999999999).random().toString().padStart(11, '0')
+            }",
+        ).getOrThrow()

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
@@ -49,7 +49,7 @@ class YkiSuoritusMappingService {
 
     fun convertToResponse(entity: YkiSuoritusEntity): YkiSuoritusCsv =
         YkiSuoritusCsv(
-            suorittajanOID = Oid.valueOfOrThrow(entity.suorittajanOID),
+            suorittajanOID = Oid.parse(entity.suorittajanOID).getOrThrow(),
             hetu = entity.hetu,
             sukupuoli = entity.sukupuoli,
             sukunimi = entity.sukunimi,
@@ -64,7 +64,7 @@ class YkiSuoritusMappingService {
             tutkintopaiva = entity.tutkintopaiva,
             tutkintokieli = entity.tutkintokieli,
             tutkintotaso = entity.tutkintotaso,
-            jarjestajanOID = Oid.valueOfOrThrow(entity.jarjestajanTunnusOid),
+            jarjestajanOID = Oid.parse(entity.jarjestajanTunnusOid).getOrThrow(),
             jarjestajanNimi = entity.jarjestajanNimi,
             arviointipaiva = entity.arviointipaiva,
             tekstinYmmartaminen = entity.tekstinYmmartaminen,

--- a/server/src/test/kotlin/fi/oph/kitu/OidTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/OidTest.kt
@@ -2,8 +2,7 @@ package fi.oph.kitu
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class OidTest {
     private val validOidString = "1.2.246.562.10.1234567890"
@@ -11,22 +10,22 @@ class OidTest {
 
     @Test
     fun `parsing correctly formatted string as OID succeeds`() {
-        assertNotNull(Oid.valueOf(validOidString))
+        assertTrue(Oid.parse(validOidString).isSuccess)
     }
 
     @Test
-    fun `parsing incorrectly formatted string as OID returns NULL`() {
-        assertNull(Oid.valueOf(nonValidOidString))
+    fun `parsing incorrectly formatted string as OID returns a failure`() {
+        assertTrue(Oid.parse(nonValidOidString).isFailure)
     }
 
     @Test
     fun `converting OID to string yields a correctly formatted OID string`() {
-        assertEquals(validOidString, Oid.valueOf(validOidString).toString())
+        assertEquals(validOidString, Oid.parse(validOidString).getOrThrow().toString())
     }
 
     @Test
     fun `implicit toString yields a correctly formatted OID string`() {
-        val oid = Oid.valueOf(validOidString)
+        val oid = Oid.parse(validOidString).getOrThrow()
         val string = "$oid"
         assertEquals(validOidString, string)
     }

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -32,7 +32,7 @@ class CsvParsingTest {
 
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
-        assertEquals(Oid.valueOf("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
+        assertEquals(Oid.parse("1.2.246.562.24.20281155246").getOrNull(), suoritus.suorittajanOID)
         assertEquals("010180-9026", suoritus.hetu)
         assertEquals(Sukupuoli.N, suoritus.sukupuoli)
         assertEquals("Öhman-Testi", suoritus.sukunimi)
@@ -47,7 +47,7 @@ class CsvParsingTest {
         assertEquals("2024-09-01", suoritus.tutkintopaiva.format(dateFormatter))
         assertEquals(Tutkintokieli.FIN, suoritus.tutkintokieli)
         assertEquals(Tutkintotaso.YT, suoritus.tutkintotaso)
-        assertEquals(Oid.valueOf("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
+        assertEquals(Oid.parse("1.2.246.562.10.14893989377").getOrNull(), suoritus.jarjestajanOID)
         assertEquals("Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus", suoritus.jarjestajanNimi)
         assertEquals("2024-11-14", suoritus.arviointipaiva.format(dateFormatter))
         assertEquals(5, suoritus.tekstinYmmartaminen)
@@ -126,7 +126,7 @@ class CsvParsingTest {
 
         val datePattern = "yyyy-MM-dd"
         val dateFormatter = DateTimeFormatter.ofPattern(datePattern)
-        assertEquals(Oid.valueOf("1.2.246.562.24.20281155246"), suoritus.suorittajanOID)
+        assertEquals(Oid.parse("1.2.246.562.24.20281155246").getOrNull(), suoritus.suorittajanOID)
         assertEquals("010180-9026", suoritus.hetu)
         assertEquals(Sukupuoli.N, suoritus.sukupuoli)
         assertEquals("Öhman-Testi", suoritus.sukunimi)
@@ -141,7 +141,7 @@ class CsvParsingTest {
         assertEquals("2024-09-01", suoritus.tutkintopaiva.format(dateFormatter))
         assertEquals(Tutkintokieli.FIN, suoritus.tutkintokieli)
         assertEquals(Tutkintotaso.YT, suoritus.tutkintotaso)
-        assertEquals(Oid.valueOf("1.2.246.562.10.14893989377"), suoritus.jarjestajanOID)
+        assertEquals(Oid.parse("1.2.246.562.10.14893989377").getOrNull(), suoritus.jarjestajanOID)
         assertEquals("Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus", suoritus.jarjestajanNimi)
         assertEquals("2024-11-14", suoritus.arviointipaiva.format(dateFormatter))
         assertEquals(5, suoritus.tekstinYmmartaminen)
@@ -197,7 +197,7 @@ class CsvParsingTest {
     }
 
     @Test
-    fun `safe parsing returns valid throws`() {
+    fun `safe parsing returns valid rows`() {
         val event = MockEvent()
         val parser = CsvParser(event)
         val csv =
@@ -210,8 +210,8 @@ class CsvParsingTest {
 
         val (data, errors) = parser.safeConvertCsvToData<YkiSuoritusCsv>(csv)
 
-        assertTrue(data.size == 3)
-        assertTrue(errors.size == 1)
+        assertEquals(3, data.size)
+        assertEquals(1, errors.size)
     }
 
     @Test
@@ -222,7 +222,7 @@ class CsvParsingTest {
         val writable =
             listOf(
                 YkiSuoritusCsv(
-                    suorittajanOID = Oid.valueOfOrThrow("1.2.246.562.24.20281155246"),
+                    suorittajanOID = Oid.parse("1.2.246.562.24.20281155246").getOrThrow(),
                     hetu = "010180-9026",
                     sukupuoli = Sukupuoli.N,
                     sukunimi = "Öhman-Testi",
@@ -237,7 +237,7 @@ class CsvParsingTest {
                     tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                     tutkintokieli = Tutkintokieli.FIN,
                     tutkintotaso = Tutkintotaso.YT,
-                    jarjestajanOID = Oid.valueOfOrThrow("1.2.246.562.10.14893989377"),
+                    jarjestajanOID = Oid.parse("1.2.246.562.10.14893989377").getOrThrow(),
                     jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
                     arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                     tekstinYmmartaminen = 5,
@@ -273,7 +273,7 @@ class CsvParsingTest {
         val writable =
             listOf(
                 YkiSuoritusCsv(
-                    suorittajanOID = Oid.valueOfOrThrow("1.2.246.562.24.20281155246"),
+                    suorittajanOID = Oid.parse("1.2.246.562.24.20281155246").getOrThrow(),
                     hetu = "010180-9026",
                     sukupuoli = Sukupuoli.N,
                     sukunimi = "Öhman-Testi",
@@ -288,7 +288,7 @@ class CsvParsingTest {
                     tutkintopaiva = LocalDate.parse("2024-09-01", dateFormatter),
                     tutkintokieli = Tutkintokieli.FIN,
                     tutkintotaso = Tutkintotaso.YT,
-                    jarjestajanOID = Oid.valueOfOrThrow("1.2.246.562.10.14893989377"),
+                    jarjestajanOID = Oid.parse("1.2.246.562.10.14893989377").getOrThrow(),
                     jarjestajanNimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
                     arviointipaiva = LocalDate.parse("2024-11-14", dateFormatter),
                     tekstinYmmartaminen = null,

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
@@ -131,7 +131,7 @@ class KoealustaServiceTests(
             actual = mervi.coursename,
         )
         assertEquals(
-            expected = Oid.valueOf("1.2.246.562.10.1234567890"),
+            expected = Oid.parse("1.2.246.562.10.1234567890").getOrThrow(),
             actual = mervi.schoolOid,
         )
     }


### PR DESCRIPTION
Siirretään vastuu virheenkäsittelystä parsintalogiikalta kutsujalle, jolloin kutsujan tulee itse tehdä tietoinen valinta miten virhe tulee käsitellä tai voidaanko se jättää käsittelemättä.

Toteutus käyttää tähän Kotlinin standardikijaston `Result<T>`-tyyppiä. Tämä jakaa jonkin verran mielipiteitä, ja varsinaista konsensusta `Result`-tyypin käytön puolesta tai vastaan on hieman hankala löytää. En kuitenkaan halua tuoda tässä kohtaa mukaan mitään fp-mehusteluhassuttelu-kirjastoja uusiksi riippuvuuksiksi, joten tämä lienee tässä yhteydessä ihan järkeenkäypä kokeilu.

Nämä muutokset itsessään ovat melko mitäänsanomattomia (`Oid.valueOfOrThrow(oidStr)` -> `Oid.parse(oidStr).getOrThrow()`), mutta mahdollistavat `Result`-pohjaisen toteutuksen muualla.

Lisää draftailua `Result`-pohjaisesta validaatiologiikasta #954:ssa, näiden muutosten päälle toteutettuna.