### PR TITLE
Remove HttpClient otel instrumentation

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -263,10 +263,6 @@
             <version>1.44.0-alpha</version>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-java-http-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroHttpClientConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroHttpClientConfig.kt
@@ -1,7 +1,5 @@
 package fi.oph.kitu.oppijanumero
 
-import io.opentelemetry.instrumentation.javahttpclient.JavaHttpClientTelemetry
-import io.opentelemetry.sdk.OpenTelemetrySdk
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -15,19 +13,12 @@ import java.time.Duration
 @Configuration
 class OppijanumeroHttpClientConfig {
     @Bean("oppijanumeroHttpClient")
-    fun HttpClient(openTelemetry: OpenTelemetrySdk): HttpClient {
-        val httpClient =
-            HttpClient
-                .newBuilder()
-                .cookieHandler(CookieManager()) // sends JSESSIONID Cookie between the requests
-                .connectTimeout(Duration.ofSeconds(10))
-                .build()
-
-        return JavaHttpClientTelemetry
-            .builder(openTelemetry)
+    fun HttpClient(): HttpClient =
+        HttpClient
+            .newBuilder()
+            .cookieHandler(CookieManager()) // sends JSESSIONID Cookie between the requests
+            .connectTimeout(Duration.ofSeconds(10))
             .build()
-            .newHttpClient(httpClient)
-    }
 }
 
 @Configuration


### PR DESCRIPTION
We don't use java.net.HttpClient directly anymore, and RestClient is instrumented automatically: https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation/#spring-web-autoconfiguration