### PR TITLE
Make enum variant parsing from query parameters slightly less magical

### DIFF
--- a/e2e/models/kotoutumiskoulutus/KielitestiSuorituksetPage.ts
+++ b/e2e/models/kotoutumiskoulutus/KielitestiSuorituksetPage.ts
@@ -40,6 +40,15 @@ export default class KielitestiSuorituksetPage extends BasePage {
     return suorituksetTable.getByTestId("suoritus-details-row")
   }
 
+  getSuoritusColumn(rowIndex: number, columnIndex: number) {
+    const row = this.getSuoritusRow().nth(rowIndex)
+    return row.getByRole("cell").nth(columnIndex)
+  }
+
+  getTableColumnHeaderLink(text: string) {
+    return this.getSuorituksetTable().getByRole("link", { name: text })
+  }
+
   getErrorLink() {
     return this.getContent().locator(".error-text").getByRole("link")
   }

--- a/e2e/tests/kotoutumiskoulutus/kielitesti-suoritukset.spec.ts
+++ b/e2e/tests/kotoutumiskoulutus/kielitesti-suoritukset.spec.ts
@@ -1,10 +1,5 @@
-import {
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "../../fixtures/baseFixture"
+import { beforeEach, describe, expect, test } from "../../fixtures/baseFixture"
+import { enumerate } from "../../util/arrays"
 
 describe("Kotoutumiskoulutuksen kielitesti -page", () => {
   beforeEach(async ({ db, kotoSuoritus, basePage }) => {
@@ -63,4 +58,62 @@ describe("Kotoutumiskoulutuksen kielitesti -page", () => {
     await expect(thirdSuoritus).toBeVisible()
     await expect(thirdSuoritus).toContainText(magdalena.firstNames)
   })
+
+  const sortTestCases = [
+    {
+      column: "Sukunimi",
+      tableColumnIndex: 0,
+      order: Array<string>(
+        "Välimaa-Testi",
+        "Torvinen-Testi",
+        "Sallinen-Testi",
+        "Laasonen-Testi",
+      ),
+    },
+    {
+      column: "Etunimet",
+      tableColumnIndex: 1,
+      order: Array<string>(
+        "Toni Testi",
+        "Magdalena Testi",
+        "Eino Testi",
+        "Anniina Testi",
+      ),
+    },
+    {
+      column: "Sähköposti",
+      tableColumnIndex: 2,
+      order: Array<string>(
+        "devnull-6@oph.fi",
+        "devnull-14@oph.fi",
+        "devnull-12@oph.fi",
+        "devnull-10@oph.fi",
+      ),
+    },
+  ] as const
+  for (const testCase of sortTestCases) {
+    const { column, tableColumnIndex, order } = testCase
+    const reverseOrder = [...order].reverse()
+
+    test(`registry data can be sorted by "${column}"`, async ({
+      kielitestiSuorituksetPage: page,
+    }) => {
+      await page.open()
+
+      const sortByLink = page.getTableColumnHeaderLink(column)
+      await sortByLink.click()
+
+      for (const [expected, row] of enumerate(order)) {
+        const actualValue = page.getSuoritusColumn(row, tableColumnIndex)
+        await expect(actualValue).toHaveText(expected)
+      }
+
+      await sortByLink.click()
+
+      for (const [expected, row] of enumerate(reverseOrder)) {
+        const actualValue = page.getSuoritusColumn(row, tableColumnIndex)
+        await expect(actualValue).toHaveText(expected)
+      }
+    })
+  }
 })

--- a/e2e/util/arrays.ts
+++ b/e2e/util/arrays.ts
@@ -1,0 +1,2 @@
+export const enumerate = <T>(arr: readonly T[]): [T, number][] =>
+  arr.map((v, i) => [v, i])

--- a/server/src/main/kotlin/fi/oph/kitu/html/DisplayTable.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/html/DisplayTable.kt
@@ -23,13 +23,12 @@ interface DisplayTableEnum {
     val name: String
     val dbColumn: String?
     val uiHeaderValue: String
-
-    fun toLowercase(): String = name.lowercase()
+    val urlParam: String
 
     fun <T> withValue(renderValue: FlowContent.(T) -> Unit) =
         DisplayTableColumn(
             label = uiHeaderValue,
-            sortKey = dbColumn?.let { toLowercase() },
+            sortKey = urlParam,
             renderValue = renderValue,
         )
 }
@@ -41,7 +40,7 @@ fun <T> FlowContent.displayTable(
     sortDirection: SortDirection? = null,
     compact: Boolean = false,
 ) {
-    val sortedByKey = sortedBy?.toLowercase()
+    val sortedByKey = sortedBy?.urlParam
 
     table(classes = "${if (compact) "compact" else ""} striped") {
         debugTrace()

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritusColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritusColumn.kt
@@ -3,33 +3,35 @@ package fi.oph.kitu.kotoutumiskoulutus
 enum class KielitestiSuoritusColumn(
     val entityName: String,
     val uiHeaderValue: String,
+    val urlParam: String,
 ) {
     Sukunimi(
         entityName = "lastName",
         uiHeaderValue = "Sukunimi",
+        urlParam = "sukunimi",
     ),
 
     Etunimet(
         entityName = "firstNames",
         uiHeaderValue = "Etunimet",
+        urlParam = "etunimet",
     ),
 
     Sahkoposti(
         entityName = "email",
         uiHeaderValue = "Sähköposti",
+        urlParam = "sahkoposti",
     ),
 
     KurssinNimi(
         entityName = "coursename",
         uiHeaderValue = "Kurssin nimi",
+        urlParam = "kurssinnimi",
     ),
 
     Suoritusaika(
         entityName = "timeCompleted",
         uiHeaderValue = "Suoritusaika",
+        urlParam = "suoritusaika",
     ),
-
-    ;
-
-    fun lowercaseName(): String = name.lowercase()
 }

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritusErrorColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiSuoritusErrorColumn.kt
@@ -3,16 +3,14 @@ package fi.oph.kitu.kotoutumiskoulutus
 enum class KielitestiSuoritusErrorColumn(
     val fieldName: String,
     val uiHeaderValue: String,
+    val urlParam: String,
 ) {
-    Henkilötunnus("hetu", "Henkilötunnus"),
-    Nimi("nimi", "Nimi"),
-    SchoolOid("schoolOid", "Organisaation OID"),
-    TeacherEmail("teacherEmail", "Opettajan sähköpostiosoite"),
-    VirheenLuontiaika("virheenLuontiaika", "Virheen luontiaika"),
-    Viesti("viesti", "Virheviesti"),
-    VirheellinenKentta("virheellinenKentta", "Virheellinen kenttä"),
-    VirheellinenArvo("virheellinenArvo", "Virheellinen arvo"),
-    ;
-
-    fun lowercaseName(): String = name.lowercase()
+    Henkilötunnus("hetu", "Henkilötunnus", "henkilötunnus"),
+    Nimi("nimi", "Nimi", "nimi"),
+    SchoolOid("schoolOid", "Organisaation OID", "schooloid"),
+    TeacherEmail("teacherEmail", "Opettajan sähköpostiosoite", "teacheremail"),
+    VirheenLuontiaika("virheenLuontiaika", "Virheen luontiaika", "virheenluontiaika"),
+    Viesti("viesti", "Virheviesti", "viesti"),
+    VirheellinenKentta("virheellinenKentta", "Virheellinen kenttä", "virheellinenkentta"),
+    VirheellinenArvo("virheellinenArvo", "Virheellinen arvo", "virheellinenarvo"),
 }

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiViewController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiViewController.kt
@@ -27,7 +27,7 @@ class KielitestiViewController(
 
         return ModelAndView("koto-kielitesti-suoritukset")
             .addObject("header", generateHeader<KielitestiSuoritusColumn>(sortColumn, sortDirection))
-            .addObject("sortColumn", sortColumn.lowercaseName())
+            .addObject("sortColumn", sortColumn.urlParam)
             .addObject("sortDirection", sortDirection)
             .addObject(
                 "errorsCount",
@@ -43,7 +43,7 @@ class KielitestiViewController(
     ): ModelAndView =
         ModelAndView("koto-kielitesti-virheet")
             .addObject("header", generateHeader<KielitestiSuoritusErrorColumn>(sortColumn, sortDirection))
-            .addObject("sortColumn", sortColumn.lowercaseName())
+            .addObject("sortColumn", sortColumn.urlParam)
             .addObject("sortDirection", sortDirection)
             .addObject("virheet", suoritusService.getErrors(sortColumn, sortDirection))
 }

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/html/VktIlmoittautuneet.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/html/VktIlmoittautuneet.kt
@@ -33,12 +33,13 @@ object VktIlmoittautuneet {
     enum class Column(
         override val dbColumn: String?,
         override val uiHeaderValue: String,
+        override val urlParam: String,
     ) : DisplayTableEnum {
-        Sukunimi("sukunimi", "Sukunimi"),
-        Etunimet("etunimi", "Etunimet"),
-        Kieli("tutkintokieli", "Tutkintokieli"),
-        Taitotaso("taitotaso", "Taitotaso"),
-        Tutkintopaiva("tutkintopaiva", "Tutkintopäivä"),
+        Sukunimi("sukunimi", "Sukunimi", "sukunimi"),
+        Etunimet("etunimi", "Etunimet", "etunimet"),
+        Kieli("tutkintokieli", "Tutkintokieli", "kieli"),
+        Taitotaso("taitotaso", "Taitotaso", "taitotaso"),
+        Tutkintopaiva("tutkintopaiva", "Tutkintopäivä", "tutkintopaiva"),
     }
 }
 

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/EnumFromUrlParamsParsingConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/EnumFromUrlParamsParsingConfig.kt
@@ -11,7 +11,7 @@ import org.springframework.format.FormatterRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+class EnumFromUrlParamsParsingConfig : WebMvcConfigurer {
     override fun addFormatters(registry: FormatterRegistry) {
         registry.apply {
             addEnumFromUrlParamParser<YkiSuoritusColumn>(YkiSuoritusColumn::urlParam)

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/WebConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/WebConfig.kt
@@ -25,11 +25,10 @@ class WebConfig : WebMvcConfigurer {
 
     private final inline fun <reified E : Enum<E>> FormatterRegistry.addEnumFromUrlParamParser(
         crossinline urlParamFieldGetter: (E) -> String,
-        ignoreCase: Boolean = true,
     ) {
         this.addConverter(String::class.java, E::class.java) { source ->
             enumValues<E>().find {
-                source.equals(urlParamFieldGetter(it), ignoreCase)
+                source.equals(urlParamFieldGetter(it), ignoreCase = true)
             }
         }
     }

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/WebConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/WebConfig.kt
@@ -14,19 +14,22 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class WebConfig : WebMvcConfigurer {
     override fun addFormatters(registry: FormatterRegistry) {
         registry.apply {
-            addEnumConverter<YkiSuoritusColumn>()
-            addEnumConverter<YkiSuoritusErrorColumn>()
-            addEnumConverter<YkiArvioijaColumn>()
-            addEnumConverter<KielitestiSuoritusColumn>()
-            addEnumConverter<KielitestiSuoritusErrorColumn>()
-            addEnumConverter<VktIlmoittautuneet.Column>()
+            addEnumConverter<YkiSuoritusColumn>(YkiSuoritusColumn::urlParam)
+            addEnumConverter<YkiSuoritusErrorColumn>(YkiSuoritusErrorColumn::urlParam)
+            addEnumConverter<YkiArvioijaColumn>(YkiArvioijaColumn::urlParam)
+            addEnumConverter<KielitestiSuoritusColumn>(KielitestiSuoritusColumn::urlParam)
+            addEnumConverter<KielitestiSuoritusErrorColumn>(KielitestiSuoritusErrorColumn::urlParam)
+            addEnumConverter<VktIlmoittautuneet.Column>(VktIlmoittautuneet.Column::urlParam)
         }
     }
 
-    private final inline fun <reified E : Enum<E>> FormatterRegistry.addEnumConverter(ignoreCase: Boolean = true) {
+    private final inline fun <reified E : Enum<E>> FormatterRegistry.addEnumConverter(
+        crossinline urlParamFieldGetter: (E) -> String,
+        ignoreCase: Boolean = true,
+    ) {
         this.addConverter(String::class.java, E::class.java) { source ->
             enumValues<E>().find {
-                it.name.equals(source, ignoreCase)
+                source.equals(urlParamFieldGetter(it), ignoreCase)
             }
         }
     }

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/WebConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/WebConfig.kt
@@ -14,16 +14,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class WebConfig : WebMvcConfigurer {
     override fun addFormatters(registry: FormatterRegistry) {
         registry.apply {
-            addEnumConverter<YkiSuoritusColumn>(YkiSuoritusColumn::urlParam)
-            addEnumConverter<YkiSuoritusErrorColumn>(YkiSuoritusErrorColumn::urlParam)
-            addEnumConverter<YkiArvioijaColumn>(YkiArvioijaColumn::urlParam)
-            addEnumConverter<KielitestiSuoritusColumn>(KielitestiSuoritusColumn::urlParam)
-            addEnumConverter<KielitestiSuoritusErrorColumn>(KielitestiSuoritusErrorColumn::urlParam)
-            addEnumConverter<VktIlmoittautuneet.Column>(VktIlmoittautuneet.Column::urlParam)
+            addEnumFromUrlParamParser<YkiSuoritusColumn>(YkiSuoritusColumn::urlParam)
+            addEnumFromUrlParamParser<YkiSuoritusErrorColumn>(YkiSuoritusErrorColumn::urlParam)
+            addEnumFromUrlParamParser<YkiArvioijaColumn>(YkiArvioijaColumn::urlParam)
+            addEnumFromUrlParamParser<KielitestiSuoritusColumn>(KielitestiSuoritusColumn::urlParam)
+            addEnumFromUrlParamParser<KielitestiSuoritusErrorColumn>(KielitestiSuoritusErrorColumn::urlParam)
+            addEnumFromUrlParamParser<VktIlmoittautuneet.Column>(VktIlmoittautuneet.Column::urlParam)
         }
     }
 
-    private final inline fun <reified E : Enum<E>> FormatterRegistry.addEnumConverter(
+    private final inline fun <reified E : Enum<E>> FormatterRegistry.addEnumFromUrlParamParser(
         crossinline urlParamFieldGetter: (E) -> String,
         ignoreCase: Boolean = true,
     ) {

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiViewController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiViewController.kt
@@ -60,7 +60,7 @@ class YkiViewController(
                     offset,
                 ),
             ).addObject("header", generateHeader<YkiSuoritusColumn>(sortColumn, sortDirection))
-            .addObject("sortColumn", sortColumn.lowercaseName())
+            .addObject("sortColumn", sortColumn.urlParam)
             .addObject("sortDirection", sortDirection)
             .addObject("paging", paging)
             .addObject("versionHistory", versionHistory)
@@ -75,7 +75,7 @@ class YkiViewController(
     ): ModelAndView =
         ModelAndView("yki-suoritukset-virheet")
             .addObject("header", generateHeader<YkiSuoritusErrorColumn>(sortColumn, sortDirection))
-            .addObject("sortColumn", sortColumn.lowercaseName())
+            .addObject("sortColumn", sortColumn.urlParam)
             .addObject("sortDirection", sortDirection)
             .addObject("virheet", suoritusErrorService.getErrors(sortColumn, sortDirection))
 
@@ -86,7 +86,7 @@ class YkiViewController(
     ): ModelAndView =
         ModelAndView("yki-arvioijat")
             .addObject("header", generateHeader<YkiArvioijaColumn>(sortColumn, sortDirection))
-            .addObject("sortColumn", sortColumn.lowercaseName())
+            .addObject("sortColumn", sortColumn.urlParam)
             .addObject("sortDirection", sortDirection)
             .addObject("arvioijat", ykiService.allArvioijat(sortColumn, sortDirection))
             // nullify 0 values for mustache
@@ -99,7 +99,7 @@ class YkiViewController(
     ): ModelAndView =
         ModelAndView("yki-arvioijat-virheet")
             .addObject("header", generateHeader<YkiArvioijaErrorColumn>(sortColumn, sortDirection))
-            .addObject("sortColumn", sortColumn.lowercaseName())
+            .addObject("sortColumn", sortColumn.urlParam)
             .addObject("sortDirection", sortDirection)
             .addObject("virheet", arvioijaErrorService.getErrors(sortColumn, sortDirection))
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaColumn.kt
@@ -3,37 +3,44 @@ package fi.oph.kitu.yki.arvioijat
 enum class YkiArvioijaColumn(
     val entityName: String,
     val uiHeaderValue: String,
+    val urlParam: String,
 ) {
     // id not added
 
     Oppijanumero(
         entityName = "arvioijanOppijanumero",
         uiHeaderValue = "Oppijanumero",
+        urlParam = "oppijanumero",
     ),
 
     Hetu(
         entityName = "henkilotunnus",
         uiHeaderValue = "Henkilötunnus",
+        urlParam = "hetu",
     ),
 
     Sukunimi(
         entityName = "sukunimi",
         uiHeaderValue = "Sukunimi",
+        urlParam = "sukunimi",
     ),
 
     Etunimet(
         entityName = "etunimet",
         uiHeaderValue = "Etunimet",
+        urlParam = "etunimet",
     ),
 
     Email(
         entityName = "sahkopostiosoite",
         uiHeaderValue = "Sähköposti",
+        urlParam = "email",
     ),
 
     Katuosoite(
         entityName = "katuosoite",
         uiHeaderValue = "Osoite",
+        urlParam = "katuosoite",
     ),
 
     // Postinumero(
@@ -49,43 +56,47 @@ enum class YkiArvioijaColumn(
     Tila(
         entityName = "tila",
         uiHeaderValue = "Tila",
+        urlParam = "tila",
     ),
 
     Kieli(
         entityName = "kieli",
         uiHeaderValue = "Kieli",
+        urlParam = "kieli",
     ),
 
     Tasot(
         entityName = "tasot",
         uiHeaderValue = "Tasot",
+        urlParam = "tasot",
     ),
 
     KaudenAlkupaiva(
         entityName = "kaudenAlkupaiva",
         uiHeaderValue = "Kauden Alkupäivä",
+        urlParam = "kaudenalkupaiva",
     ),
 
     KaudenPaattymispaiva(
         entityName = "kaudenPaattymispaiva",
         uiHeaderValue = "Kauden päättymispäivä",
+        urlParam = "kaudenpaattymispaiva",
     ),
 
     Jatkorekisterointi(
         entityName = "jatkorekisterointi",
         uiHeaderValue = "Jatkorekisteröinti",
+        urlParam = "jatkorekisterointi",
     ),
 
     Rekisteriintuontiaika(
         entityName = "rekisteriintuontiaika",
         uiHeaderValue = "Rekisteriintuontiaika",
+        urlParam = "rekisteriintuontiaika",
     ),
 
     // EnsimmainenRekisterointipaiva(
     //    dbColumn = "ensimmainenRekisterointipaiva",
     //    uiHeaderValue = "Ensimmäinen Rekisteröintipäivä",
     // ),
-    ;
-
-    fun lowercaseName(): String = name.lowercase()
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/error/YkiArvioijaErrorColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/error/YkiArvioijaErrorColumn.kt
@@ -3,16 +3,34 @@ package fi.oph.kitu.yki.arvioijat.error
 enum class YkiArvioijaErrorColumn(
     val entityName: String,
     val uiHeaderValue: String,
+    val urlParam: String,
 ) {
-    ArvioijanOid(entityName = "arvioijanOid", uiHeaderValue = "oppijanumero"),
-    Hetu(entityName = "hetu", uiHeaderValue = "hetu"),
-    Nimi(entityName = "nimi", uiHeaderValue = "nimi"),
-    VirheellinenKentta(entityName = "virheellinenKentta", uiHeaderValue = "virheellinen kenttä"),
-    VirheellinenArvo(entityName = "virheellinenArvo", uiHeaderValue = "virheellinen arvo"),
-    VirheellinenRivi(entityName = "virheellinenRivi", uiHeaderValue = "virheellinen rivi"),
-    VirheenRivinumero(entityName = "virheenRivinumero", uiHeaderValue = "virheen rivinumero"),
-    VirheenLuontiaika(entityName = "virheenLuontiaika", uiHeaderValue = "virheen luontiaika"),
-    ;
-
-    fun lowercaseName(): String = name.lowercase()
+    ArvioijanOid(entityName = "arvioijanOid", uiHeaderValue = "oppijanumero", urlParam = "arvioijanoid"),
+    Hetu(entityName = "hetu", uiHeaderValue = "hetu", urlParam = "hetu"),
+    Nimi(entityName = "nimi", uiHeaderValue = "nimi", urlParam = "nimi"),
+    VirheellinenKentta(
+        entityName = "virheellinenKentta",
+        uiHeaderValue = "virheellinen kenttä",
+        urlParam = "virheellinenkentta",
+    ),
+    VirheellinenArvo(
+        entityName = "virheellinenArvo",
+        uiHeaderValue = "virheellinen arvo",
+        urlParam = "virheellinenarvo",
+    ),
+    VirheellinenRivi(
+        entityName = "virheellinenRivi",
+        uiHeaderValue = "virheellinen rivi",
+        urlParam = "virheellinenrivi",
+    ),
+    VirheenRivinumero(
+        entityName = "virheenRivinumero",
+        uiHeaderValue = "virheen rivinumero",
+        urlParam = "virheenrivinumero",
+    ),
+    VirheenLuontiaika(
+        entityName = "virheenLuontiaika",
+        uiHeaderValue = "virheen luontiaika",
+        urlParam = "virheenluontiaika",
+    ),
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusColumn.kt
@@ -7,112 +7,131 @@ package fi.oph.kitu.yki.suoritukset
 enum class YkiSuoritusColumn(
     val dbColumn: String,
     val uiHeaderValue: String,
+    val urlParam: String,
 ) {
     SuorittajanOid(
         dbColumn = "suorittajan_oid",
         uiHeaderValue = "Oppijanumero",
+        urlParam = "suorittajanoid",
     ),
 
     Sukunimi(
         dbColumn = "sukunimi",
         uiHeaderValue = "Sukunimi",
+        urlParam = "sukunimi",
     ),
 
     Etunimet(
         dbColumn = "etunimet",
         uiHeaderValue = "Etunimi",
+        urlParam = "etunimet",
     ),
 
     Sukupuoli(
         dbColumn = "sukupuoli",
         uiHeaderValue = "Sukupuoli",
+        urlParam = "sukupuoli",
     ),
 
     Hetu(
         dbColumn = "hetu",
         uiHeaderValue = "Henkilötunnus",
+        urlParam = "hetu",
     ),
 
     Kansalaisuus(
         dbColumn = "kansalaisuus",
         uiHeaderValue = "Kansalaisuus",
+        urlParam = "kansalaisuus",
     ),
 
     Katuosoite(
         dbColumn = "katuosoite",
         uiHeaderValue = "Osoite",
+        urlParam = "katuosoite",
     ),
 
     Email(
         dbColumn = "email",
         uiHeaderValue = "Sähköposti",
+        urlParam = "email",
     ),
 
     SuoritusId(
         dbColumn = "suoritus_id",
         uiHeaderValue = "Suorituksen tunniste",
+        urlParam = "suoritusid",
     ),
 
     Tutkintopaiva(
         dbColumn = "tutkintopaiva",
         uiHeaderValue = "Tutkintopäivä",
+        urlParam = "tutkintopaiva",
     ),
 
     Tutkintokieli(
         dbColumn = "tutkintokieli",
         uiHeaderValue = "Tutkintokieli",
+        urlParam = "tutkintokieli",
     ),
 
     Tutkintotaso(
         dbColumn = "tutkintotaso",
         uiHeaderValue = "Tutkintotaso",
+        urlParam = "tutkintotaso",
     ),
 
     JarjestajanTunnusOid(
         dbColumn = "jarjestajan_tunnus_oid",
         uiHeaderValue = "Järjestäjän OID",
+        urlParam = "jarjestajantunnusoid",
     ),
 
     JarjestajanNimi(
         dbColumn = "jarjestajan_nimi",
         uiHeaderValue = "Järjestäjän nimi",
+        urlParam = "jarjestajannimi",
     ),
 
     Arviointipaiva(
         dbColumn = "arviointipaiva",
         uiHeaderValue = "Arviointipäivä",
+        urlParam = "arviointipaiva",
     ),
 
     TekstinYmmartaminen(
         dbColumn = "tekstin_ymmartaminen",
         uiHeaderValue = "Tekstin ymmärtäminen",
+        urlParam = "tekstinymmartaminen",
     ),
 
     Kirjoittaminen(
         dbColumn = "kirjoittaminen",
         uiHeaderValue = "Kirjoittaminen",
+        urlParam = "kirjoittaminen",
     ),
 
     RakenteetJaSanasto(
         dbColumn = "rakenteet_ja_sanasto",
         uiHeaderValue = "Rakenteet ja sanasto",
+        urlParam = "rakenteetjasanasto",
     ),
 
     PuheenYmmartamainen(
         dbColumn = "puheen_ymmartaminen",
         uiHeaderValue = "Puheen ymmärtäminen",
+        urlParam = "puheenymmartamainen",
     ),
 
     Puhuminen(
         dbColumn = "puhuminen",
         uiHeaderValue = "Puhuminen",
+        urlParam = "puhuminen",
     ),
 
     Yleisarvosana(
         dbColumn = "yleisarvosana",
         uiHeaderValue = "Yleisarvosana",
+        urlParam = "yleisarvosana",
     ),
-    ;
-
-    fun lowercaseName(): String = name.lowercase()
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorColumn.kt
@@ -3,17 +3,35 @@ package fi.oph.kitu.yki.suoritukset.error
 enum class YkiSuoritusErrorColumn(
     val entityName: String,
     val uiHeaderValue: String,
+    val urlParam: String,
 ) {
-    SuorittajanOid(entityName = "suorittajanOid", uiHeaderValue = "oppijanumero"),
-    Hetu(entityName = "hetu", uiHeaderValue = "hetu"),
-    Nimi(entityName = "nimi", uiHeaderValue = "nimi"),
-    LastModified(entityName = "lastModified", uiHeaderValue = "last modified"),
-    VirheellinenKentta(entityName = "virheellinenKentta", uiHeaderValue = "virheellinen kenttä"),
-    VirheellinenArvo(entityName = "virheellinenArvo", uiHeaderValue = "virheellinen arvo"),
-    VirheellinenRivi(entityName = "virheellinenRivi", uiHeaderValue = "virheellinen rivi"),
-    VirheenRivinumero(entityName = "virheenRivinumero", uiHeaderValue = "virheen rivinumero"),
-    VirheenLuontiaika(entityName = "virheenLuontiaika", uiHeaderValue = "virheen luontiaika"),
-    ;
-
-    fun lowercaseName(): String = name.lowercase()
+    SuorittajanOid(entityName = "suorittajanOid", uiHeaderValue = "oppijanumero", urlParam = "suorittajanoid"),
+    Hetu(entityName = "hetu", uiHeaderValue = "hetu", urlParam = "hetu"),
+    Nimi(entityName = "nimi", uiHeaderValue = "nimi", urlParam = "nimi"),
+    LastModified(entityName = "lastModified", uiHeaderValue = "last modified", urlParam = "lastmodified"),
+    VirheellinenKentta(
+        entityName = "virheellinenKentta",
+        uiHeaderValue = "virheellinen kenttä",
+        urlParam = "virheellinenkentta",
+    ),
+    VirheellinenArvo(
+        entityName = "virheellinenArvo",
+        uiHeaderValue = "virheellinen arvo",
+        urlParam = "virheellinenarvo",
+    ),
+    VirheellinenRivi(
+        entityName = "virheellinenRivi",
+        uiHeaderValue = "virheellinen rivi",
+        urlParam = "virheellinenrivi",
+    ),
+    VirheenRivinumero(
+        entityName = "virheenRivinumero",
+        uiHeaderValue = "virheen rivinumero",
+        urlParam = "virheenrivinumero",
+    ),
+    VirheenLuontiaika(
+        entityName = "virheenLuontiaika",
+        uiHeaderValue = "virheen luontiaika",
+        urlParam = "virheenluontiaika",
+    ),
 }

--- a/server/src/main/resources/templates/koto-kielitesti-suoritukset.mustache
+++ b/server/src/main/resources/templates/koto-kielitesti-suoritukset.mustache
@@ -21,7 +21,7 @@
           {{#header}}
             <th>
               <a href="?sortColumn={{
-            column.lowercaseName
+            column.urlParam
             }}&sortDirection={{
             sortDirection
             }}">

--- a/server/src/main/resources/templates/koto-kielitesti-virheet.mustache
+++ b/server/src/main/resources/templates/koto-kielitesti-virheet.mustache
@@ -13,8 +13,8 @@
         <thead>
         <tr>
           {{#header}}
-            <th id="{{column.lowercaseName}}">
-              <a href="?sortColumn={{column.lowercaseName}}&sortDirection={{sortDirection}}">
+            <th id="{{column.urlParam}}">
+              <a href="?sortColumn={{column.urlParam}}&sortDirection={{sortDirection}}">
               {{column.uiHeaderValue}} {{symbol}}
               </a>
             </th>

--- a/server/src/main/resources/templates/yki-arvioijat-virheet.mustache
+++ b/server/src/main/resources/templates/yki-arvioijat-virheet.mustache
@@ -15,7 +15,7 @@
         {{#header}}
           <th>
             <a href="?sortColumn={{
-              column.lowercaseName
+              column.urlParam
             }}&sortDirection={{
               sortDirection
             }}">

--- a/server/src/main/resources/templates/yki-arvioijat.mustache
+++ b/server/src/main/resources/templates/yki-arvioijat.mustache
@@ -21,7 +21,7 @@ Kielitutkintorekisteri - Yleiset kielitutkinnot - arvioijat
           {{#header}}
             <th>
               <a href="?sortColumn={{
-                  column.lowercaseName
+                  column.urlParam
               }}&sortDirection={{
                   sortDirection
               }}">

--- a/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
+++ b/server/src/main/resources/templates/yki-suoritukset-virheet.mustache
@@ -15,7 +15,7 @@
         {{#header}}
           <th>
             <a href="?sortColumn={{
-              column.lowercaseName
+              column.urlParam
             }}&sortDirection={{
               sortDirection
             }}">

--- a/server/src/main/resources/templates/yki-suoritukset.mustache
+++ b/server/src/main/resources/templates/yki-suoritukset.mustache
@@ -53,7 +53,7 @@ Kielitutkintorekisteri - Yleiset kielitutkinnot - suoritukset
             }}&includeVersionHistory={{
             versionHistory
             }}&sortColumn={{
-            column.lowercaseName
+            column.urlParam
             }}&sortDirection={{
             sortDirection
             }}">


### PR DESCRIPTION
Nämä muutokset pyrkivät vähentämään query parametrien parsintaan liittyviä epäselvyyksiä/maagisuuksia tekemällä muunnoksissa käytetyt merkkijonoarvot eksplisiittisemmin näkyviksi ja uudelleennimeämällä luokkia/metodeja hieman kuvaavammilla nimillä.

Nykyinen toteutus Enum-String-Enum -muunnoksille query parametreja varten sisältää joitain epäselvyyksiä. Toteutuksessa on jonkin verran yllättäviä, "tämä pitää vain tietää" -piirteitä. Muunmuassa `lowercaseName` ja (de)serialisionnin välinen yhteys ei ole juuri mitenkään dokumentoitu, eikä esim. "find all usages" -tyylisillä IDE ominaisuuksilla ole mahdollista huomata `Enum::name` ja `WebConfig.kt`:n liittyvän mitenkään toisiinsa.

Tämän vuoksi on esim. helpohkoa vahingossa päätyä rikkomaan sarakkeiden järjestämislinkit eri näkymissä, melko harmittoman oloisilla koodimuutoksilla.