### PR TITLE
OPHKOTO-17: Palauta virheellisestä vkt-suoritusdatasta 400 ja lista validointivirheistä

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/ErrorHandler.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ErrorHandler.kt
@@ -26,7 +26,7 @@ class GlobalControllerExceptionHandler {
             RestErrorMessage(
                 status = HttpStatus.BAD_REQUEST.value(),
                 error = "Bad request: validation error",
-                messages = e.errors,
+                messages = e.errors.map { it.toString() },
             ),
             HttpStatus.BAD_REQUEST,
         )

--- a/server/src/main/kotlin/fi/oph/kitu/Validation.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/Validation.kt
@@ -18,8 +18,15 @@ interface Validation<T> {
     fun validationAfterEnrichment(value: T): ValidationResult<T> = ok(value)
 
     data class ValidationException(
-        val errors: List<String>,
+        val errors: List<ValidationError>,
     ) : Exception(errors.joinToString("; "))
+
+    data class ValidationError(
+        val path: List<String>,
+        val message: String,
+    ) {
+        override fun toString(): String = "${path.joinToString(".")}: $message"
+    }
 
     companion object {
         inline fun <reified T> fold(
@@ -39,8 +46,12 @@ interface Validation<T> {
 
         fun <T> ok(value: T): ValidationResult<T> = TypedResult.Success(value)
 
-        fun <T> fail(reason: String): ValidationResult<T> = fail(listOf(reason))
+        fun <T> fail(
+            path: List<String>,
+            message: String,
+        ): ValidationResult<T> = fail(listOf(ValidationError(path, message)))
 
-        fun <T> fail(reasons: List<String>): ValidationResult<T> = TypedResult.Failure(ValidationException(reasons))
+        fun <T> fail(reasons: List<ValidationError>): ValidationResult<T> =
+            TypedResult.Failure(ValidationException(reasons))
     }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktTiedonsiirtoController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktTiedonsiirtoController.kt
@@ -131,6 +131,6 @@ class VktTiedonsiirtoController(
         } catch (e: JsonMappingException) {
             TiedonsiirtoFailure.badRequest(e.message ?: "JSON mapping failed for unknown reason")
         } catch (e: Validation.ValidationException) {
-            TiedonsiirtoFailure(statusCode = HttpStatus.BAD_REQUEST, errors = e.errors)
+            TiedonsiirtoFailure(statusCode = HttpStatus.BAD_REQUEST, errors = e.errors.map { it.toString() })
         }.toResponseEntity()
 }

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktValidation.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktValidation.kt
@@ -33,14 +33,14 @@ class VktValidation : Validation<VktSuoritus> {
 
     private fun validateSuorituspaikkakunta(s: VktSuoritus): ValidationResult<VktSuoritus> =
         if (s.suorituspaikkakunta == null) {
-            Validation.fail("Suorituspaikkakunta puuttuu")
+            Validation.fail(listOf("suoritus", "suorituspaikkakunta"), "Suorituspaikkakunta puuttuu")
         } else {
             Validation.ok(s)
         }
 
     private fun validateSuorituksenVastaanottaja(s: VktSuoritus): ValidationResult<VktSuoritus> =
         if (s.suorituksenVastaanottaja == null) {
-            Validation.fail("Suorituksen vastaanottaja puuttuu")
+            Validation.fail(listOf("suoritus", "suorituksenVastaanottaja"), "Suorituksen vastaanottaja puuttuu")
         } else {
             Validation.ok(s)
         }


### PR DESCRIPTION
- **Palauta validaatiovirheet oikein kutsujalle**
- **Mahdollista useamman viestin lähetys virheviestissä**
- **Palauta validointivirheissä json-polku**
