### PR TITLE
feat(yki): add traces to scheduledtasks

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -253,6 +253,11 @@
             <version>1.44.0-alpha</version>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>no.bekk.db-scheduler-ui</groupId>
             <artifactId>db-scheduler-ui-starter</artifactId>
             <version>4.1.0</version>

--- a/server/src/main/kotlin/fi/oph/kitu/logging/OpenTelemetryExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/OpenTelemetryExtensions.kt
@@ -15,3 +15,8 @@ inline fun <T> Span.use(block: (Span) -> T): T {
         this.end()
     }
 }
+
+inline fun Span.setAttribute(
+    key: String,
+    value: Int,
+) = this.setAttribute(key, value.toLong())

--- a/server/src/test/kotlin/fi/oph/kitu/logging/MockEvent.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/logging/MockEvent.kt
@@ -4,6 +4,7 @@ import org.slf4j.Marker
 import org.slf4j.spi.LoggingEventBuilder
 import java.util.function.Supplier
 
+@Deprecated("replace with OpenTelemetry tracing")
 class MockEvent : LoggingEventBuilder {
     val keyValues = mutableMapOf<String?, Any?>()
     val causes = mutableListOf<Throwable?>()

--- a/server/src/test/kotlin/fi/oph/kitu/logging/OpenTelemetryTestConfig.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/logging/OpenTelemetryTestConfig.kt
@@ -1,0 +1,33 @@
+package fi.oph.kitu.logging
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class OpenTelemetryTestConfig {
+    @Bean
+    fun inMemorySpanExporter(): InMemorySpanExporter = InMemorySpanExporter.create()
+
+    @Bean
+    fun openTelemetry(inMemorySpanExporter: InMemorySpanExporter): OpenTelemetry {
+        val spanProcessor = SimpleSpanProcessor.create(inMemorySpanExporter)
+        val tracerProvider =
+            SdkTracerProvider
+                .builder()
+                .addSpanProcessor(spanProcessor)
+                .build()
+        val openTelemetry =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(tracerProvider)
+                .build()
+        GlobalOpenTelemetry.set(openTelemetry)
+        return openTelemetry
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
@@ -9,6 +9,7 @@ import fi.oph.kitu.yki.suoritukset.YkiSuoritusMappingService
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusRepository
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorRepository
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorService
+import io.opentelemetry.api.trace.Tracer
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -39,6 +40,7 @@ class YkiServiceTests(
     @Autowired private val suoritusErrorRepository: YkiSuoritusErrorRepository,
     @Autowired private val parser: CsvParser,
     @Autowired private val mockRestClientBuilder: RestClient.Builder,
+    @Autowired private val tracer: Tracer,
 ) {
     @Suppress("unused")
     companion object {
@@ -85,6 +87,7 @@ class YkiServiceTests(
                 suoritusErrorService = ykiSuoritusErrorService,
                 auditLogger = auditLogger,
                 parser = parser,
+                tracer = tracer,
             )
 
         // Act
@@ -124,6 +127,7 @@ class YkiServiceTests(
                 suoritusErrorService = ykiSuoritusErrorService,
                 auditLogger = auditLogger,
                 parser = parser,
+                tracer = tracer,
             )
 
         // Act
@@ -169,6 +173,7 @@ class YkiServiceTests(
                 suoritusErrorService = ykiSuoritusErrorService,
                 auditLogger = auditLogger,
                 parser = parser,
+                tracer = tracer,
             )
 
         // Act
@@ -223,6 +228,7 @@ class YkiServiceTests(
                 suoritusErrorService = ykiSuoritusErrorService,
                 auditLogger = auditLogger,
                 parser = parser,
+                tracer = tracer,
             )
 
         assertDoesNotThrow {
@@ -270,6 +276,7 @@ class YkiServiceTests(
                 suoritusErrorService = ykiSuoritusErrorService,
                 auditLogger = auditLogger,
                 parser = parser,
+                tracer = tracer,
             )
 
         assertDoesNotThrow {
@@ -344,6 +351,7 @@ class YkiServiceTests(
                 suoritusErrorService = ykiSuoritusErrorService,
                 auditLogger = auditLogger,
                 parser = parser,
+                tracer = tracer,
             )
 
         assertThrows<RuntimeException>(

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusErrorTests.kt
@@ -55,7 +55,7 @@ class YkiSuoritusErrorTests(
         )
 
         // Act
-        service.handleErrors(event, errors)
+        service.handleErrors(errors)
 
         // Assert
         val errorsInDatabase = repository.findAll()
@@ -106,7 +106,7 @@ class YkiSuoritusErrorTests(
         )
 
         // Act
-        service.handleErrors(event, errors)
+        service.handleErrors(errors)
 
         // Assert
         val errorsInDatabase = repository.findAll()


### PR DESCRIPTION
Jos haluaa opentelemetry spanit alkamaan taskien scheduloinnista, niin se pitää tehdä näin:
```kotlin
    @Bean
    fun dailyImport(ykiService: YkiService): Task<Instant?> =
        // ensin luodaan span, joka ajetaan aina kun Beania kutsutaan. 
        // Se taitaa olla ainoastaan jos sovellus käynnistetään?
        tracer
            .spanBuilder("Beans.dailyImport.init")
            .startSpan()
            .use {
                Tasks
                    .recurring("YKI-import", ExtendedSchedules.parse(ykiImportSchedule), Instant::class.java)
                    .initialData(Instant.EPOCH)
                    .executeStateful { taskInstance, _ ->
                        // Tämä konkteksti alkaa kun Scheduler API päättää, että nyt pitää suorittaa tämä block
                        // Tämä ei ajallisesti liity beanin triggeröintiin, joten tarvitaan uusi span
                        tracer
                            .spanBuilder("Beans.dailyImport.execute")
                            .startSpan()
                            .use { ykiService.importYkiSuoritukset(taskInstance.data) }
                    }
            }
```