### PR TITLE
feat: add ecs task definition for rds proxying

### DIFF
--- a/infra/lib/ecs-rds-proxy-stack.ts
+++ b/infra/lib/ecs-rds-proxy-stack.ts
@@ -1,0 +1,31 @@
+import { Stack, StackProps } from "aws-cdk-lib"
+import { Construct } from "constructs"
+import { ContainerImage, FargateTaskDefinition } from "aws-cdk-lib/aws-ecs"
+import { PolicyStatement } from "aws-cdk-lib/aws-iam"
+
+export class EcsRdsProxyStack extends Stack {
+  private readonly taskDefinition: FargateTaskDefinition
+
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props)
+
+    this.taskDefinition = new FargateTaskDefinition(this, "TaskDefinition")
+    // https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html#sessions-remote-port-forwarding
+    this.taskDefinition.addToTaskRolePolicy(
+      new PolicyStatement({
+        actions: [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ],
+        resources: ["*"],
+      }),
+    )
+    this.taskDefinition.addContainer("proxy", {
+      image: ContainerImage.fromRegistry(
+        "public.ecr.aws/amazonlinux/amazonlinux:2023-minimal",
+      ),
+    })
+  }
+}

--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -15,6 +15,7 @@ import { BackupsStack } from "./backups-stack"
 import { BackupResource } from "aws-cdk-lib/aws-backup"
 import { SlackBotStack } from "./slack-bot-stack"
 import { BastionStack } from "./bastion-stack"
+import { EcsRdsProxyStack } from "./ecs-rds-proxy-stack"
 
 interface EnvironmentStageProps extends StageProps {
   environmentConfig: EnvironmentConfig
@@ -80,6 +81,10 @@ export class EnvironmentStage extends Stage {
       env,
       vpc: networkStack.vpc,
       cluster: dbStack.cluster,
+    })
+
+    new EcsRdsProxyStack(this, "EcsRdsProxy", {
+      env,
     })
 
     new ServiceStack(this, "Service", {


### PR DESCRIPTION
Tämä on vaihtoehtoinen toteutustapa #1626 lisäksi. Se käytti EC2-instanssia, tämän kanssa taas voimme käyttää väliaikaisia ECS-taskeja. Kiitokset @ritinae lle ideasta.

Tässä ei ole vielä itse skriptejä tai luvitusta RDS-pääsyyn, eikä tämä poista tuota vaihtoehtoista tapaa vielä, vaan teen ne tämän päälle.