### PR TITLE
Return oppijanumero as `Oid` from `OppijanumeroService`

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
@@ -172,7 +172,7 @@ class KoealustaMappingService(
 
     fun completionToEntity(
         user: User,
-        oppijanumero: String?,
+        oppijanumero: Oid?,
         completion: Completion,
     ): TypedResult<KielitestiSuoritus, Error.SuoritusValidationFailure> {
         val errors = mutableListOf<Error.Validation>()
@@ -201,10 +201,9 @@ class KoealustaMappingService(
             validateNonEmpty("preferredname", user.userid, user.preferredname)
                 .onFailure { errors.add(it) }
                 .getOrNull()
-        val validOppijanumero =
-            validateNonEmpty("oppijanumero", user.userid, oppijanumero)
-                .onFailure { errors.add(it) }
-                .getOrNull()
+        if (oppijanumero == null) {
+            errors.add(Error.Validation.MissingField("oppijanumero", user.userid))
+        }
 
         if (errors.isNotEmpty()) {
             return Failure(
@@ -223,7 +222,7 @@ class KoealustaMappingService(
         checkNotNull(kirjoittaminen?.quiz_result_teacher)
         checkNotNull(schoolOid)
         checkNotNull(preferredName)
-        checkNotNull(validOppijanumero)
+        checkNotNull(oppijanumero)
 
         return Success(
             KielitestiSuoritus(
@@ -231,7 +230,7 @@ class KoealustaMappingService(
                 lastName = user.lastname,
                 preferredname = preferredName,
                 email = user.email,
-                oppijanumero = validOppijanumero,
+                oppijanumero = oppijanumero.toString(),
                 timeCompleted = Instant.ofEpochSecond(completion.timecompleted),
                 schoolOid = schoolOid,
                 courseid = completion.courseid,

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroException.kt
@@ -19,4 +19,12 @@ open class OppijanumeroException(
         oppijanumeroServiceError: OppijanumeroServiceError? = null,
         cause: Throwable? = null,
     ) : OppijanumeroException(oppija, message, oppijanumeroServiceError, cause)
+
+    class MalformedOppijanumero(
+        oppija: Oppija,
+        oppijanumero: String?,
+        message: String = "Received a malformed oppijanumero \"$oppijanumero\" for ${oppija.henkilo_oid}",
+        oppijanumeroServiceError: OppijanumeroServiceError? = null,
+        cause: Throwable? = null,
+    ) : OppijanumeroException(oppija, message, oppijanumeroServiceError, cause)
 }

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaServiceTests.kt
@@ -105,7 +105,7 @@ class KoealustaServiceTests(
                 mappingService =
                     KoealustaMappingService(
                         objectMapper,
-                        OppijanumeroServiceMock("123"),
+                        OppijanumeroServiceMock("1.2.246.562.24.33342764709"),
                     ),
                 auditLogger = auditLogger,
             )

--- a/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceMock.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceMock.kt
@@ -1,11 +1,13 @@
 package fi.oph.kitu.oppijanumero
 
+import fi.oph.kitu.Oid
 import fi.oph.kitu.TypedResult
-import fi.oph.kitu.TypedResult.Success
 
 class OppijanumeroServiceMock(
     private val oppijanumero: String,
 ) : OppijanumeroService {
-    override fun getOppijanumero(oppija: Oppija): TypedResult<String, OppijanumeroException> =
-        Success(this.oppijanumero)
+    override fun getOppijanumero(oppija: Oppija): TypedResult<Oid, OppijanumeroException> =
+        Oid
+            .parseTyped(oppijanumero)
+            .mapFailure { OppijanumeroException.MalformedOppijanumero(oppija, oppijanumero) }
 }

--- a/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroServiceTests.kt
@@ -47,7 +47,7 @@ class OppijanumeroServiceTests {
                         ),
                     ).getOrThrow()
             }
-        assertEquals(expectedOppijanumero.toString(), result)
+        assertEquals(expectedOppijanumero, result)
     }
 
     @Test


### PR DESCRIPTION
Tehdään datan parsinta ja mankelointi haluttuun muotoon mahdollisimman aikaisin, ettei validoinnin tarve valu muille luokille. Koodi pysyy siistimpänä, kun `Oid` muotoinen data on `Oid` eikä `String` koko käsittelyn ajan.