### PR TITLE
chore(mise): upgrade maven to 3.9.11

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -5,7 +5,7 @@ AWS_PROFILE = "oph-ktr-dev"
 [tools]
 node = "22.17.0"
 "npm:prettier" = "3.6.2"
-"aqua:maven" = "3.9.10"
+"aqua:maven" = "3.9.11"
 awscli = "2.27.51"
 java = "corretto-21.0.7"
 shellcheck = "0.10.0"


### PR DESCRIPTION
Jostain syystä mise ei oo päivittänyt tähän, ja se hajotti ainakin tän #1498