### PR TITLE
Refactor: Reduce test init boilerplate from Koealusta tests

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
@@ -18,7 +18,7 @@ import java.time.Instant
 
 @Service
 class KoealustaService(
-    private val restClientBuilder: RestClient.Builder,
+    val restClientBuilder: RestClient.Builder,
     private val kielitestiSuoritusRepository: KielitestiSuoritusRepository,
     private val mappingService: KoealustaMappingService,
     private val auditLogger: AuditLogger,

--- a/server/src/test/resources/application-local.properties
+++ b/server/src/test/resources/application-local.properties
@@ -1,0 +1,1 @@
+kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=false


### PR DESCRIPTION
Vältetään hieman boilerplatea testeissä käyttämällä Springin luomaa service-instanssia.