### PR TITLE
WIP VKT suorituksen mäppäys KoskiRequestiin

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/koodisto/Koodisto.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koodisto/Koodisto.kt
@@ -47,6 +47,7 @@ object Koodisto {
         YleisenKielitutkinnonOsa("yleisenkielitutkinnonosa"),
         ValtionhallinnonKielitutkinto("valtionhallinnonkielitutkinto"),
         ValtionhallinnonKielitaito("valtionhallinnonkielitaito"),
+        ValtionhallinnonKielitutkinnonOsa("valtionhallinnonkielitutkinnonosa"),
         ValtionhallinnonKielitutkinnonOsakoe("valtionhallinnonkielitutkinnonosakoe"),
         ;
 

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequest.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequest.kt
@@ -56,22 +56,6 @@ data class KoskiRequest(
                 val päivä: LocalDate,
                 val myöntäjäOrganisaatio: Organisaatio,
             )
-
-            data class Osasuoritus(
-                val tyyppi: Koodisto.SuorituksenTyyppi = Koodisto.SuorituksenTyyppi.YleisenKielitutkinnonOsa,
-                val koulutusmoduuli: OsasuoritusKoulutusModuuli,
-                val arviointi: List<Arvosana>,
-            ) {
-                data class OsasuoritusKoulutusModuuli(
-                    val tunniste: KoskiKoodiviite,
-                )
-
-                data class Arvosana(
-                    val arvosana: KoskiKoodiviite,
-                    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-                    val päivä: LocalDate,
-                )
-            }
         }
     }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
@@ -16,13 +16,12 @@ import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus.KoulutusModuuli
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus.Organisaatio
-import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus.Osasuoritus
-import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus.Osasuoritus.Arvosana
-import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus.Osasuoritus.OsasuoritusKoulutusModuuli
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus.Vahvistus
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.LahdeJarjestelmanId
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.Tila
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.Tila.OpiskeluoikeusJakso
+import fi.oph.kitu.vkt.VktOsakoe
+import fi.oph.kitu.vkt.VktSuoritusEntity
 import fi.oph.kitu.yki.Tutkintotaso
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -121,7 +120,7 @@ class KoskiRequestMapper {
         arvosana: Int,
         tutkintotaso: Tutkintotaso,
         arviointipaiva: LocalDate,
-    ) = Osasuoritus(
+    ) = YkiOsasuoritus(
         koulutusmoduuli =
             OsasuoritusKoulutusModuuli(
                 tunniste = suorituksenNimi.toKoski(),
@@ -170,6 +169,121 @@ class KoskiRequestMapper {
                 else -> throw IllegalArgumentException("Invalid YKI arvosana $arvosana for tutkintotaso $tutkintotaso")
             }
     }
+
+    fun vktSuoritusToKoskiRequest(vktSuoritus: VktSuoritusEntity) =
+        vktSuoritus.tutkinnot.mapNotNull { it.arviointipaiva }.maxOrNull()?.let { arviointipaiva ->
+            KoskiRequest(
+                henkilö = Henkilo(oid = vktSuoritus.suorittajanOppijanumero.toString()),
+                opiskeluoikeudet =
+                    listOf(
+                        Opiskeluoikeus(
+                            lähdejärjestelmänId = LahdeJarjestelmanId(id = vktSuoritus.id.toString()),
+                            tyyppi = Koodisto.OpiskeluoikeudenTyyppi.Kielitutkinto,
+                            tila =
+                                Tila(
+                                    opiskeluoikeusjaksot =
+                                        listOf(
+                                            OpiskeluoikeusJakso(
+                                                alku = vktSuoritus.osakokeet.minOf { it.tutkintopaiva },
+                                                tila = Koodisto.OpiskeluoikeudenTila.Lasna,
+                                            ),
+                                            OpiskeluoikeusJakso(
+                                                alku = vktSuoritus.osakokeet.maxOf { it.tutkintopaiva },
+                                                tila = Koodisto.OpiskeluoikeudenTila.Paattynyt,
+                                            ),
+                                        ),
+                                ),
+                            suoritukset =
+                                listOf(
+                                    KielitutkintoSuoritus(
+                                        tyyppi = Koodisto.SuorituksenTyyppi.ValtionhallinnonKielitutkinto,
+                                        koulutusmoduuli =
+                                            KoulutusModuuli(
+                                                tunniste = vktSuoritus.taitotaso.toKoski(),
+                                                kieli = vktSuoritus.tutkintokieli,
+                                            ),
+                                        toimipiste = Organisaatio(
+                                            oid = "" // TODO VKT-suorituksista puuttuu organisaatio mikä laittaa tähän
+                                        ),
+                                        vahvistus =
+                                            Vahvistus(
+                                                päivä = arviointipaiva,
+                                                myöntäjäOrganisaatio = Organisaatio(
+                                                    oid = "" // TODO VKT-suorituksista puuttuu organisaatio mikä laittaa tähän
+                                                ),
+                                            ),
+                                        osasuoritukset =
+                                            mapVktOsakokeetToTutkinto(vktSuoritus).let { osakokeet ->
+                                                vktSuoritus.tutkinnot
+                                                    .filter { it.arvosana != null && it.arviointipaiva != null }
+                                                    .map {
+                                                    VktKielitaito(
+                                                        tyyppi = Koodisto.SuorituksenTyyppi.ValtionhallinnonKielitaito,
+                                                        koulutusmoduuli =
+                                                            OsasuoritusKoulutusModuuli(
+                                                                tunniste = it.tyyppi.toKoski(),
+                                                            ),
+                                                        arviointi =
+                                                            listOf(
+                                                                Arvosana(
+                                                                    arvosana = it.arvosana!!.toKoski(),
+                                                                    päivä = it.arviointipaiva!!,
+                                                                ),
+                                                            ),
+                                                        osasuoritukset = osakokeet[it.tyyppi] ?: listOf(),
+                                                    )
+                                                }
+                                            },
+                                        yleisarvosana = null,
+                                    ),
+                                ),
+                        ),
+                    ),
+            )
+
+        }
+
+    fun mapVktOsakokeetToTutkinto(vktSuoritus: VktSuoritusEntity) =
+        vktOsakokeetToKoski(vktSuoritus).let { osakokeet ->
+            mapOf(
+                Koodisto.VktKielitaito.Kirjallinen to
+                    osakokeet.filter {
+                        it.koulutusmoduuli.tunniste == Koodisto.VktOsakoe.Kirjoittaminen.toKoski() ||
+                            it.koulutusmoduuli.tunniste == Koodisto.VktOsakoe.TekstinYmmärtäminen.toKoski()
+                    },
+                Koodisto.VktKielitaito.Suullinen to
+                    osakokeet.filter {
+                        it.koulutusmoduuli.tunniste == Koodisto.VktOsakoe.Puhuminen.toKoski() ||
+                            it.koulutusmoduuli.tunniste == Koodisto.VktOsakoe.PuheenYmmärtäminen.toKoski()
+                    },
+                Koodisto.VktKielitaito.Ymmärtäminen to
+                    osakokeet.filter {
+                        it.koulutusmoduuli.tunniste == Koodisto.VktOsakoe.PuheenYmmärtäminen.toKoski() ||
+                            it.koulutusmoduuli.tunniste == Koodisto.VktOsakoe.TekstinYmmärtäminen.toKoski()
+                    },
+            )
+        }
+
+    fun vktOsakokeetToKoski(vktSuoritus: VktSuoritusEntity) =
+        vktSuoritus.osakokeet.mapNotNull {
+            if (it.arvosana != null && it.arviointipaiva != null) {
+                VktOsakoe(
+                    koulutusmoduuli =
+                        OsasuoritusKoulutusModuuli(
+                            tunniste = it.tyyppi.toKoski(),
+                        ),
+                    arviointi =
+                        listOf(
+                            Arvosana(
+                                arvosana = it.arvosana.toKoski(),
+                                päivä = it.arviointipaiva,
+                            ),
+                        ),
+                )
+            } else {
+                null
+            }
+        }
 
     companion object {
         fun getObjectMapper(): ObjectMapper {

--- a/server/src/main/kotlin/fi/oph/kitu/koski/Osasuoritus.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/Osasuoritus.kt
@@ -1,0 +1,41 @@
+package fi.oph.kitu.koski
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import fi.oph.kitu.koodisto.Koodisto
+import fi.oph.kitu.koodisto.KoskiKoodiviite
+import java.time.LocalDate
+
+interface Osasuoritus {
+    val tyyppi: Koodisto.SuorituksenTyyppi
+    val koulutusmoduuli: OsasuoritusKoulutusModuuli
+    val arviointi: List<Arvosana>
+}
+
+data class OsasuoritusKoulutusModuuli(
+    val tunniste: KoskiKoodiviite,
+)
+
+data class Arvosana(
+    val arvosana: KoskiKoodiviite,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val päivä: LocalDate,
+)
+
+data class YkiOsasuoritus(
+    override val tyyppi: Koodisto.SuorituksenTyyppi = Koodisto.SuorituksenTyyppi.YleisenKielitutkinnonOsa,
+    override val koulutusmoduuli: OsasuoritusKoulutusModuuli,
+    override val arviointi: List<Arvosana>,
+) : Osasuoritus
+
+data class VktKielitaito(
+    override val tyyppi: Koodisto.SuorituksenTyyppi = Koodisto.SuorituksenTyyppi.ValtionhallinnonKielitaito,
+    override val koulutusmoduuli: OsasuoritusKoulutusModuuli,
+    override val arviointi: List<Arvosana>,
+    val osasuoritukset: List<VktOsakoe>,
+) : Osasuoritus
+
+data class VktOsakoe(
+    override val tyyppi: Koodisto.SuorituksenTyyppi = Koodisto.SuorituksenTyyppi.ValtionhallinnonKielitutkinnonOsakoe,
+    override val koulutusmoduuli: OsasuoritusKoulutusModuuli,
+    override val arviointi: List<Arvosana>,
+) : Osasuoritus

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -6,21 +6,21 @@ kitu.appUrl=http://localhost:8080
 kitu.opintopolkuHostname=virkailija.untuvaopintopolku.fi
 
 kitu.kotoutumiskoulutus.koealusta.baseurl=https://kielitesti.mmg.fi
-kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=true
+kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=false
 kitu.kotoutumiskoulutus.koealusta.scheduling.import.schedule=FIXED_DELAY|60s
 kitu.kotoutumiskoulutus.koealusta.scheduling.importTehtavapankki.schedule=-
 
 kitu.oppijanumero.casUrl=https://virkailija.untuvaopintopolku.fi/cas
 kitu.oppijanumero.service.url=https://virkailija.untuvaopintopolku.fi/oppijanumerorekisteri-service
 
-kitu.yki.scheduling.enabled=true
+kitu.yki.scheduling.enabled=false
 kitu.yki.scheduling.import.schedule=FIXED_DELAY|60s
 kitu.yki.scheduling.importArvioijat.schedule=FIXED_DELAY|60s
 kitu.yki.baseUrl=http://localhost:8080/dev/yki/import/
 #kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/yki-sp/oph/
 
 kitu.koski.baseUrl=https://untuvaopintopolku.fi/koski/api/
-kitu.koski.scheduling.enabled=true
+kitu.koski.scheduling.enabled=false
 kitu.koski.scheduling.send.schedule=FIXED_DELAY|60s
 
 kitu.koodistopalvelu.baseUrl=https://virkailija.untuvaopintopolku.fi/koodisto-service/rest/


### PR DESCRIPTION
- Lähinnä alustava hahmotelma, en ole kerennyt testaamaan toimiiko saati kirjottamaan testejä
- Kaipaa myös refaktorointia selkeämmäksi, nyt tämä on vähän tällainen ajatuksenvirta-henkinen 😅 
- VKT-suorituksiin ei ole liitetty organisaatiota jonka voisi lähettää Koskeen 
  - Erinomaisen taidon suorituksiin tarvitaan joku organisaatio, jonka voi liittää suorituksiin Koskessa 
  - Hyvän ja tyydyttävän taidon suorituksiin pitänee tuoda sen organisaation OID, joka kokeen järjestää
- Kysymyksiä joita en vielä ehtinyt miettiä loppuun:
  - Arvosanat ja arviointipäivät voi olla `null` suorituksilla, mäppäyksessä pitää ottaa huomioon miten ne käsitellään koska KOSKI vaatii niihin arvon -- jätetäänkö ne osasuoritukset pois joissa ei ole arvosanaa, vai mäpätäänkö ne esim hylätyksi? 
  - Osakokeet on KOSKI-tietomallissa ainoastaan osatutkintojen alla, joten jos esim. vain yksi osasuoritus on arvosteltu, miten se näytetään Koskessa? (Merkataanko tutkinnot joihin se kuuluu hylätyiksi ja niiden alla näkyy hyväksytty yksittäinen suoritus?) Tästä on ehkä puhuttu jossain weeklyssä, mutta en muista mitä olisi sovittu.
