### PR TITLE
[Don't merge] Add a global HttpClient cookie manager

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/http/JDKHttpClientConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/http/JDKHttpClientConfig.kt
@@ -1,0 +1,22 @@
+package fi.oph.kitu.http
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.event.ContextStartedEvent
+import org.springframework.context.event.GenericApplicationListener
+import java.net.CookieHandler
+import java.net.CookieManager
+
+/**
+ * Configuration class for setting up and customizing [java.net.http.HttpClient].
+ *
+ * Adds a default cookie handler, which is missing in the default HttpClient configuration.
+ */
+@Configuration
+class JDKHttpClientConfig {
+    @Bean
+    fun configureCookieManager(): GenericApplicationListener =
+        GenericApplicationListener.forEventType(ContextStartedEvent::class.java) { _ ->
+            CookieHandler.setDefault(CookieManager())
+        }
+}


### PR DESCRIPTION
This allows us to remove the `HttpClient.newBuilder().cookieHandler()` customization where we use HttpClient or RestClient. I'm not sure this is actually needed.

We should first see merge #1337. 