### PR TITLE
Add OpenTelemetry instrumentation to java.net HttpClient

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -258,6 +258,10 @@
             <version>1.44.0-alpha</version>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-java-http-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/HttpClientConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/HttpClientConfig.kt
@@ -1,5 +1,7 @@
 package fi.oph.kitu.oppijanumero
 
+import io.opentelemetry.instrumentation.javahttpclient.JavaHttpClientTelemetry
+import io.opentelemetry.sdk.OpenTelemetrySdk
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.net.CookieManager
@@ -9,10 +11,17 @@ import java.time.Duration
 @Configuration
 class HttpClientConfig {
     @Bean("oppijanumeroHttpClient")
-    fun HttpClient(): HttpClient =
-        HttpClient
-            .newBuilder()
-            .cookieHandler(CookieManager()) // sends JSESSIONID Cookie between the requests
-            .connectTimeout(Duration.ofSeconds(10))
+    fun HttpClient(openTelemetry: OpenTelemetrySdk): HttpClient {
+        val httpClient =
+            HttpClient
+                .newBuilder()
+                .cookieHandler(CookieManager()) // sends JSESSIONID Cookie between the requests
+                .connectTimeout(Duration.ofSeconds(10))
+                .build()
+
+        return JavaHttpClientTelemetry
+            .builder(openTelemetry)
             .build()
+            .newHttpClient(httpClient)
+    }
 }


### PR DESCRIPTION
CAS-autentikaatiota käyttävät kutsut käyttävät [java.net.HttpClient](https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/HttpClient.html)-kirjastoa Springin RestTemplaten/RestClientin sijaan. Se pitää instrumentoida erikseen että saadaan kutsut mukaan traceihin.