### PR TITLE
Make deploys faster

### DIFF
--- a/infra/lib/service-stack.ts
+++ b/infra/lib/service-stack.ts
@@ -1,4 +1,11 @@
-import { aws_ecs, aws_secretsmanager, Stack, StackProps } from "aws-cdk-lib"
+import * as cdk from "aws-cdk-lib"
+import {
+  aws_ecs,
+  aws_secretsmanager,
+  Duration,
+  Stack,
+  StackProps,
+} from "aws-cdk-lib"
 import {
   Certificate,
   CertificateValidation,
@@ -27,7 +34,6 @@ import { ITopic } from "aws-cdk-lib/aws-sns"
 import { Construct } from "constructs"
 import { ManagedPolicy } from "aws-cdk-lib/aws-iam"
 import * as s3 from "aws-cdk-lib/aws-s3"
-import * as cdk from "aws-cdk-lib"
 
 export interface ServiceStackProps extends StackProps {
   auditLogGroup: ILogGroup
@@ -147,6 +153,7 @@ export class ServiceStack extends Stack {
       },
       cpu: 1024,
       memoryLimitMiB: 2048,
+      healthCheckGracePeriod: Duration.seconds(15),
       circuitBreaker: {
         enable: true,
         rollback: true,
@@ -159,16 +166,31 @@ export class ServiceStack extends Stack {
       sslPolicy: SslPolicy.RECOMMENDED_TLS,
     })
 
+    // The default target group health check for ALBs is {healthyThresholdCount: 5, interval: Duration.seconds(30)}.
+    // This means that a deployment takes at least 5*30 seconds = 2 minutes 30 seconds per container.
+    // Let's go faster.
+    this.service.targetGroup.configureHealthCheck({
+      enabled: true,
+      healthyThresholdCount: 2,
+      interval: Duration.seconds(10),
+      path: "/actuator/health",
+    })
+
+    // The default load balancer configuration waits 300 seconds (5 minutes) before moving a container to UNUSED state.
+    // This means that a deployment can take 300 seconds to wait for a container to shut down.
+    // This value should be low enough that deployments are fast, and high enough that any large file transfers succeed.
+    // This only affects connections that are open when a new deployment occurs.
+    // Let's go faster.
+    this.service.targetGroup.setAttribute(
+      "deregistration_delay.timeout_seconds",
+      "5",
+    )
+
     this.service.taskDefinition.addContainer("AwsOtelCollector", {
       image: ContainerImage.fromRegistry(
         // renovate: datasource=docker
         "public.ecr.aws/aws-observability/aws-otel-collector:v0.43.0",
       ),
-    })
-
-    this.service.targetGroup.configureHealthCheck({
-      ...this.service.targetGroup.healthCheck,
-      path: "/actuator/health",
     })
 
     props.auditLogGroup.grantWrite(this.service.service.taskDefinition.taskRole)


### PR DESCRIPTION
It currently takes ~four and a half minutes to deploy the koto-rekisteri container to each environment. We can make that faster by fiddling with the load balancer configuration, which by default is very conservative.

This is a new version of #915, fixing the following issues:

- The target group health check interval has to be longer than the timeout. The default timeout is 5 seconds (not documented in the CDK API, but [available here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html#health-check-settings)), so this PR sets the interval to 10 seconds.
- This PR sets the `deregistration_delay.timeout_seconds` attribute correctly on the target group, not on the load balancer.