### PR TITLE
General validation functions for Koealusta quiz completion results

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/ResultExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ResultExtensions.kt
@@ -5,3 +5,9 @@ inline fun <T, R> Result<T>.flatMap(transform: (T) -> Result<R>): Result<R> =
         onSuccess = { value -> transform(value) },
         onFailure = { error -> Result.failure<R>(error) },
     )
+
+inline fun <T> Result<T>.mapFailure(transform: (Throwable) -> Throwable): Result<T> =
+    fold(
+        onSuccess = { value -> Result.success(value) },
+        onFailure = { throwable -> Result.failure(transform(throwable)) },
+    )


### PR DESCRIPTION
Kaikki `Completion.Result` -validaatiofunktiot tekivät käytännössä samaa asiaa. Ainoat muuttuvat osat olivat käytännössä `Result::name` ja `quiz_result_system` pakollisuus. Tämän abstraktointi yleiseen validaatiofunktioon oli suoraviivaista.

Yhtenäistetyn validaatiofunktion lisäksi, oli helpohko homma refaktoroida virheenkäsittely tässäkin tilanteessa palauttamaan `Result<Completion.Result>`, poikkeuksen heittämisen sijaan.

Jotta virheenkäsittely `completionToEntity`:ssa olisi muutenkin yhteneväistä, refaktoroin myös muiden kenttien validaatiot samanmuotoisiksi, lisäämällä `validate`-funktiosta näille sopivat versiot.

Null-tarkistukset oli aiemmin jätetty tekemättä, sillä käytännössä validaatiofunktiosta palautuva arvo on riittävä tae, että arvojen tulisi olla olemassa. Tähän tarkistuksien "ohitukseen" käytettiin double-bang `!!`-operaattoria. Olen näissä muutoksissa toteuttanut tämän hieman verboosimmin, käyttäen `checkNotNull`-tarkistuksia `!!`-operaattorin sijasta. Ajatuksena tässä on tuoda alla olevat oletukset datan eheydestä hieman eksplisiittisemmin esiin. Tämä on hieman olennaisempaa loppujen #954 muutoksien yhteydessä.