### PR TITLE
local: update to jaeger v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,6 @@ services:
       - jaeger
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686" # UI


### PR DESCRIPTION
v2 is in preview mode, but it seems to work fine for me. How about others? v1 will be deprecated.

Ref: https://medium.com/jaegertracing/jaeger-v2-released-09a6033d1b10