### PR TITLE
feat(yki) UI cleaner UI table version 2

### DIFF
--- a/e2e/fixtures/kotoSuoritus.ts
+++ b/e2e/fixtures/kotoSuoritus.ts
@@ -2,6 +2,7 @@ import SQL from "sql-template-strings"
 import { TestDB } from "./baseFixture"
 
 export type Oid = `${number}.${number}.${number}.${number}.${number}.${number}`
+export type OidQuoted = `"${Oid}"`
 export type Email = `${string}@${string}.${string}`
 
 export interface KotoSuoritus {

--- a/e2e/fixtures/ykiSuoritusError.ts
+++ b/e2e/fixtures/ykiSuoritusError.ts
@@ -3,7 +3,7 @@ import { TestDB } from "./baseFixture"
 import { OidQuoted } from "./kotoSuoritus"
 
 export interface YkiSuoritusError {
-  oid: OidQuoted | undefined
+  suorittajanOid: OidQuoted | undefined
   hetu: string | undefined
   nimi: string | undefined
   lastModified: string | undefined
@@ -16,7 +16,7 @@ export interface YkiSuoritusError {
 
 export const fixtureData = {
   missingOid: {
-    oid: undefined,
+    suorittajanOid: undefined,
     hetu: '"010180-9026"',
     nimi: '"Öhman-Testi" "Ranja Testi"',
     lastModified: "2024-10-30 13:53:56",
@@ -28,7 +28,7 @@ export const fixtureData = {
     virheenLuontiaika: "2025-03-27 07:29:53",
   } as YkiSuoritusError,
   invalidGender: {
-    oid: '"1.2.246.562.24.59267607404"',
+    suorittajanOid: '"1.2.246.562.24.59267607404"',
     hetu: '"010116A9518"',
     nimi: '"Kivinen-Testi" "Petro Testi"',
     lastModified: "2024-10-30 13:55:09",
@@ -43,7 +43,7 @@ export const fixtureData = {
 
 const insertQuery = (error: YkiSuoritusError) => SQL`
   INSERT INTO yki_suoritus_error(
-    oid,
+    suorittajan_oid,
     hetu,
     nimi,
     last_modified,
@@ -52,7 +52,7 @@ const insertQuery = (error: YkiSuoritusError) => SQL`
     virheellinen_rivi,
     virheen_rivinumero,
     virheen_luontiaika
-  ) VALUES (${error.oid},
+  ) VALUES (${error.suorittajanOid},
             ${error.hetu},
             ${error.nimi},
             ${error.lastModified},

--- a/e2e/fixtures/ykiSuoritusError.ts
+++ b/e2e/fixtures/ykiSuoritusError.ts
@@ -1,48 +1,66 @@
 import SQL from "sql-template-strings"
 import { TestDB } from "./baseFixture"
+import { OidQuoted } from "./kotoSuoritus"
 
 export interface YkiSuoritusError {
-  message: string
-  context: string
-  exception_message: string
-  stack_trace: string
-  created: string
-}
-
-const toTimestamp = (date: Date): string => {
-  const yyyy = date.getFullYear()
-  const MM = date.getMonth() + 1
-  const dd = date.getDate()
-  const hh = date.getHours()
-  const mm = date.getMinutes()
-  const ss = date.getSeconds()
-
-  // "yyyy-MM-dd HH:mm:ss"
-  return `${yyyy}-${MM}-${dd} ${hh}:${mm}:${ss}`
+  oid: OidQuoted | undefined
+  hetu: string | undefined
+  nimi: string | undefined
+  lastModified: string | undefined
+  virheellinenKentta: string | undefined
+  virheellinenArvo: string | undefined
+  virheellinenRivi: string
+  virheenRivinumero: number
+  virheenLuontiaika: string
 }
 
 export const fixtureData = {
-  first: {
-    message: "An error was occurred",
-    context: "1,2,3,4,5,6,7,8,9",
-    exception_message: "RuntimeException",
-    stack_trace: "at ykiSuoritusError",
-    created: toTimestamp(new Date()),
-  },
+  missingOid: {
+    oid: undefined,
+    hetu: '"010180-9026"',
+    nimi: '"Öhman-Testi" "Ranja Testi"',
+    lastModified: "2024-10-30 13:53:56",
+    virheellinenKentta: undefined,
+    virheellinenArvo: undefined,
+    virheellinenRivi:
+      ',"010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,',
+    virheenRivinumero: 2,
+    virheenLuontiaika: "2025-03-27 07:29:53",
+  } as YkiSuoritusError,
+  invalidSex: {
+    oid: '"1.2.246.562.24.59267607404"',
+    hetu: '"010116A9518"',
+    nimi: '"Kivinen-Testi" "Petro Testi"',
+    lastModified: "2024-10-30 13:55:09",
+    virheellinenKentta: "sukupuoli",
+    virheellinenArvo: "CORRUPTED",
+    virheellinenRivi:
+      '"1.2.246.562.24.59267607404","010116A9518","CORRUPTED","Kivinen-Testi","Petro Testi","","Testikuja 10","40100","Testinsuu","testi.petro@testi.fi",183425,2024-10-30T13:55:09Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-10-30,6,6,,6,6,,,,0,0,,',
+    virheenRivinumero: 3,
+    virheenLuontiaika: "2025-03-27 07:29:53",
+  } as YkiSuoritusError,
 }
 
 const insertQuery = (error: YkiSuoritusError) => SQL`
   INSERT INTO yki_suoritus_error(
-      message,
-      context,
-      exception_message,
-      stack_trace,
-      created
-  ) VALUES (${error.message},
-            ${error.context},
-            ${error.exception_message},
-            ${error.stack_trace},
-            ${error.created})
+    oid,
+    hetu,
+    nimi,
+    last_modified,
+    virheellinen_kentta,
+    virheellinen_arvo,
+    virheellinen_rivi,
+    virheen_rivinumero,
+    virheen_luontiaika
+  ) VALUES (${error.oid},
+            ${error.hetu},
+            ${error.nimi},
+            ${error.lastModified},
+            ${error.virheellinenKentta},
+            ${error.virheellinenArvo},
+            ${error.virheellinenRivi},
+            ${error.virheenRivinumero},
+            ${error.virheenLuontiaika})
 `
 
 export type YkiSuorittajaErrorName = keyof typeof fixtureData

--- a/e2e/fixtures/ykiSuoritusError.ts
+++ b/e2e/fixtures/ykiSuoritusError.ts
@@ -27,7 +27,7 @@ export const fixtureData = {
     virheenRivinumero: 2,
     virheenLuontiaika: "2025-03-27 07:29:53",
   } as YkiSuoritusError,
-  invalidSex: {
+  invalidGender: {
     oid: '"1.2.246.562.24.59267607404"',
     hetu: '"010116A9518"',
     nimi: '"Kivinen-Testi" "Petro Testi"',

--- a/e2e/tests/yki/yki-suoritukset-error.spec.ts
+++ b/e2e/tests/yki/yki-suoritukset-error.spec.ts
@@ -6,7 +6,7 @@ describe('"YKI Suoritukset" -page', () => {
   beforeEach(async ({ db, basePage, ykiSuoritusError }) => {
     await db.withEmptyDatabase()
 
-    await ykiSuoritusError.insert(db, "first")
+    await ykiSuoritusError.insert(db, "missingOid")
 
     await basePage.login()
   })

--- a/e2e/tests/yki/yki-suoritukset.spec.ts
+++ b/e2e/tests/yki/yki-suoritukset.spec.ts
@@ -9,7 +9,8 @@ describe('"YKI Suoritukset" -page', () => {
     await ykiSuoritus.insert(db, "ranja")
     await ykiSuoritus.insert(db, "ranjaTarkistus")
     await ykiSuoritus.insert(db, "petro")
-    await ykiSuoritusError.insert(db, "first")
+    await ykiSuoritusError.insert(db, "missingOid")
+    //await ykiSuoritusError.insert(db, "invalidSex")
 
     await basePage.login()
   })

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -10,7 +10,7 @@ class InvalidFormatCsvExportError(
     val field = exception.path.firstOrNull()?.fieldName ?: ""
 
     init {
-        keyValues.addAll(
+        keyValues.putAll(
             listOf(
                 "value" to exception.value,
                 "path" to exception.path,
@@ -33,7 +33,7 @@ abstract class CsvExportError(
     val exception: Throwable,
 ) {
     val keyValues =
-        mutableListOf<Pair<String, Any>>(
+        mutableMapOf<String, Any>(
             "lineNumber" to lineNumber,
             "exception" to exception,
         )

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -7,12 +7,15 @@ class InvalidFormatCsvExportError(
     context: String?,
     exception: InvalidFormatException,
 ) : CsvExportError(lineNumber, context, exception) {
+    val field = exception.path.firstOrNull()?.fieldName ?: ""
+
     init {
         keyValues.addAll(
             listOf(
                 "value" to exception.value,
                 "path" to exception.path,
                 "targetType" to exception.targetType,
+                "field" to field,
             ),
         )
     }

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvExportError.kt
@@ -7,7 +7,7 @@ class InvalidFormatCsvExportError(
     context: String?,
     exception: InvalidFormatException,
 ) : CsvExportError(lineNumber, context, exception) {
-    val field = exception.path.firstOrNull()?.fieldName ?: ""
+    private val fieldWithValidationError = exception.path.firstOrNull()?.fieldName ?: ""
 
     init {
         keyValues.putAll(
@@ -15,7 +15,7 @@ class InvalidFormatCsvExportError(
                 "value" to exception.value,
                 "path" to exception.path,
                 "targetType" to exception.targetType,
-                "field" to field,
+                "fieldWithValidationError" to fieldWithValidationError,
             ),
         )
     }

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
@@ -97,7 +97,7 @@ class CsvParser(
         val csvMapper = getCsvMapper<T>()
         val schema = getSchema<T>(csvMapper)
         val lineSeparator =
-            only(schema.lineSeparator)
+            onlyOrNull(schema.lineSeparator)
                 ?: throw IllegalStateException(
                     "Can't find only one line seperator from schema (${schema.lineSeparator}).",
                 )
@@ -151,8 +151,8 @@ class CsvParser(
     }
 }
 
-/** Returns the only element in the object or throws an exception */
-fun only(list: CharArray): Char? = if (list.isEmpty() || list.size != 1) null else list[0]
+/** Returns the only element in the object or null */
+fun onlyOrNull(list: CharArray): Char? = if (list.isEmpty() || list.size != 1) null else list[0]
 
 fun <T> MappingIterator<T>.toDataWithErrorHandling(
     onFailure: (index: Int, exception: Throwable) -> Unit = { _, _ -> },

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
@@ -129,7 +129,7 @@ class CsvParser(
         errors.forEachIndexed { i, error ->
             event.add("serialization.error[$i].index" to i)
             for (kvp in error.keyValues) {
-                event.add("serialization.error[$i].${kvp.first}" to kvp.second)
+                event.add("serialization.error[$i].${kvp.key}" to kvp.value)
             }
         }
 

--- a/server/src/main/kotlin/fi/oph/kitu/dev/YkiController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/dev/YkiController.kt
@@ -52,6 +52,8 @@ class YkiController(
             """
             "1.2.246.562.24.20281155246","010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-12-13T07:10:13Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-12-13,5,5,,5,5,,2024-12-14,"OPH-5000-1234",1,1,"Suorituksesta jäänyt viimeinen tehtävä arvioimatta. Arvioinnin jälkeen puhumisen taitotasoa 6.",2024-12-14
             "1.2.246.562.24.59267607404","010116A9518","M","Kivinen-Testi","Petro Testi","EST","Testikuja 10","40100","Testinsuu","testi.petro@testi.fi",183425,2024-12-13T06:54:38Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-12-09,6,6,,6,6,,2024-11-01,"OPH-5002-2024",4,0,,2024-12-09
+            ,"010180-9026","N","Öhman-Testi","Ranja Testi","EST","Testikuja 5","40100","Testilä","testi@testi.fi",183424,2024-10-30T13:53:56Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-11-14,5,5,,5,5,,,,0,0,,
+            "1.2.246.562.24.59267607404","010116A9518","CORRUPTED","Kivinen-Testi","Petro Testi","","Testikuja 10","40100","Testinsuu","testi.petro@testi.fi",183425,2024-10-30T13:55:09Z,2024-09-01,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",2024-10-30,6,6,,6,6,,,,0,0,,
             """.trimIndent(),
         )
 }

--- a/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
@@ -1,5 +1,49 @@
 package fi.oph.kitu.mock
 
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusMappingService
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorEntity
+import java.time.Instant
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 
-fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity = TODO()
+fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity {
+    val lastModified = getRandomInstant(Instant.parse("2004-01-01T00:00:00Z"))
+    val virheenLuontiaika = getRandomInstant(lastModified)
+    val virheellinenKentta = YkiSuoritusCsv::class.memberProperties.random().name
+
+    val suoritusEntity = generateRandomYkiSuoritusEntity()
+
+    val csv =
+        try {
+            YkiSuoritusMappingService()
+                .convertToResponse(suoritusEntity)
+                .toCsvString()
+        } catch (e: Throwable) {
+            println(e)
+            throw e
+        }
+
+    return YkiSuoritusErrorEntity(
+        id = null,
+        oid = suoritusEntity.suorittajanOID,
+        hetu = suoritusEntity.hetu,
+        nimi = "${suoritusEntity.sukunimi} ${suoritusEntity.etunimet}",
+        lastModified = lastModified,
+        virheellinenKentta = virheellinenKentta,
+        virheellinenArvo = "virheellinen_arvo",
+        virheellinenRivi = csv,
+        virheenRivinumero = (0..1000).random(),
+        virheenLuontiaika = virheenLuontiaika,
+    )
+}
+
+fun YkiSuoritusCsv.toCsvString(): String =
+    this::class
+        .memberProperties
+        .onEach { it.isAccessible = true }
+        .joinToString(separator = ",") {
+            @Suppress("UNCHECKED_CAST")
+            (it as KProperty1<YkiSuoritusCsv, *>).get(this).toString()
+        }

--- a/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
@@ -15,15 +15,7 @@ fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity {
 
     val suoritusEntity = generateRandomYkiSuoritusEntity()
 
-    val csv =
-        try {
-            YkiSuoritusMappingService()
-                .convertToResponse(suoritusEntity)
-                .toCsvString()
-        } catch (e: Throwable) {
-            println(e)
-            throw e
-        }
+    val csv = YkiSuoritusMappingService().convertToResponse(suoritusEntity).toCsvString()
 
     return YkiSuoritusErrorEntity(
         id = null,

--- a/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
@@ -4,9 +4,7 @@ import fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusMappingService
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorEntity
 import java.time.Instant
-import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.isAccessible
 
 fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity {
     val lastModified = getRandomInstant(Instant.parse("2004-01-01T00:00:00Z"))
@@ -32,10 +30,33 @@ fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity {
 }
 
 fun YkiSuoritusCsv.toCsvString(): String =
-    this::class
-        .memberProperties
-        .onEach { it.isAccessible = true }
-        .joinToString(separator = ",") {
-            @Suppress("UNCHECKED_CAST")
-            (it as KProperty1<YkiSuoritusCsv, *>).get(this).toString()
-        }
+    this.suorittajanOID.toString() + "," +
+        this.hetu + "," +
+        this.sukupuoli + "," +
+        this.sukunimi + "," +
+        this.etunimet + "," +
+        this.kansalaisuus + "," +
+        this.katuosoite + "," +
+        this.postinumero + "," +
+        this.postitoimipaikka + "," +
+        this.email + "," +
+        this.suoritusID + "," +
+        this.lastModified + "," +
+        this.tutkintopaiva + "," +
+        this.tutkintokieli + "," +
+        this.tutkintotaso + "," +
+        this.jarjestajanOID + "," +
+        this.jarjestajanNimi + "," +
+        this.arviointipaiva + "," +
+        this.tekstinYmmartaminen + "," +
+        this.kirjoittaminen + "," +
+        this.rakenteetJaSanasto + "," +
+        this.puheenYmmartaminen + "," +
+        this.puhuminen + "," +
+        this.yleisarvosana + "," +
+        this.tarkistusarvioinninSaapumisPvm + "," +
+        this.tarkistusarvioinninAsiatunnus + "," +
+        this.tarkistusarvioidutOsakokeet + "," +
+        this.arvosanaMuuttui + "," +
+        this.perustelu + "," +
+        this.tarkistusarvioinninKasittelyPvm

--- a/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
@@ -1,14 +1,5 @@
 package fi.oph.kitu.mock
 
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorEntity
-import java.time.Instant
 
-fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity =
-    YkiSuoritusErrorEntity(
-        id = null,
-        message = "An error was occurred!",
-        context = "1,2,3,4,5,6,7,8,9,10",
-        stackTrace = "\tat somewhere\n\tat somewhere",
-        created = Instant.now(),
-        exceptionMessage = "An error was occurred!",
-    )
+fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity = TODO()

--- a/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/YkiSuoritusErrorMock.kt
@@ -27,7 +27,7 @@ fun generateRandomYkiSuoritusErrorEntity(): YkiSuoritusErrorEntity {
 
     return YkiSuoritusErrorEntity(
         id = null,
-        oid = suoritusEntity.suorittajanOID,
+        suorittajanOid = suoritusEntity.suorittajanOID,
         hetu = suoritusEntity.hetu,
         nimi = "${suoritusEntity.sukunimi} ${suoritusEntity.etunimet}",
         lastModified = lastModified,

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiViewController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiViewController.kt
@@ -67,17 +67,14 @@ class YkiViewController(
 
     @GetMapping("/suoritukset/virheet", produces = ["text/html"])
     fun view(
-        sortColumn: YkiSuoritusErrorColumn = YkiSuoritusErrorColumn.Created,
+        sortColumn: YkiSuoritusErrorColumn = YkiSuoritusErrorColumn.VirheenLuontiaika,
         sortDirection: SortDirection = SortDirection.ASC,
-    ): ModelAndView {
-        val mav =
-            ModelAndView("yki-suoritukset-virheet")
-                .addObject("header", generateHeader<YkiSuoritusErrorColumn>(sortColumn, sortDirection))
-                .addObject("sortColumn", sortColumn.lowercaseName())
-                .addObject("sortDirection", sortDirection)
-                .addObject("virheet", errorService.getErrors(sortColumn, sortDirection))
-        return mav
-    }
+    ): ModelAndView =
+        ModelAndView("yki-suoritukset-virheet")
+            .addObject("header", generateHeader<YkiSuoritusErrorColumn>(sortColumn, sortDirection))
+            .addObject("sortColumn", sortColumn.lowercaseName())
+            .addObject("sortDirection", sortDirection)
+            .addObject("virheet", errorService.getErrors(sortColumn, sortDirection))
 
     @GetMapping("/arvioijat")
     fun arvioijatView(

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorColumn.kt
@@ -4,11 +4,15 @@ enum class YkiSuoritusErrorColumn(
     val entityName: String,
     val uiHeaderValue: String,
 ) {
-    Message(entityName = "message", uiHeaderValue = "Viesti"),
-    Context(entityName = "context", uiHeaderValue = "Konteksti"),
-    ExceptionMessage(entityName = "exception", uiHeaderValue = "virhe"),
-    StackTrace(entityName = "stackTrace", uiHeaderValue = "stack trace"),
-    Created(entityName = "created", uiHeaderValue = "luontiaika"),
+    Oid(entityName = "oid", uiHeaderValue = "oi"),
+    Hetu(entityName = "hetu", uiHeaderValue = "hetu"),
+    Nimi(entityName = "nimi", uiHeaderValue = "nimi"),
+    LastModified(entityName = "lastModified", uiHeaderValue = "last modified"),
+    VirheellinenKentta(entityName = "virheellinenKentta", uiHeaderValue = "virheellinen kenttä"),
+    VirheellinenArvo(entityName = "virheellinenArvo", uiHeaderValue = "virheellinen arvo"),
+    VirheellinenRivi(entityName = "virheellinenRivi", uiHeaderValue = "virheellinen rivi"),
+    VirheenRivinumero(entityName = "virheenRivinumero", uiHeaderValue = "virheen rivinumero"),
+    VirheenLuontiaika(entityName = "virheenLuontiaika", uiHeaderValue = "virheen luontiaika"),
     ;
 
     fun lowercaseName(): String = name.lowercase()

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorColumn.kt
@@ -4,7 +4,7 @@ enum class YkiSuoritusErrorColumn(
     val entityName: String,
     val uiHeaderValue: String,
 ) {
-    Oid(entityName = "oid", uiHeaderValue = "oi"),
+    SuorittajanOid(entityName = "suorittajanOid", uiHeaderValue = "oppijanumero"),
     Hetu(entityName = "hetu", uiHeaderValue = "hetu"),
     Nimi(entityName = "nimi", uiHeaderValue = "nimi"),
     LastModified(entityName = "lastModified", uiHeaderValue = "last modified"),

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorEntity.kt
@@ -13,7 +13,7 @@ import java.time.Instant
 data class YkiSuoritusErrorEntity(
     @Id
     val id: Long?,
-    val oid: String?,
+    val suorittajanOid: String?,
     val hetu: String?,
     val nimi: String?,
     val lastModified: Instant?,

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorEntity.kt
@@ -4,13 +4,22 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
 
+/**
+ * Represents Yki Suoritus Error Entity.
+ *
+ * virheelllinenRivi and virheenRivinumero forms a unique constraint.
+ */
 @Table(name = "yki_suoritus_error")
 data class YkiSuoritusErrorEntity(
     @Id
     val id: Long?,
-    val message: String,
-    val context: String,
-    val exceptionMessage: String,
-    val stackTrace: String,
-    val created: Instant,
+    val oid: String?,
+    val hetu: String?,
+    val nimi: String?,
+    val lastModified: Instant?,
+    val virheellinenKentta: String?,
+    val virheellinenArvo: String?,
+    val virheellinenRivi: String,
+    val virheenRivinumero: Int,
+    val virheenLuontiaika: Instant,
 )

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
@@ -6,6 +6,20 @@ import java.time.Instant
 
 @Service
 class YkiSuoritusErrorMappingService {
+    private inline fun <reified T> List<Pair<String, Any>>.getValueByKey(key: String?) =
+        this
+            .filter { it.first == key }
+            .map { it.second }
+            .filterIsInstance<T>()
+            .first()
+
+    private inline fun <reified T> List<Pair<String, Any>>.getValueOrNullByKey(key: String?) =
+        this
+            .filter { it.first == key }
+            .map { it.second }
+            .filterIsInstance<T>()
+            .firstOrNull()
+
     fun convertToEntityIterable(
         iterable: Iterable<CsvExportError>,
         created: Instant = Instant.now(),
@@ -14,12 +28,20 @@ class YkiSuoritusErrorMappingService {
     fun convertToEntity(
         data: CsvExportError,
         created: Instant = Instant.now(),
-    ) = YkiSuoritusErrorEntity(
-        id = null,
-        message = data::class.simpleName!!,
-        context = data.context!!,
-        exceptionMessage = data.exception.message!!,
-        stackTrace = data.exception.stackTrace!!.toString(),
-        created = created,
-    )
+    ): YkiSuoritusErrorEntity {
+        val csv = data.context!!.split(",")
+
+        return YkiSuoritusErrorEntity(
+            id = null,
+            oid = csv[0],
+            hetu = csv[1],
+            nimi = csv[3] + " " + csv[4],
+            lastModified = runCatching { Instant.parse(csv[11]) }.getOrNull(),
+            virheellinenKentta = data.keyValues.getValueOrNullByKey<String>("field"),
+            virheellinenArvo = data.keyValues.getValueOrNullByKey<Any>("value").toString(),
+            virheellinenRivi = data.context,
+            virheenRivinumero = data.keyValues.getValueByKey<Int>("lineNumber"),
+            virheenLuontiaika = Instant.now(),
+        )
+    }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
@@ -19,7 +19,7 @@ class YkiSuoritusErrorMappingService {
 
         return YkiSuoritusErrorEntity(
             id = null,
-            oid = csv[0],
+            suorittajanOid = csv[0],
             hetu = csv[1],
             nimi = csv[3] + " " + csv[4],
             lastModified = runCatching { Instant.parse(csv[11]) }.getOrNull(),

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
@@ -11,6 +11,13 @@ class YkiSuoritusErrorMappingService {
         created: Instant = Instant.now(),
     ) = iterable.map { convertToEntity(it, created) }
 
+    /**
+     * Tries to convert raw CSV data into YkiSuoritusErrorEntity as well as possible.
+     *
+     * The method assumes the data was tried to be converted into an YkiSuoritusEntity and the conversion failed.
+     * Therefore the conversion of this function is done with the best effort. For example, it won't handle
+     * values inside double quotes or commas inside quoted fields correctly.
+     */
     fun convertToEntity(
         data: CsvExportError,
         created: Instant = Instant.now(),

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorMappingService.kt
@@ -6,20 +6,6 @@ import java.time.Instant
 
 @Service
 class YkiSuoritusErrorMappingService {
-    private inline fun <reified T> List<Pair<String, Any>>.getValueByKey(key: String?) =
-        this
-            .filter { it.first == key }
-            .map { it.second }
-            .filterIsInstance<T>()
-            .first()
-
-    private inline fun <reified T> List<Pair<String, Any>>.getValueOrNullByKey(key: String?) =
-        this
-            .filter { it.first == key }
-            .map { it.second }
-            .filterIsInstance<T>()
-            .firstOrNull()
-
     fun convertToEntityIterable(
         iterable: Iterable<CsvExportError>,
         created: Instant = Instant.now(),
@@ -37,10 +23,10 @@ class YkiSuoritusErrorMappingService {
             hetu = csv[1],
             nimi = csv[3] + " " + csv[4],
             lastModified = runCatching { Instant.parse(csv[11]) }.getOrNull(),
-            virheellinenKentta = data.keyValues.getValueOrNullByKey<String>("field"),
-            virheellinenArvo = data.keyValues.getValueOrNullByKey<Any>("value").toString(),
+            virheellinenKentta = data.keyValues["field"]?.toString(),
+            virheellinenArvo = data.keyValues["value"]?.toString(),
             virheellinenRivi = data.context,
-            virheenRivinumero = data.keyValues.getValueByKey<Int>("lineNumber"),
+            virheenRivinumero = data.keyValues["lineNumber"] as Int,
             virheenLuontiaika = Instant.now(),
         )
     }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorService.kt
@@ -49,7 +49,7 @@ class YkiSuoritusErrorService(
         }
 
     fun getErrors(
-        orderBy: YkiSuoritusErrorColumn = YkiSuoritusErrorColumn.Created,
+        orderBy: YkiSuoritusErrorColumn = YkiSuoritusErrorColumn.VirheenLuontiaika,
         orderByDirection: SortDirection = SortDirection.ASC,
     ): List<YkiSuoritusErrorEntity> =
         repository

--- a/server/src/main/resources/db/migration/V28__refactor_yki_suoritus_error_table.sql
+++ b/server/src/main/resources/db/migration/V28__refactor_yki_suoritus_error_table.sql
@@ -4,7 +4,7 @@ DROP TABLE yki_suoritus_error;
 CREATE TABLE yki_suoritus_error
 (
     id                  SERIAL PRIMARY KEY,
-    oid                 TEXT,
+    suorittajan_oid     TEXT,
     hetu                TEXT,
     nimi                TEXT,
     last_modified       TIMESTAMP WITH TIME ZONE,

--- a/server/src/main/resources/db/migration/V28__refactor_yki_suoritus_error_table.sql
+++ b/server/src/main/resources/db/migration/V28__refactor_yki_suoritus_error_table.sql
@@ -1,0 +1,22 @@
+TRUNCATE TABLE yki_suoritus_error;
+DROP TABLE yki_suoritus_error;
+
+CREATE TABLE yki_suoritus_error
+(
+    id                  SERIAL PRIMARY KEY,
+    oid                 TEXT,
+    hetu                TEXT,
+    nimi                TEXT,
+    last_modified       TIMESTAMP WITH TIME ZONE,
+    virheellinen_kentta TEXT,
+    virheellinen_arvo   TEXT,
+    virheellinen_rivi   TEXT                        NOT NULL,
+    virheen_rivinumero  INTEGER                     NOT NULL,
+    virheen_luontiaika  TIMESTAMP WITH TIME ZONE    NOT NULL,
+
+    CONSTRAINT unique_suoritus_error UNIQUE
+    (
+        virheellinen_rivi,
+        virheen_rivinumero
+    )
+)

--- a/server/src/main/resources/db/migration/V28__refactor_yki_suoritus_error_table.sql
+++ b/server/src/main/resources/db/migration/V28__refactor_yki_suoritus_error_table.sql
@@ -14,9 +14,5 @@ CREATE TABLE yki_suoritus_error
     virheen_rivinumero  INTEGER                     NOT NULL,
     virheen_luontiaika  TIMESTAMP WITH TIME ZONE    NOT NULL,
 
-    CONSTRAINT unique_suoritus_error UNIQUE
-    (
-        virheellinen_rivi,
-        virheen_rivinumero
-    )
+    CONSTRAINT unique_suoritus_error_virheellinen_rivi_is_unique UNIQUE (virheellinen_rivi)
 )

--- a/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
+++ b/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
@@ -23,12 +23,54 @@
       <tbody class="virheet">
       {{#virheet}}
         <tr>
-          <td>{{#suorittajanOid}}{{suorittajanOid}}{{/suorittajanOid}}</td>
-          <td>{{#hetu}}{{hetu}}{{/hetu}}</td>
-          <td>{{#nimi}}{{nimi}}{{/nimi}}</td>
-          <td>{{#lastModified}}{{lastModified}}{{/lastModified}}</td>
-          <td>{{#virheellinenKentta}}{{virheellinenKentta}}{{/virheellinenKentta}}</td>
-          <td>{{#virheellinenArvo}}{{virheellinenArvo}}{{/virheellinenArvo}}</td>
+          <td>
+              {{#suorittajanOid}}
+                  {{suorittajanOid}}
+              {{/suorittajanOid}}
+              {{^suorittajanOid}}
+                 arvo puuttuu
+              {{/suorittajanOid}}
+          </td>
+          <td>
+              {{#hetu}}
+                  {{hetu}}
+              {{/hetu}}
+              {{^hetu}}
+                  arvo puuttuu
+              {{/hetu}}
+          </td>
+          <td>
+              {{#nimi}}
+                {{nimi}}
+              {{/nimi}}
+              {{^nimi}}
+                  arvo puuttuu
+              {{/nimi}}
+          </td>
+          <td>
+              {{#lastModified}}
+                  {{lastModified}}
+              {{/lastModified}}
+              {{^lastModified}}
+                  arvo puuttuu
+              {{/lastModified}}
+          </td>
+          <td>
+              {{#virheellinenKentta}}
+                  {{virheellinenKentta}}
+              {{/virheellinenKentta}}
+              {{^virheellinenKentta}}
+                  arvo puuttuu
+              {{/virheellinenKentta}}
+          </td>
+          <td>
+              {{#virheellinenArvo}}
+                  {{virheellinenArvo}}
+              {{/virheellinenArvo}}
+              {{^virheellinenArvo}}
+                  arvo puuttuu
+              {{/virheellinenArvo}}
+          </td>
 	      <td>{{virheellinenRivi}}</td>
           <td>{{virheenRivinumero}}</td>
           <td>{{virheenLuontiaika}}</td>

--- a/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
+++ b/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
@@ -23,7 +23,7 @@
       <tbody class="virheet">
       {{#virheet}}
         <tr>
-          <td>{{#oid}}{{oid}}{{/oid}}</td>
+          <td>{{#suorittajanOid}}{{suorittajanOid}}{{/suorittajanOid}}</td>
           <td>{{#hetu}}{{hetu}}{{/hetu}}</td>
           <td>{{#nimi}}{{nimi}}{{/nimi}}</td>
           <td>{{#lastModified}}{{lastModified}}{{/lastModified}}</td>

--- a/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
+++ b/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
@@ -23,11 +23,15 @@
       <tbody class="virheet">
       {{#virheet}}
         <tr>
-          <td>{{message}}</td>
-          <td>{{context}}</td>
-          <td>{{exceptionMessage}}</td>
-          <td>{{stackTrace}}</td>
-          <td>{{created}}</td>
+          <td>{{#oid}}{{oid}}{{/oid}}</td>
+          <td>{{#hetu}}{{hetu}}{{/hetu}}</td>
+          <td>{{#nimi}}{{nimi}}{{/nimi}}</td>
+          <td>{{#lastModified}}{{lastModified}}{{/lastModified}}</td>
+          <td>{{#virheellinenKentta}}{{virheellinenKentta}}{{/virheellinenKentta}}</td>
+          <td>{{#virheellinenArvo}}{{virheellinenArvo}}{{/virheellinenArvo}}</td>
+	      <td>{{virheellinenRivi}}</td>
+          <td>{{virheenRivinumero}}</td>
+          <td>{{virheenLuontiaika}}</td>
         </tr>
       {{/virheet}}
       </tbody>

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -177,7 +177,7 @@ class CsvParsingTest {
         val serializationErrors = event.keyValues.filter { kvp -> kvp.first?.startsWith("serialization.error") == true }
 
         val count = serializationErrors.size
-        assertTrue(count == 10)
+        assertEquals(10, count, "Unexpected number of serialization errors")
 
         val exceptions =
             serializationErrors

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -174,7 +174,7 @@ class CsvParsingTest {
             parser.convertCsvToData<YkiSuoritusCsv>(csv)
         }
 
-        val serializationErrors = event.keyValues.filter { kvp -> kvp.first?.startsWith("serialization.error") == true }
+        val serializationErrors = event.keyValues.filterKeys { it?.startsWith("serialization.error") == true }
 
         val count = serializationErrors.size
         assertEquals(10, count, "Unexpected number of serialization errors")
@@ -182,7 +182,8 @@ class CsvParsingTest {
         val exceptions =
             serializationErrors
                 //  Removes everything before last dot, from the keys.
-                .map { kvp -> Pair(kvp.first?.substringAfterLast("."), kvp.second) }
+                // as a side effect disassociate keys with the values
+                .map { kvp -> Pair(kvp.key?.substringAfterLast("."), kvp.value) }
                 .filter { it.first.equals("exception") }
                 .map { it.second }
 

--- a/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/csvparsing/CsvParsingTest.kt
@@ -177,7 +177,7 @@ class CsvParsingTest {
         val serializationErrors = event.keyValues.filter { kvp -> kvp.first?.startsWith("serialization.error") == true }
 
         val count = serializationErrors.size
-        assertTrue(count == 9)
+        assertTrue(count == 10)
 
         val exceptions =
             serializationErrors

--- a/server/src/test/kotlin/fi/oph/kitu/logging/EventLoggerTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/logging/EventLoggerTests.kt
@@ -23,7 +23,7 @@ class EventLoggerTests {
         val result = logger.getOrThrow()
         assertNotNull(result)
 
-        val success = event.getValueOrNullByKey<Boolean>("success")
+        val success = event.keyValues["success"] as Boolean
         assertNotNull(success, "missing success")
         assertTrue(success, "success should be true")
 
@@ -61,7 +61,7 @@ class EventLoggerTests {
             logger.getOrThrow()
         }
 
-        val success = event.getValueOrNullByKey<Boolean>("success")
+        val success = event.keyValues["success"] as Boolean
         assertNotNull(success, "missing success")
         assertFalse(success, "success should be false")
 
@@ -104,7 +104,7 @@ class EventLoggerTests {
                 Thread.sleep(1)
             }.getOrThrow()
 
-        val durationMs = event.getValueOrNullByKey<Long>("duration_ms")
+        val durationMs = event.keyValues["duration_ms"] as Long
         assertNotNull(durationMs, "duration_ms should not be null")
         assertTrue(durationMs > 0, "duration_ms should be greater than 0")
     }
@@ -128,7 +128,7 @@ class EventLoggerTests {
                 }.getOrThrow()
         }
 
-        val durationMs = event.getValueOrNullByKey<Long>("duration_ms")
+        val durationMs = event.keyValues["duration_ms"] as Long
         assertNotNull(durationMs, "duration_ms should not be null")
         assertTrue(durationMs > 0, "duration_ms should be greater than 0")
     }

--- a/server/src/test/kotlin/fi/oph/kitu/logging/MockEvent.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/logging/MockEvent.kt
@@ -5,20 +5,13 @@ import org.slf4j.spi.LoggingEventBuilder
 import java.util.function.Supplier
 
 class MockEvent : LoggingEventBuilder {
-    val keyValues = mutableListOf<Pair<String?, Any?>>()
+    val keyValues = mutableMapOf<String?, Any?>()
     val causes = mutableListOf<Throwable?>()
     val markers = mutableListOf<Marker?>()
     val arguments = mutableListOf<Any?>()
     val messages = mutableListOf<String?>()
     val logs = mutableListOf<String?>()
     val defaultLogValue: String = "NULL"
-
-    inline fun <reified T> getValueOrNullByKey(key: String?) =
-        keyValues
-            .filter { it.first == key }
-            .map { it.second }
-            .filterIsInstance<T>()
-            .firstOrNull()
 
     override fun setCause(p0: Throwable?): LoggingEventBuilder {
         causes.add(p0)
@@ -44,7 +37,7 @@ class MockEvent : LoggingEventBuilder {
         p0: String?,
         p1: Any?,
     ): LoggingEventBuilder {
-        keyValues.add(Pair(p0, p1))
+        keyValues[p0] = p1
         return this
     }
 
@@ -52,7 +45,7 @@ class MockEvent : LoggingEventBuilder {
         p0: String?,
         p1: Supplier<Any>?,
     ): LoggingEventBuilder {
-        keyValues.add(Pair(p0, p1?.get()))
+        keyValues[p0] = p1
         return this
     }
 

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
@@ -3,7 +3,6 @@ package fi.oph.kitu.yki
 import fi.oph.kitu.csvparsing.CsvExportError
 import fi.oph.kitu.csvparsing.SimpleCsvExportError
 import fi.oph.kitu.logging.MockEvent
-import fi.oph.kitu.logging.only
 import fi.oph.kitu.mock.generateRandomYkiSuoritusErrorEntity
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorRepository
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorService
@@ -61,10 +60,11 @@ class YkiSuoritusErrorTests(
         val errorsInDatabase = repository.findAll()
         assertEquals(0, errorsInDatabase.count())
 
-        val (_, errorSize) = event.keyValues.only { kvp -> kvp.first == "errors.size" }
+        val errorSize = event.keyValues["errors.size"] as Int
+
         assertEquals(0, errorSize)
 
-        val (_, truncate) = event.keyValues.only { kvp -> kvp.first == "errors.truncate" }
+        val truncate = event.keyValues["errors.truncate"] as Boolean
         assertEquals(true, truncate)
     }
 
@@ -103,13 +103,13 @@ class YkiSuoritusErrorTests(
         val errorsInDatabase = repository.findAll()
         assertEquals(2, errorsInDatabase.count())
 
-        val (_, errorSize) = event.keyValues.only { kvp -> kvp.first == "errors.size" }
+        val errorSize = event.keyValues["errors.size"] as Int
         assertEquals(1, errorSize)
 
-        val (_, truncate) = event.keyValues.only { kvp -> kvp.first == "errors.truncate" }
+        val truncate = event.keyValues["errors.truncate"] as Boolean
         assertEquals(false, truncate)
 
-        val (_, addedSize) = event.keyValues.only { kvp -> kvp.first == "errors.addedSize" }
+        val addedSize = event.keyValues["errors.addedSize"] as Int
         assertEquals(1, addedSize)
     }
 }

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
@@ -4,7 +4,7 @@ import fi.oph.kitu.csvparsing.CsvExportError
 import fi.oph.kitu.csvparsing.SimpleCsvExportError
 import fi.oph.kitu.logging.MockEvent
 import fi.oph.kitu.logging.only
-import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorEntity
+import fi.oph.kitu.mock.generateRandomYkiSuoritusErrorEntity
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorRepository
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorService
 import org.junit.jupiter.api.BeforeEach
@@ -49,13 +49,8 @@ class YkiSuoritusErrorTests(
         val errors = emptyList<CsvExportError>()
         repository.save(
             // Existing error
-            YkiSuoritusErrorEntity(
-                id = null,
-                message = "old error",
-                context = "1,2,3",
-                exceptionMessage = "OldErrorException",
-                stackTrace = "123",
-                created = Instant.parse("2025-03-06T10:50:00.00Z"),
+            generateRandomYkiSuoritusErrorEntity().copy(
+                virheenLuontiaika = Instant.parse("2025-03-06T10:50:00.00Z"),
             ),
         )
 
@@ -80,20 +75,24 @@ class YkiSuoritusErrorTests(
         val errors =
             listOf(
                 SimpleCsvExportError(
-                    lineNumber = 1,
-                    context = "4,5,6",
-                    exception = RuntimeException("test"),
+                    lineNumber = 2,
+                    context =
+                        """
+                        ,\"010180-9026\",\"N\",\"Öhman-Testi\",\"Ranja Testi\",\"EST\",\"Testikuja 5\",\"40100\",\"Testilä\",\"testi@testi.fi\",183424,2024-10-30T13:53:56Z,2024-09-01,\"fin\",\"YT\",\"1.2.246.562.10.14893989377\",\"Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus\",2024-11-14,5,5,,5,5,,,,0,0,,
+                        """.trimIndent(),
+                    exception =
+                        RuntimeException(
+                            """
+                            Cannot construct instance of `fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv`, problem: Parameter specified as non-null is null: method fi.oph.kitu.yki.suoritukset.YkiSuoritusCsv.<init>, parameter suorittajanOID
+                                at [Source: (StringReader); line: 3, column: 270]
+                            """.trimIndent(),
+                        ),
                 ),
             )
         repository.save(
             // Existing error
-            YkiSuoritusErrorEntity(
-                id = null,
-                message = "old error",
-                context = "1,2,3",
-                exceptionMessage = "OldErrorException",
-                stackTrace = "123",
-                created = Instant.parse("2025-03-06T10:50:00.00Z"),
+            generateRandomYkiSuoritusErrorEntity().copy(
+                virheenLuontiaika = Instant.parse("2025-03-06T10:50:00.00Z"),
             ),
         )
 


### PR DESCRIPTION
* Alkuperäinen ajatus, #988, oli liian monimutkainen, joten sitä ajatusta on suoraviivaistettu tässä
* Pullaria voi olla helpompi lukea commit-kerrallaan:
1. 675accd71a6d8f23c84dd9bbb0391ea1f00a4623 - lisätty että dev-controllerin vastaukseen virheellisiä rivejä
2. 50f3810c8d3e26ca18e356701ef2338893f674ef - kaivetaan virheellinen kenttä lokitietoihin
3. 5611a84502ea387f87721b1bed832493ea928632 - **rikkova commit:** refaktoroitu (sql) taulu. SQL sisältää unique constraint, joten duplikaattirivejä ei synny, vaan aiheuttaa virheen, mikä lokittuu oteliin
4. 72df04fa791c42ab5f0b4a7d34f6852282680ac2 - korjattu entity-luokka
5. 19b4fb136dd7b9342785697f427b4d1669ff1f70 - tallennetaan virheelliset rivit. csv-parsiminen on nyt minimalistinen
6. 77ea07e5e7397b826dca1c5dbb03666088769c54 - korjattu yksikkötestit (e2e putki ei vieläkään toimi)
7. 1bd16050db2907624b5ef75ddd591be31406486c - tehty käli muutokset ja korjattu e2e -testit samalla

Nyt mun filosofia on error-servicessä, että asiat on mahd. minimalistia ja toteutuksena erillään muusta toteutuksesta. Sillä vältetään, että jos muuhun koodiin syntyy bugi, niin sillä olisi suurempaa vaikutusta tähän viankäsittelyyn. 
Ja myöskin niinkuin edellisessä pullarin katselmoinnissa todettiin, tämä virheenkäsittely käsittelee vain odotetut virheen. Odottamattomat virheet ui jatkossakin otel-collectorille.