### PR TITLE
Use `Result<T>` for oppijanumero queries

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/ResultExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ResultExtensions.kt
@@ -1,0 +1,7 @@
+package fi.oph.kitu
+
+inline fun <T, R> Result<T>.flatMap(transform: (T) -> Result<R>): Result<R> =
+    fold(
+        onSuccess = { value -> transform(value) },
+        onFailure = { error -> Result.failure<R>(error) },
+    )

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroService.kt
@@ -12,7 +12,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
 interface OppijanumeroService {
-    fun getOppijanumero(oppija: Oppija): String
+    fun getOppijanumero(oppija: Oppija): Result<String>
 }
 
 @Service
@@ -25,7 +25,7 @@ class OppijanumeroServiceImpl(
     @Value("\${kitu.oppijanumero.service.url}")
     lateinit var serviceUrl: String
 
-    override fun getOppijanumero(oppija: Oppija): String =
+    override fun getOppijanumero(oppija: Oppija): Result<String> =
         logger
             .atInfo()
             .withEventAndPerformanceCheck { event ->
@@ -79,7 +79,7 @@ class OppijanumeroServiceImpl(
                 return@withEventAndPerformanceCheck body.oppijanumero
             }.apply {
                 addDefaults("getOppijanumero")
-            }.getOrThrow()
+            }.result
 
     /**
      * Tries to convert HttpResponse<String> into the given T.

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
@@ -51,12 +51,12 @@ class KoealustaServiceTests(
                     {
                       "users": [
                         {
-                          "firstnames": "Mervi-Marianne",
-                          "lastname": "Esimerkki",
-                          "preferredname": "Mervi", 
-                          "oppijanumero": "",
+                          "firstnames": "Ranja Testi",
+                          "lastname": "\u00f6hman-Testi",
+                          "preferredname": "Ranja", 
+                          "oppijanumero": "1.2.246.562.24.33342764709",
                           "SSN": "12345678901",
-                          "email": "mervi.esimerkki@oph.fi",
+                          "email": "ranja.testi@oph.fi",
                           "completions": [
                             {
                               "courseid": 32,
@@ -124,15 +124,15 @@ class KoealustaServiceTests(
             actual = lastSeen,
         )
 
-        val mervi = kielitestiSuoritusRepository.findById(1).get()
+        val ranja = kielitestiSuoritusRepository.findById(1).get()
 
         assertEquals(
             expected = "Integraatio testaus",
-            actual = mervi.coursename,
+            actual = ranja.coursename,
         )
         assertEquals(
             expected = Oid.parse("1.2.246.562.10.1234567890").getOrThrow(),
-            actual = mervi.schoolOid,
+            actual = ranja.schoolOid,
         )
     }
 }

--- a/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceMock.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceMock.kt
@@ -3,5 +3,5 @@ package fi.oph.kitu.oppijanumero
 class OppijanumeroServiceMock(
     private val oppijanumero: String,
 ) : OppijanumeroService {
-    override fun getOppijanumero(oppija: Oppija) = this.oppijanumero
+    override fun getOppijanumero(oppija: Oppija) = Result.success(this.oppijanumero)
 }

--- a/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceTests.kt
@@ -2,13 +2,17 @@ package fi.oph.kitu.oppijanumero
 
 import HttpResponseMock
 import com.fasterxml.jackson.databind.ObjectMapper
+import fi.oph.kitu.Oid
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
 
 class OppijanumeroServiceTests {
     @Test
     fun `oppijanumero service returns identified user`() {
         // Facade
+        val expectedOppijanumero = Oid.parse("1.2.246.562.24.33342764709").getOrThrow()
         val response =
             Result.success(
                 HttpResponseMock(
@@ -17,7 +21,7 @@ class OppijanumeroServiceTests {
                         """
                         {
                             "oid": "1.2.246.562.24.33342764709",
-                            "oppijanumero": "1.2.246.562.24.33342764709"
+                            "oppijanumero": "$expectedOppijanumero"
                         }
                         """.trimIndent(),
                 ),
@@ -31,14 +35,19 @@ class OppijanumeroServiceTests {
             )
         oppijanumeroService.serviceUrl = "http://localhost:8080/oppijanumero-service"
 
-        oppijanumeroService.getOppijanumero(
-            Oppija(
-                "Magdalena Testi",
-                "Sallinen-Testi",
-                "Magdalena",
-                "010866-9260",
-            ),
-        )
+        val result =
+            assertDoesNotThrow {
+                oppijanumeroService
+                    .getOppijanumero(
+                        Oppija(
+                            "Magdalena Testi",
+                            "Sallinen-Testi",
+                            "Magdalena",
+                            "010866-9260",
+                        ),
+                    ).getOrThrow()
+            }
+        assertEquals(expectedOppijanumero.toString(), result)
     }
 
     @Test
@@ -67,14 +76,15 @@ class OppijanumeroServiceTests {
         oppijanumeroService.serviceUrl = "http://localhost:8080/oppijanumero-service"
 
         assertThrows<OppijanumeroException.OppijaNotIdentifiedException> {
-            oppijanumeroService.getOppijanumero(
-                Oppija(
-                    "Magdalena Testi",
-                    "Sallinen-Testi",
-                    "Magdalena",
-                    "010866-9260",
-                ),
-            )
+            oppijanumeroService
+                .getOppijanumero(
+                    Oppija(
+                        "Magdalena Testi",
+                        "Sallinen-Testi",
+                        "Magdalena",
+                        "010866-9260",
+                    ),
+                ).getOrThrow()
         }
     }
 
@@ -106,14 +116,15 @@ class OppijanumeroServiceTests {
         oppijanumeroService.serviceUrl = "http://localhost:8080/oppijanumero-service"
 
         assertThrows<OppijanumeroException.OppijaNotFoundException> {
-            oppijanumeroService.getOppijanumero(
-                Oppija(
-                    "Magdalena Testi",
-                    "Sallinen-Testi",
-                    "Magdalena",
-                    "010866-9260",
-                ),
-            )
+            oppijanumeroService
+                .getOppijanumero(
+                    Oppija(
+                        "Magdalena Testi",
+                        "Sallinen-Testi",
+                        "Magdalena",
+                        "010866-9260",
+                    ),
+                ).getOrThrow()
         }
     }
 }


### PR DESCRIPTION
Mahdollistetaan aavistuksen siistimpi virheenhallinta `KoealustaMappingService`:ssa palauttamalla oppijanumeroiden hakuoperaatioista `Result<String>` raa'an `String` sijasta.

Koska `OppijanumeroService` on käytössä vain `KoealustaMappingService`:ssa, tämä muutos on melko suoraviivainen. Parantelin samoilla lämpimillä `OppijanumeroService`:n testejä hieman.

Tämä muutos on seurausta käytännön esimerkistä miksi "piilotetut" virhetilanteet ovat helppo tapa ampua itseään jalkaan; #954 kanssa työskennellessä, `oppijanumero` haku oli pitkään hieman yksinkertaisempi (joskin rikki), sillä en huomannut että `toOppija(user)` voi heittää validaatiovirheen:
```kt
try {
    oppijanumeroService.getOppijanumero(toOppija(user))
}
/* snip */
```
_(mitä kaikkia virheitä `catch`:ssa kuuluu käsitellä?)_

Tämän PR:n muutoksilla myös `toOppija` palauttaa `Result<Oppija>`, jolloin virheen mahdollisuus ei voi jäädä huomaamatta. Tämä kuitenkin monimutkaistaa tilannetta hieman, sillä nyt `Result<Oppija>`:lla pitäisi saada tehtyä `getOppijanumero`-haku.

Tästä syystä, virheenkäsittelyä helpottamaan on lisätty vielä laajennosfunktio `fun <T,R> Result<T>.flatMap(..): Result<R>`, joka helpottaa virheenkäsittelyputkien kirjoittelua juurikin tällaisissa tilanteissa, joissa jonkin `Result`:n success-arvolla halutaan tehdä jotain, joka sekin palauttaa `Result`. Tässä tapauksessa `Result<Oppija>`:lla halutaan tehdä oppijanumerohaku, joka palauttaa `Result<String>`. Tämän kirjoittaminen ilman `flatMap` on jokseenkin työlästä, mutta yksinkertaistuu nyt mukavasti:
```kt
// Ilman .flatMap:
toOppija(user)
    .fold(
        onSuccess = { value ->
            oppijanumeroService.getOppijanumero(value)
        },
        onFailure = { throwable ->
            Result.failure(throwable)
        }
    )

// ...joka on sama kuin:
toOppija(user).flatMap { oppijanumeroService.getOppijanumero(it) }
```

Kun bisneslogiikka on yhdessä putkessa, virheenkäsittely tapahtuu lopussa melko tiiviisti ja selkeästi:
```kt
.onFailure {
    when (it) {
        // Käsitellään validaatiovirheet ja epäonnistuneet ONR-hakuoperaatiot 
        is Error.OppijaValidationFailure -> validationErrors.addAll(it.validationErrors)
        is OppijanumeroException -> oppijanumeroExceptions.add(it)
        // Odottamaton virhe? There be dragons, turvallisinta keskeyttää operaatio välittömästi.  
        else -> throw it
    }
}
```