### PR TITLE
feat: add basic swagger ui with springdoc starter

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -109,6 +109,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -45,3 +45,4 @@ logging.level.io.opentelemetry.contrib.aws.resource=TRACE
 # export for YKI suoritukset is exposed at `GET /yki/api/suoritukset`. This patter matches any
 # API endpoints with similar formats. Any endpoints matched by this pattern are shown in the UI
 springdoc.pathsToMatch=/**/api/**/*
+springdoc.swagger-ui.try-it-out-enabled=true

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -40,3 +40,8 @@ logging.level.io.opentelemetry.contrib.aws.resource=TRACE
 # Uncomment this to debug authentication/authorization issues.
 # Ref: https://docs.spring.io/spring-security/reference/servlet/architecture.html#servlet-logging
 #logging.level.org.springframework.security=TRACE
+
+# Controller endpoint paths to include in the Swagger UI. APIs are defined per-domain, e.g. CSV
+# export for YKI suoritukset is exposed at `GET /yki/api/suoritukset`. This patter matches any
+# API endpoints with similar formats. Any endpoints matched by this pattern are shown in the UI
+springdoc.pathsToMatch=/**/api/**/*


### PR DESCRIPTION
Hyvin pelkistetty automaagisesti konfiguroitu Swagger UI setup. Näyttää kaikki muotoa `/DOMAIN/api/**/*` olevat API-endpointit Swagger UI:ssa. Itse UI oletuksena saatavilla polussa `/swagger-ui.html`

Meillä on tällä hetkellä yksi endpoint; YKI-CSV -export, `GET /yki/api/suoritukset`. Tämä näkyy seuraavanlaisesti:

![screenshot-2025-05-07T12:24:17+00:00](https://github.com/user-attachments/assets/8af58bbc-f74b-4795-9819-ca860ac2e751)
