### PR TITLE
fix(infra): parametrize health check path

### DIFF
--- a/infra/lib/accounts.ts
+++ b/infra/lib/accounts.ts
@@ -1,4 +1,5 @@
 export interface EnvironmentConfig {
+  healthCheckPath: string
   name: string
   account: string
   region: string
@@ -38,6 +39,7 @@ export const deploymentAccounts: {
     slackWorkspaceId: "T02C6SZL7KP",
     slackChannelName: "kielitutkintorekisteri-alerts-dev-test",
     slackChannelId: "C08E14CRZ3J",
+    healthCheckPath: "/kielitutkinnot/actuator/health",
   },
   test: {
     name: "qa",
@@ -53,6 +55,7 @@ export const deploymentAccounts: {
     slackWorkspaceId: "T02C6SZL7KP",
     slackChannelName: "kielitutkintorekisteri-alerts-dev-test",
     slackChannelId: "C08E14CRZ3J",
+    healthCheckPath: "/actuator/health",
   },
   prod: {
     name: "prod",
@@ -68,6 +71,7 @@ export const deploymentAccounts: {
     slackWorkspaceId: "T02C6SZL7KP",
     slackChannelName: "kielitutkintorekisteri-alerts",
     slackChannelId: "C07QPSYBY7L",
+    healthCheckPath: "/actuator/health",
   },
 }
 

--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -89,6 +89,7 @@ export class EnvironmentStage extends Stage {
       image: props.serviceImage,
       alarmSnsTopic: alarmsStack.alarmSnsTopic,
       productionQuality: environmentConfig.productionQuality,
+      healthCheckPath: environmentConfig.healthCheckPath,
     })
 
     new Route53HealthChecksStack(this, "Route53HealthChecks", {

--- a/infra/lib/service-stack.ts
+++ b/infra/lib/service-stack.ts
@@ -37,6 +37,7 @@ import * as s3 from "aws-cdk-lib/aws-s3"
 import { StringParameter } from "aws-cdk-lib/aws-ssm"
 
 export interface ServiceStackProps extends StackProps {
+  healthCheckPath: string
   auditLogGroup: ILogGroup
   logGroup: ILogGroup
   image: ContainerImage
@@ -174,7 +175,7 @@ export class ServiceStack extends Stack {
       enabled: true,
       healthyThresholdCount: 2,
       interval: Duration.seconds(10),
-      path: "/kielitutkinnot/actuator/health",
+      path: props.healthCheckPath,
     })
 
     // The default load balancer configuration waits 300 seconds (5 minutes) before moving a container to UNUSED state.


### PR DESCRIPTION
We're in a weird situation where the application URL path component is different in untuva vs. test and prod. This will disappear soon but for now, let's do this.