### PR TITLE
Simplify OTEL sampling customizer 

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/observability/OpenTelemetrySamplingRules.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/observability/OpenTelemetrySamplingRules.kt
@@ -2,7 +2,6 @@ package fi.oph.kitu.observability
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.contrib.sampler.RuleBasedRoutingSampler
-import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
 import io.opentelemetry.semconv.UrlAttributes
 import org.springframework.context.annotation.Bean
@@ -13,14 +12,12 @@ class OpenTelemetrySamplingRules {
     // Sample 1% of health check requests
     @Bean
     fun healthCheckSampling() =
-        object : AutoConfigurationCustomizerProvider {
-            override fun customize(customizer: AutoConfigurationCustomizer) {
-                customizer.addSamplerCustomizer { fallback, config ->
-                    RuleBasedRoutingSampler
-                        .builder(SpanKind.SERVER, fallback)
-                        .drop(UrlAttributes.URL_PATH, "/actuator/health")
-                        .build()
-                }
+        AutoConfigurationCustomizerProvider { customizer ->
+            customizer.addSamplerCustomizer { fallback, _ ->
+                RuleBasedRoutingSampler
+                    .builder(SpanKind.SERVER, fallback)
+                    .drop(UrlAttributes.URL_PATH, "/actuator/health")
+                    .build()
             }
         }
 }


### PR DESCRIPTION
We can use Kotlin's functional interface syntax here. 