### PR TITLE
Use Oid types for Koto suoritukset in the database

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritus.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritus.kt
@@ -12,7 +12,7 @@ data class KielitestiSuoritus(
     val firstNames: String,
     val lastName: String,
     val preferredname: String,
-    val oppijanumero: String,
+    val oppijanumero: Oid,
     val email: String,
     val timeCompleted: Instant,
     val schoolOid: Oid,

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaMappingService.kt
@@ -230,7 +230,7 @@ class KoealustaMappingService(
                 lastName = user.lastname,
                 preferredname = preferredName,
                 email = user.email,
-                oppijanumero = oppijanumero.toString(),
+                oppijanumero = oppijanumero,
                 timeCompleted = Instant.ofEpochSecond(completion.timecompleted),
                 schoolOid = schoolOid,
                 courseid = completion.courseid,

--- a/server/src/main/kotlin/fi/oph/kitu/mock/KielitestiMock.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/KielitestiMock.kt
@@ -25,7 +25,7 @@ fun generateRandomKielitestiSuoritus(): KielitestiSuoritus {
         firstNames = oppilas.etunimet,
         lastName = oppilas.sukunimi,
         preferredname = oppilas.kutsumanimi,
-        oppijanumero = oppilas.oppijanumero.toString(),
+        oppijanumero = oppilas.oppijanumero,
         email = oppilas.email,
         timeCompleted = getRandomInstant(LocalDate.of(2000, 1, 1).toInstant()),
         schoolOid = generateRandomOrganizationOid(),

--- a/server/src/main/resources/db/migration/V31__validate_koto_suoritus_oppijanumero_oid.sql
+++ b/server/src/main/resources/db/migration/V31__validate_koto_suoritus_oppijanumero_oid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE koto_suoritus
+    ALTER COLUMN oppijanumero SET DATA TYPE henkilo_oid USING oppijanumero::henkilo_oid;


### PR DESCRIPTION
Samat setit kuin YKI suorituksille; validoidaan OID tyyppiset kentät myös tietokannassa. Aikaisempien refaktorointien vuoksi tämä on KOTO:n osalta koodin puolella huomattavan paljon kivuttomampaa, kuin YKI:n tapauksessa.

Tietokannassa olevan datan osalta ei valitettavasti voi sanoa samaa. Näitä muutoksia ei voida mergetä, sillä migraatio ei tällä hetkellä menisi testiympäristössä läpi. Tuotannossa ei vielä ole KOTO-suorituksia, joten siellä ei ole ongelmia.

Testiympäristössä on tällä hetkellä tietokannassa rivejä, joissa `oppijanumero` on sellainen merkkijono, ettei se ole kelvollinen Oid (esim. tyhjä merkkijono). Nämä rivit tulee korjata (mielellään lähtöjärjestelmässä), jotta migraatiot voidaan ajaa sisään. Teoriassa myös rivien poistaminen on ehkä vaihtoehto, sillä koalustaintegraation tekemän pyynnön `from`-parametri varmistaa, ettei vanhoja rivejä yritetä tuoda uudelleen. Tämä saattaa tosin siirtää ongelman tulevaisuuteen, mikäli aikaleima jossain vaiheessa nollattaisiin.