### PR TITLE
feat: get only cloudwatch events containing word operation

### DIFF
--- a/infra/lib/koski-audit-logs-integration-stack.ts
+++ b/infra/lib/koski-audit-logs-integration-stack.ts
@@ -28,7 +28,10 @@ export class KoskiAuditLogsIntegrationStack extends Stack {
     new SubscriptionFilter(this, "sendAuditLogsToKoskiSubscriptionFilter", {
       logGroup: props.serviceAuditLogGroup,
       filterName: "sendAuditLogsToKoski",
-      filterPattern: FilterPattern.allEvents(),
+      // We only send audit logs to koski, that are in OPH standardized format.
+      // The format is checking by this filter - if the event contains word "operation",
+      // it will be passed to lambda
+      filterPattern: FilterPattern.anyTerm("operation"),
       destination: new aws_logs_destinations.LambdaDestination(
         sendAuditLogsToKoskiLambda,
       ),

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KoealustaService.kt
@@ -4,7 +4,6 @@ import fi.oph.kitu.PeerService
 import fi.oph.kitu.SortDirection
 import fi.oph.kitu.findAllSorted
 import fi.oph.kitu.jdbc.replaceAll
-import fi.oph.kitu.logging.AuditContext
 import fi.oph.kitu.logging.AuditLogger
 import fi.oph.kitu.logging.KituAuditLogMessageField
 import fi.oph.kitu.logging.KituAuditLogOperation
@@ -50,7 +49,7 @@ class KoealustaService(
                     )
                 }
 
-                auditLogger.logAll("Kielitesti suoritus viewed", it) { suoritus ->
+                auditLogger.logAllInternalOnly("Kielitesti suoritus viewed", it) { suoritus ->
                     arrayOf(
                         "suoritus.id" to suoritus.id,
                     )
@@ -98,7 +97,7 @@ class KoealustaService(
                 kielitestiSuoritusRepository
                     .saveAll(suoritukset)
                     .also {
-                        auditLogger.logAll("Kielitesti suoritus imported", it) { suoritus ->
+                        auditLogger.logAllInternalOnly("Kielitesti suoritus imported", it) { suoritus ->
                             arrayOf(
                                 "suoritus.id" to suoritus.id,
                                 "principal" to "koealusta.import",

--- a/server/src/main/kotlin/fi/oph/kitu/logging/AuditLogger.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/AuditLogger.kt
@@ -42,12 +42,22 @@ class AuditLogger(
             .log(message)
     }
 
+    /**
+     * Logs events.
+     *
+     * Note: the logged events with this method will be passed to an audit log integration on a lambda.
+     */
     fun log(
         operation: KituAuditLogOperation,
         target: Iterable<Pair<KituAuditLogMessageField, String>>,
         changes: Changes = Changes.EMPTY,
     ) = log(AuditContext.get(), operation, target, changes)
 
+    /**
+     * Logs events.
+     *
+     * Note: the logged events with this method will be passed to an audit log integration on a lambda.
+     */
     fun log(
         context: AuditContext,
         operation: KituAuditLogOperation,
@@ -64,7 +74,7 @@ class AuditLogger(
         audit.log(user, operation, targetBuilder.build(), changes)
     }
 
-    fun <E> logAll(
+    fun <E> logAllInternalOnly(
         message: String,
         entities: Iterable<E>,
         properties: (E) -> Array<Pair<String, Any?>>,
@@ -78,6 +88,11 @@ class AuditLogger(
         }
     }
 
+    /**
+     * Logs events.
+     *
+     * Note: the logged events with this method will be passed to an audit log integration on a lambda.
+     */
     fun <E> logAll(
         operation: KituAuditLogOperation,
         entities: Iterable<E>,

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -76,7 +76,7 @@ class YkiService(
 
                 val saved = suoritusRepository.saveAll(suoritusMapper.convertToEntityIterable(suoritukset))
                 span.setAttribute("importedSuorituksetSize", saved.count().toLong())
-                auditLogger.logAll("YKI suoritus imported", saved) { suoritus ->
+                auditLogger.logAllInternalOnly("YKI suoritus imported", saved) { suoritus ->
                     arrayOf(
                         "principal" to "yki.importSuoritukset",
                         "suoritus.id" to suoritus.suoritusId,
@@ -123,7 +123,7 @@ class YkiService(
 
                 span.setAttribute("yki.arvioijat.importedCount", importedArvioijat.count())
 
-                auditLogger.logAll("YKI arvioija imported", importedArvioijat) { arvioija ->
+                auditLogger.logAllInternalOnly("YKI arvioija imported", importedArvioijat) { arvioija ->
                     arrayOf(
                         "principal" to "yki.importArvioijat",
                         "peer.service" to PeerService.Solki.value,
@@ -153,7 +153,7 @@ class YkiService(
             .find(distinct = !versionHistory)
             .toList()
             .also {
-                auditLogger.logAll("Yki suoritus viewed", it) { suoritus ->
+                auditLogger.logAllInternalOnly("Yki suoritus viewed", it) { suoritus ->
                     arrayOf(
                         "suoritus.id" to suoritus.id,
                     )
@@ -185,7 +185,7 @@ class YkiService(
                 offset = offset,
             ).toList()
             .also {
-                auditLogger.logAll("Yki suoritus viewed", it) { suoritus ->
+                auditLogger.logAllInternalOnly("Yki suoritus viewed", it) { suoritus ->
                     arrayOf(
                         "suoritus.id" to suoritus.id,
                     )
@@ -201,7 +201,7 @@ class YkiService(
             .findAllSorted(orderBy.entityName, orderByDirection)
             .toList()
             .also {
-                auditLogger.logAll("Yki arvioija viewed", it) { arvioija ->
+                auditLogger.logAllInternalOnly("Yki arvioija viewed", it) { arvioija ->
                     arrayOf("arvioija.oppijanumero" to arvioija.arvioijanOppijanumero)
                 }
             }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/error/YkiArvioijaErrorService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/error/YkiArvioijaErrorService.kt
@@ -43,7 +43,7 @@ class YkiArvioijaErrorService(
             .findAllSorted(orderBy.entityName, orderByDirection)
             .toList()
             .also {
-                auditLogger.logAll("Yki arvioija errors viewed", it) { error ->
+                auditLogger.logAllInternalOnly("Yki arvioija errors viewed", it) { error ->
                     arrayOf("arvioija.error.id" to error.id)
                 }
             }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/error/YkiSuoritusErrorService.kt
@@ -57,7 +57,7 @@ class YkiSuoritusErrorService(
             .findAllSorted(orderBy.entityName, orderByDirection)
             .toList()
             .also {
-                auditLogger.logAll("Yki suoritus errors viewed", it) { error ->
+                auditLogger.logAllInternalOnly("Yki suoritus errors viewed", it) { error ->
                     arrayOf("suoritus.error.id" to error.id)
                 }
             }


### PR DESCRIPTION
Lähetetään vain CloudWatch -eventit lambdalle, jotka sisältää sanan `operation`. Käytännössä #1666 - muutosten myötä ainoastaan 

https://github.com/Opetushallitus/koto-rekisteri/pull/1666/files#diff-e91b75094973745b11911849ba53a6a9dd306fe939a89a9a8263fee4a50bab1fR45-R51

log-overloadit viedään lambdaan. Pitäisiköhän niihin merkata/kommentoida jotenkin, näin tapahtuu? Tämä logiikka on aika implisiiittinen / ja ehkä hiljaista tietoa, niin siitä vois jotenkin huomauttaa koodissa