### PR TITLE
Use __Host prefix to secure session cookie

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -10,6 +10,8 @@ server.error.path=/error
 
 kitu.uses-ssl-proxy=true
 
+server.servlet.session.cookie.name=__Host_KITU_SESSION
+
 kitu.kotoutumiskoulutus.koealusta.wstoken=${KIELITESTI_TOKEN}
 kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=false
 


### PR DESCRIPTION
Tämän lisäksi pitäisi kertoa Springille ettei aseta keksin domain-attribuuttia ollenkaan.