### PR TITLE
Mise experimental mode is no longer needed

### DIFF
--- a/scripts/start_local_env.sh
+++ b/scripts/start_local_env.sh
@@ -8,8 +8,6 @@ require_command mise
 
 # Trust the mise configuration
 mise trust --quiet "$REPO_ROOT/.mise.toml"
-# Enable experimental features (npm backend is experimental)
-mise settings --quiet set experimental true
 
 # Ensure mise is activated
 if [ -z "${MISE_SHELL:-}" ]; then


### PR DESCRIPTION
Misen `experimental` -asetusta ei ole enää tarpeen asettaa päälle, sillä Misen `npm`-backend ei enää tätä vaadi.

Jos/kun on aiemmin asettanut `mise settings set experimental true` tai ajanut `start_local_env.sh`-skriptin, `experimental` -asetus on pysyvästi päällä. Jos asetuksen haluaa pois päältä, voi ajaa komennon:
```sh
mise settings set experimental false
```