### PR TITLE
OPHKOTO-18: Siirrä vkt-suoritukset kokonaisuuksina Koskeen yksittäisten ilmoittautumisten sijaan

### DIFF
--- a/e2e/tests/vkt/vkt-suoritukset.spec.ts
+++ b/e2e/tests/vkt/vkt-suoritukset.spec.ts
@@ -36,7 +36,7 @@ describe("Valtionkielitutkinnon suoritukset page", () => {
     await expect(table.rows).toHaveCount(50)
 
     await testForEach(
-      table.getCellsOfRow("1.2.246.562.24.62917207394-SV"),
+      table.getCellsOfRow("1.2.246.562.24.00000000012-SV"),
       expectToHaveText("Halonen"),
       expectToHaveText("Vilho Eero"),
       expectToHaveKoodiviite("kieli", "SV"),
@@ -77,7 +77,7 @@ describe("Valtionkielitutkinnon suoritukset page", () => {
     // Varmista että ollaan oikeassa fikstuurissa
     await vktHjtSuorituksetPage.login()
     await vktHjtSuorituksetPage.open()
-    await vktHjtSuorituksetPage.followLinkOfRow("1.2.246.562.24.26960378782-SV")
+    await vktHjtSuorituksetPage.followLinkOfRow("1.2.246.562.24.00000000007-SV")
     await expect(vktSuorituksenTiedotPage.heading()).toHaveText(
       "Eriksson, Fiona Konsta",
     )
@@ -124,7 +124,7 @@ describe("Valtionkielitutkinnon suoritukset page", () => {
     await vktArvioidutSuorituksetPage.login()
     await vktArvioidutSuorituksetPage.open()
     await vktArvioidutSuorituksetPage.followLinkOfRow(
-      "1.2.246.562.24.08842807667-FI",
+      "1.2.246.562.24.00000000063-FI",
     )
     await expect(vktSuorituksenTiedotPage.heading()).toHaveText(
       "Eriksson, Daniel Ville",
@@ -170,7 +170,7 @@ describe("Valtionkielitutkinnon suoritukset page", () => {
     // Varmista että ollaan oikeassa fikstuurissa
     await vktSuorituksenTiedotPage.login()
     await vktSuorituksenTiedotPage.open(
-      "1.2.246.562.24.18289922952",
+      "1.2.246.562.24.00000000446",
       "FIN",
       "Erinomainen",
     )
@@ -214,7 +214,7 @@ describe("Valtionkielitutkinnon suoritukset page", () => {
     await vktIlmoittautuneetPage.login()
     await vktIlmoittautuneetPage.open()
     await vktIlmoittautuneetPage.followLinkOfRow(
-      "1.2.246.562.24.62917207394-SV",
+      "1.2.246.562.24.00000000012-SV",
     )
     await expect(vktSuorituksenTiedotPage.heading()).toHaveText(
       "Halonen, Vilho Eero",
@@ -297,12 +297,12 @@ describe("Valtionkielitutkinnon suoritukset page", () => {
     test("Search by oppijanumero works", async ({ vktIlmoittautuneetPage }) => {
       await vktIlmoittautuneetPage.login()
       await vktIlmoittautuneetPage.open()
-      await vktIlmoittautuneetPage.search("1.2.246.562.24.58644376343")
+      await vktIlmoittautuneetPage.search("1.2.246.562.24.00000000055")
 
       await expect(vktIlmoittautuneetPage.table.rows).toHaveCount(1)
       await expectToHaveTexts(
         vktIlmoittautuneetPage.table.getCellsOfRow(
-          "1.2.246.562.24.58644376343-SV",
+          "1.2.246.562.24.00000000055-SV",
         ),
         "Huhtala",
         "Nella Eveliina",

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiException.kt
@@ -1,6 +1,6 @@
 package fi.oph.kitu.koski
 
 class KoskiException(
-    val suoritusId: Int?,
+    val suoritusId: String,
     message: String?,
 ) : Throwable(message)

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
@@ -19,7 +19,6 @@ import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.KielitutkintoSuoritus.Organ
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.LahdeJarjestelmanId
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.Tila
 import fi.oph.kitu.koski.KoskiRequest.Opiskeluoikeus.Tila.OpiskeluoikeusJakso
-import fi.oph.kitu.oppijanumero.OppijanumeroService
 import fi.oph.kitu.vkt.VktSuoritus
 import fi.oph.kitu.vkt.tiedonsiirtoschema.Henkilosuoritus
 import fi.oph.kitu.yki.Tutkintotaso
@@ -187,10 +186,7 @@ class KoskiRequestMapper {
             }
     }
 
-    fun vktSuoritusToKoskiRequest(
-        henkilosuoritus: Henkilosuoritus<VktSuoritus>,
-        onrService: OppijanumeroService,
-    ): KoskiRequest? {
+    fun vktSuoritusToKoskiRequest(henkilosuoritus: Henkilosuoritus<VktSuoritus>): KoskiRequest? {
         val henkilo = henkilosuoritus.henkilo
         val suoritus = henkilosuoritus.suoritus
 

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRestClientConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRestClientConfig.kt
@@ -14,10 +14,10 @@ class KoskiRestClientConfig(
     @Value("\${kitu.koski.baseUrl}")
     private lateinit var koskiBaseUrl: String
 
-    @Value("\${kitu.palvelukayttaja.username}")
+    @Value("\${kitu.koski.username:\${kitu.palvelukayttaja.username}}")
     private lateinit var user: String
 
-    @Value("\${kitu.palvelukayttaja.password}")
+    @Value("\${kitu.koski.password:\${kitu.palvelukayttaja.password}}")
     private lateinit var password: String
 
     @Bean("koskiRestClient")

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiScheduledTask.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiScheduledTask.kt
@@ -36,8 +36,7 @@ class KoskiScheduledTask(
             .execute { _, _ ->
                 tracer.spanBuilder("KoskiScheduledTask.sendSuoritukset.tasks.execute").startSpan().use { span ->
                     span.setAttribute("task.name", "KOSKI-send-VKT-suoritukset")
-                    // TODO: Poista tämä kommenteista, kun organisaatiokysymys on saatu ratkaistua
-                    // koskiService.sendVktSuorituksetToKoski()
+                    koskiService.sendVktSuorituksetToKoski()
                 }
             }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/mock/OidGenerator.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/mock/OidGenerator.kt
@@ -3,16 +3,26 @@ package fi.oph.kitu.mock
 import fi.oph.kitu.Oid
 import kotlin.random.Random
 
-fun generateOidOfClass(
-    oidClass: String,
-    random: Random = Random,
+enum class OidClass(
+    val classString: String,
+) {
+    OPPIJA("1.2.246.562.24"),
+    USER("1.2.246.562.240"),
+    ORG("1.2.246.562.100"),
+}
+
+fun createOid(
+    oidClass: OidClass,
+    n: Long,
 ): Oid =
     Oid
-        .parse(
-            "$oidClass.${
-                (0..99999999999).random(random).toString().padStart(11, '0')
-            }",
-        ).getOrThrow()
+        .parse("${oidClass.classString}.${n.toString().padStart(11, '0')}")
+        .getOrThrow()
+
+fun generateOidOfClass(
+    oidClass: OidClass,
+    random: Random = Random,
+): Oid = createOid(oidClass, (0..99999999999).random(random))
 
 /**
  * Generates random user OID under node class 1.2.246.562.24.
@@ -20,7 +30,7 @@ fun generateOidOfClass(
  * Note: Node class 24 is the correct class for users,
  * but these values should not be used in production.
  */
-fun generateRandomOppijaOid(random: Random = Random): Oid = generateOidOfClass("1.2.246.562.24", random)
+fun generateRandomOppijaOid(random: Random = Random): Oid = generateOidOfClass(OidClass.OPPIJA, random)
 
 /**
  * Generates random oppija OID under node class 1.2.246.562.240.
@@ -28,7 +38,7 @@ fun generateRandomOppijaOid(random: Random = Random): Oid = generateOidOfClass("
  * Note: Node class 240 is the correct class for users,
  * but these values should not be used in production.
  */
-fun generateRandomUserOid(random: Random = Random): Oid = generateOidOfClass("1.2.246.562.240", random)
+fun generateRandomUserOid(random: Random = Random): Oid = generateOidOfClass(OidClass.USER, random)
 
 /**
  * Generates random user OID under node class 1.2.246.562.100.
@@ -36,4 +46,4 @@ fun generateRandomUserOid(random: Random = Random): Oid = generateOidOfClass("1.
  * Note: Node class 10 is the correct class for organizations,
  * but these values should not be used in production.
  */
-fun generateRandomOrganizationOid(random: Random = Random) = generateOidOfClass("1.2.246.562.100", random)
+fun generateRandomOrganizationOid(random: Random = Random) = generateOidOfClass(OidClass.ORG, random)

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusService.kt
@@ -4,6 +4,7 @@ import fi.oph.kitu.Cache
 import fi.oph.kitu.SortDirection
 import fi.oph.kitu.html.Pagination
 import fi.oph.kitu.koodisto.Koodisto
+import fi.oph.kitu.vkt.CustomVktSuoritusRepository.Tutkintoryhma
 import fi.oph.kitu.vkt.html.VktTableItem
 import fi.oph.kitu.vkt.tiedonsiirtoschema.Henkilosuoritus
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -74,12 +75,8 @@ class VktSuoritusService(
             .map { Henkilosuoritus.from(it) }
 
     @WithSpan("VktSuoritusService.getOppijanSuoritukset")
-    fun getOppijanSuoritukset(
-        oppijanumero: String,
-        kieli: Koodisto.Tutkintokieli,
-        taso: Koodisto.VktTaitotaso,
-    ): Henkilosuoritus<VktSuoritus>? {
-        val ids = customSuoritusRepository.getOppijanSuoritusIds(oppijanumero, kieli, taso)
+    fun getOppijanSuoritukset(id: Tutkintoryhma): Henkilosuoritus<VktSuoritus>? {
+        val ids = customSuoritusRepository.getOppijanSuoritusIds(id)
         val suoritukset =
             ids
                 .mapNotNull { suoritusRepository.findById(it).getOrNull() }
@@ -95,10 +92,10 @@ class VktSuoritusService(
     ) = osakoeRepository.updateArvosana(id, arvosana, arviointipaiva)
 
     @WithSpan("VktSuoritusServer.setSuoritusTransferredToKoski")
-    fun setSuoritusTransferredToKoski(
-        id: Int,
+    fun markKoskiTransferProcessed(
+        id: Tutkintoryhma,
         koskiOpiskeluoikeusOid: String? = null,
-    ) = customSuoritusRepository.setSuoritusTransferredToKoski(id, koskiOpiskeluoikeusOid)
+    ) = customSuoritusRepository.markSuoritusTransferredToKoski(id, koskiOpiskeluoikeusOid)
 
     private val listRowCounts =
         Cache(ttl = 5.minutes) { params: Triple<Koodisto.VktTaitotaso, Boolean?, String?> ->

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktViewController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktViewController.kt
@@ -151,9 +151,8 @@ class VktViewController(
         @PathVariable taso: Koodisto.VktTaitotaso,
         viewMessage: ViewMessage? = null,
     ): ResponseEntity<String> {
-        val suoritus =
-            vktSuoritukset
-                .getOppijanSuoritukset(oppijanumero, kieli, taso) ?: throw VktSuoritusNotFoundError()
+        val id = CustomVktSuoritusRepository.Tutkintoryhma(oppijanumero, kieli, taso)
+        val suoritus = vktSuoritukset.getOppijanSuoritukset(id) ?: throw VktSuoritusNotFoundError()
 
         val henkilo =
             suoritus.henkilo.oid

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -26,7 +26,6 @@ kitu.yki.baseUrl=http://localhost:8080/kielitutkinnot/dev/yki/import/
 #kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/yki-sp/oph/
 
 #kitu.koski.baseUrl=https://untuvaopintopolku.fi/koski/api/
-kitu.koski.baseUrl=http://localhost:7091/koski/api/
 kitu.koski.scheduling.enabled=true
 kitu.koski.scheduling.send.schedule=FIXED_DELAY|60s
 

--- a/server/src/main/resources/application-localkoski.properties
+++ b/server/src/main/resources/application-localkoski.properties
@@ -1,0 +1,3 @@
+kitu.koski.username=p\u00E4\u00E4
+kitu.koski.password=p\u00E4\u00E4
+kitu.koski.baseUrl=http://localhost:7021/koski/api/

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiRequestMapperTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiRequestMapperTest.kt
@@ -267,7 +267,7 @@ class KoskiRequestMapperTest(
             )
 
         val onr = MockOppijanumeroService.build()
-        val koskiSuoritus = koskiRequestMapper.vktSuoritusToKoskiRequest(henkilosuoritus, onr)
+        val koskiSuoritus = koskiRequestMapper.vktSuoritusToKoskiRequest(henkilosuoritus)
 
         assertNotNull(koskiSuoritus)
 
@@ -361,7 +361,7 @@ class KoskiRequestMapperTest(
                     ),
             )
 
-        val koskiSuoritus = koskiRequestMapper.vktSuoritusToKoskiRequest(henkilosuoritus, onr)
+        val koskiSuoritus = koskiRequestMapper.vktSuoritusToKoskiRequest(henkilosuoritus)
 
         assertNotNull(koskiSuoritus)
 

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
@@ -4,7 +4,6 @@ import fi.oph.kitu.DBContainerConfiguration
 import fi.oph.kitu.TypedResult
 import fi.oph.kitu.logging.OpenTelemetryTestConfig
 import fi.oph.kitu.mock.generateRandomYkiSuoritusEntity
-import fi.oph.kitu.oppijanumero.MockOppijanumeroService
 import fi.oph.kitu.vkt.CustomVktSuoritusRepository
 import fi.oph.kitu.vkt.VktSuoritusRepository
 import fi.oph.kitu.vkt.VktSuoritusService
@@ -97,18 +96,14 @@ class KoskiServiceTest(
                 ),
             )
 
-        val onrService = MockOppijanumeroService.build()
-
         val service =
             KoskiService(
                 mockRestClientBuilder.build(),
                 koskiRequestMapper,
                 ykiSuoritusRepository,
                 tracer,
-                vktSuoritusRepository,
                 customVktSuoritusRepository,
                 vktSuoritusService,
-                onrService,
             )
 
         val updatedSuoritus = service.sendYkiSuoritusToKoski(suoritus).getOrThrow()
@@ -134,25 +129,21 @@ class KoskiServiceTest(
                 withBadRequest().body(expectedResponse),
             )
 
-        val onrService = MockOppijanumeroService.build()
-
         val service =
             KoskiService(
                 mockRestClientBuilder.build(),
                 koskiRequestMapper,
                 ykiSuoritusRepository,
                 tracer,
-                vktSuoritusRepository,
                 customVktSuoritusRepository,
                 vktSuoritusService,
-                onrService,
             )
         val suoritus =
             generateRandomYkiSuoritusEntity().copy(id = 1)
 
         val updatedSuoritus = service.sendYkiSuoritusToKoski(suoritus)
         assertTrue(updatedSuoritus is TypedResult.Failure)
-        assertEquals(suoritus.id, updatedSuoritus.errorOrNull()?.suoritusId)
+        assertEquals(suoritus.id.toString(), updatedSuoritus.errorOrNull()?.suoritusId)
     }
 
     @Test
@@ -192,18 +183,14 @@ class KoskiServiceTest(
                 ),
             )
 
-        val onrService = MockOppijanumeroService.build()
-
         val service =
             KoskiService(
                 mockRestClientBuilder.build(),
                 koskiRequestMapper,
                 ykiSuoritusRepository,
                 tracer,
-                vktSuoritusRepository,
                 customVktSuoritusRepository,
                 vktSuoritusService,
-                onrService,
             )
 
         ykiSuoritusRepository.saveAll(
@@ -266,18 +253,14 @@ class KoskiServiceTest(
                 ),
             )
 
-        val onrService = MockOppijanumeroService.build()
-
         val service =
             KoskiService(
                 mockRestClientBuilder.build(),
                 koskiRequestMapper,
                 ykiSuoritusRepository,
                 tracer,
-                vktSuoritusRepository,
                 customVktSuoritusRepository,
                 vktSuoritusService,
-                onrService,
             )
 
         ykiSuoritusRepository.saveAll(


### PR DESCRIPTION
- **Tue lokaalin Kosken käyttöä rinnalla kehitykseen:**
- **Siirrä vkt-suoritukset Koskeen kokonaisuuksina yksittäisten tietokannassa olevien suoritusrivien mukaan**
