### PR TITLE
Send ADOT logs to CloudWatch

### DIFF
--- a/infra/lib/service-stack.ts
+++ b/infra/lib/service-stack.ts
@@ -191,6 +191,10 @@ export class ServiceStack extends Stack {
         // renovate: datasource=docker
         "public.ecr.aws/aws-observability/aws-otel-collector:v0.43.3",
       ),
+      logging: LogDriver.awsLogs({
+        logGroup: props.logGroup,
+        streamPrefix: "AwsOtelCollector",
+      }),
     })
 
     props.auditLogGroup.grantWrite(this.service.service.taskDefinition.taskRole)


### PR DESCRIPTION
I'm trying to figure out why untuva doesn't have any traces. This might help. 