### PR TITLE
security: wait 3 days before automerging dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
       "automerge": true
     }
   ],


### PR DESCRIPTION
This is a precaution against supply-chain attacks like https://www.bleepingcomputer.com/news/security/npm-package-is-with-28m-weekly-downloads-infected-devs-with-malware/