### PR TITLE
Change KOSKI opiskeluoikeuden tila from hyvaksytty to paattynyt

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/koski/Koodisto.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/Koodisto.kt
@@ -36,7 +36,7 @@ object Koodisto {
         override val koodistoUri: String = "koskiopiskeluoikeudentila",
     ) : Koodiviite {
         Lasna("lasna"),
-        HyvaksytystiSuoritettu("hyvaksytystisuoritettu"),
+        Paattynyt("paattynyt"),
     }
 
     enum class YkiTutkintotaso(

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
@@ -40,7 +40,7 @@ class KoskiRequestMapper {
                                         ),
                                         OpiskeluoikeusJakso(
                                             alku = ykiSuoritus.arviointipaiva,
-                                            tila = Koodisto.OpiskeluoikeudenTila.HyvaksytystiSuoritettu,
+                                            tila = Koodisto.OpiskeluoikeudenTila.Paattynyt,
                                         ),
                                     ),
                             ),

--- a/server/src/test/resources/koski-request-example.json
+++ b/server/src/test/resources/koski-request-example.json
@@ -27,7 +27,7 @@
           {
             "alku": "2025-01-03",
             "tila": {
-              "koodiarvo": "hyvaksytystisuoritettu",
+              "koodiarvo": "paattynyt",
               "koodistoUri": "koskiopiskeluoikeudentila"
             }
           }

--- a/server/src/test/resources/koski-request-with-yleisarvosana.json
+++ b/server/src/test/resources/koski-request-with-yleisarvosana.json
@@ -27,7 +27,7 @@
           {
             "alku": "2025-01-03",
             "tila": {
-              "koodiarvo": "hyvaksytystisuoritettu",
+              "koodiarvo": "paattynyt",
               "koodistoUri": "koskiopiskeluoikeudentila"
             }
           }


### PR DESCRIPTION
YKI tutkintojen eri osakokeista ei päätellä koko tutkinnon hyväksymistä/hylkäämistä, joten selkeyden vuoksi muutetaan opiskeluoikeuden tila hyväksytysti suoritettu -> päättynyt.