### PR TITLE
Audit logging: force disable file appender in deployment environments

### DIFF
--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -3,25 +3,27 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/structured-console-appender.xml"/>
 
-    <appender name="AUDIT_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/audit.log</file>
-        <encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
-            <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
-            <charset>${FILE_LOG_CHARSET}</charset>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/audit.%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-    </appender>
-
-    <logger name="auditLogger" level="INFO" additivity="false">
-        <appender-ref ref="AUDIT_LOCAL"/>
-    </logger>
-
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
+
+    <springProfile name="!(untuva | qa | prod)">
+        <appender name="AUDIT_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/audit.log</file>
+            <encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
+                <format>${FILE_LOG_STRUCTURED_FORMAT}</format>
+                <charset>${FILE_LOG_CHARSET}</charset>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>logs/audit.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+        </appender>
+
+        <logger name="auditLogger" level="INFO" additivity="false">
+            <appender-ref ref="AUDIT_LOCAL"/>
+        </logger>
+    </springProfile>
 
     <springProfile name="untuva | qa | prod">
         <appender name="AUDIT_CLOUDWATCH" class="fi.oph.kitu.logging.CloudwatchAppender">


### PR DESCRIPTION
According to [this CloudWatch query](https://515966535475-ihzxz2j3.eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/KituService/log-events/kitu$252Fweb$252F8dcea7019b054fae840fe3b3c5a1b2bc$3Fstart$3D1748048400000$26filterPattern$3Dprincipal$26end$3D1748052000000) we're using the audit log file appender in deployment environments, even though we tried to disable it there with the `additivity=false` attribute. After re-reading [the logback documentation](https://logback.qos.ch/manual/configuration.html#overridingCumulativity) again I think that attribute only helps if the other appender(s) are higher in the configuration hierarchy. In our case they're at the same level (notwithstanding Spring profiles), so my assumption is that additivity has no effect. Unfortunately I can't find in the logback documentation what its behaviour is if you add multiple loggers with the same name, as we did before this PR.

This PR hopefully fixes this by separating the non-deployment environment logback configuration into its own `springProfile` block. This should remove the possibility of a duplicate logger.

(Ignore the branch name...)

Even though we've been logging audit logs into files (as well as CloudWatch) without meaning to, this should not be a security issue, since the files are not accessible and are thrown away when the container(s) restart.