### PR TITLE
feat(e2e): start ykisuorituserror e2e test from import 

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,41 @@
+# end-to-end testing
+
+```shell
+
+# Do clean install before running the tests
+npm ci
+
+# Run code generator to create playwright tests
+npx playwright codegen
+
+# Run tests on CLI
+npx playwright test
+
+# Run tests with UI
+npx playwright test --ui
+
+
+```
+
+## Hook playwright tests in idea debugger
+
+1. Start idea debugger as usual
+2. Change `playwright.config.ts`, the return object of workerWebServer
+
+```diff
+return {
+-  command: "./mvnw spring-boot:run"
+  url: `http://localhost:${port}`
+-  reuseExistingServer: false,
++  reuseExistingServer: true,
+   // ...
+}
+```
+
+3. Run your playwright tests, eg. `npx playwright test --ui`
+
+## Check playwright report on GH actions
+
+1. If you have a pull request, open any check, for example `Build / Frontend tests`
+2. Select `Summary` from left-top on the UI
+3. From `Artifacts`, select `playwright-report`

--- a/e2e/fixtures/baseFixture.ts
+++ b/e2e/fixtures/baseFixture.ts
@@ -9,11 +9,13 @@ import * as ykiSuoritusFixture from "./ykiSuoritus"
 import * as ykiSuoritusErrorFixture from "./ykiSuoritusError"
 import BasePage from "../models/BasePage"
 import { Config, createConfig } from "../config"
+import DbSchedulerPage from "../models/dbSchedulerPage"
 
 interface Fixtures {
   ykiSuorituksetPage: YkiSuorituksetPage
   ykiSuorituksetErrorPage: YkiSuorituksetErrorPage
   kielitestiSuorituksetPage: KielitestiSuorituksetPage
+  dbSchedulerPage: DbSchedulerPage
   indexPage: IndexPage
   basePage: BasePage
   kotoSuoritus: typeof kotoSuoritusFixture
@@ -31,6 +33,10 @@ interface WorkerArgs {
 export const test = baseTest.extend<Fixtures, WorkerArgs>({
   basePage: async ({ page, config }, use) => {
     const basePage = new BasePage(page, config)
+    await use(basePage)
+  },
+  dbSchedulerPage: async ({ page, config }, use) => {
+    const basePage = new DbSchedulerPage(page, config)
     await use(basePage)
   },
   kielitestiSuorituksetPage: async ({ page, config }, use) => {

--- a/e2e/models/dbSchedulerPage.ts
+++ b/e2e/models/dbSchedulerPage.ts
@@ -1,5 +1,5 @@
 import BasePage from "./BasePage"
-import { Page } from "@playwright/test"
+import { Locator, Page } from "@playwright/test"
 import { Config } from "../config"
 
 export default class DbSchedulerPage extends BasePage {
@@ -9,5 +9,29 @@ export default class DbSchedulerPage extends BasePage {
 
   async open() {
     await this.goto("/db-scheduler")
+  }
+
+  getRowYkiImport() {
+    return this.page
+      .getByText("YKI-import", { exact: true })
+      .locator("..")
+      .locator("..")
+      .locator("..") // go up 3 levels
+  }
+
+  getRerunButton(row: Locator) {
+    return row.getByRole("button", { name: "Rerun" })
+  }
+
+  getRunButton(row: Locator) {
+    return row.getByRole("button", { name: "Run" })
+  }
+
+  getRefreshButton() {
+    return this.page.getByRole("button", { name: "Refresh" })
+  }
+
+  getNotificationIndicator() {
+    return this.getRefreshButton().locator("..").locator("text=1")
   }
 }

--- a/e2e/models/dbSchedulerPage.ts
+++ b/e2e/models/dbSchedulerPage.ts
@@ -1,0 +1,13 @@
+import BasePage from "./BasePage"
+import { Page } from "@playwright/test"
+import { Config } from "../config"
+
+export default class DbSchedulerPage extends BasePage {
+  constructor(page: Page, config: Config) {
+    super(page, config)
+  }
+
+  async open() {
+    await this.goto("/db-scheduler")
+  }
+}

--- a/e2e/tests/yki/yki-suoritukset-error.spec.ts
+++ b/e2e/tests/yki/yki-suoritukset-error.spec.ts
@@ -5,17 +5,41 @@ const fs = node_fs.promises
 describe('"YKI Suoritukset Error" -page', () => {
   beforeEach(async ({ db, basePage, ykiSuoritusError }) => {
     await db.withEmptyDatabase()
-
-    await ykiSuoritusError.insert(db, "missingOid")
-
-    await basePage.login()
   })
 
   test("yki suoritukset error page is navigable via suoritukset - page", async ({
     page,
+    basePage,
+    dbSchedulerPage,
     ykiSuorituksetPage,
     ykiSuorituksetErrorPage,
   }) => {
+    // Part 1 - Run import
+
+    await basePage.login()
+    await dbSchedulerPage.open()
+
+    // Find correct row
+    const row = dbSchedulerPage.getRowYkiImport()
+
+    // Expect there is a failed run, so Rerun
+    const rerunButton = dbSchedulerPage.getRerunButton(row)
+    await rerunButton.click()
+
+    // The same button should have now text Run
+    const runButton = dbSchedulerPage.getRunButton(row)
+    await expect(runButton).toBeVisible(/*{ timeout: 5000 }*/)
+
+    // Refresh the page
+    const refreshButton = dbSchedulerPage.getRefreshButton()
+    await refreshButton.click()
+
+    // There should be now a notification about the error
+    // This is also an indicator, that the import was run.
+    const notification = dbSchedulerPage.getNotificationIndicator()
+    await expect(notification).toBeVisible({ timeout: 10000 })
+
+    // Part 2 - Navigate to errors
     await ykiSuorituksetPage.open()
     await ykiSuorituksetPage.getErrorLink().click()
 

--- a/e2e/tests/yki/yki-suoritukset-error.spec.ts
+++ b/e2e/tests/yki/yki-suoritukset-error.spec.ts
@@ -2,7 +2,7 @@ import * as node_fs from "node:fs"
 import { beforeEach, describe, expect, test } from "../../fixtures/baseFixture"
 
 const fs = node_fs.promises
-describe('"YKI Suoritukset" -page', () => {
+describe('"YKI Suoritukset Error" -page', () => {
   beforeEach(async ({ db, basePage, ykiSuoritusError }) => {
     await db.withEmptyDatabase()
 

--- a/server/src/main/resources/application-e2e.properties
+++ b/server/src/main/resources/application-e2e.properties
@@ -18,7 +18,9 @@ kitu.oppijanumero.service.url=https://virkailija.untuvaopintopolku.fi/oppijanume
 
 kitu.yki.username=
 kitu.yki.password=
-kitu.yki.scheduling.enabled=false
+kitu.yki.scheduling.enabled=true
+kitu.yki.scheduling.import.schedule=FIXED_DELAY|3600s
+kitu.yki.scheduling.importArvioijat.schedule=FIXED_DELAY|3600s
 kitu.yki.baseUrl=http://localhost:8080/dev/yki/import/
 
 kitu.koski.baseUrl=


### PR DESCRIPTION
- Ennen YkiSuoritusError - testi alkoi YkiSuoritus - sivulta, jossa oletettiin, että import on ajettu. (Oletus on tehty alustamalla tietokanta testeissä sopivasti).
  - Nyt se osuus on korvattu, ja e2e-testi klikkaa Runia importissa.
- Tässä versiossa myöskin e2e putki ajaa importit 60min välein. Väli on valittu tarkoituksella, jotta importin seuraava ajo ei osu samalle ajalle kuin kuin e2e-testin ajo. Ja jos osuu, niin testissä on silloin jotain muuta vikaa.
- Lisätty e2e/README.md jotain komentoja, e2e testaamista varten
- Lokaalisti testasessa testi kerran hajosi, kun käliin oli ilmestynyt ylimääräinen RefreshCircle, ja mun käyttämä selectori löytää myös sen. En oo saanu toistettua sitä.