### PR TITLE
OPH-KOTO17: Korjauksia KOSKI-siirtoihin ja parannuksia virheiden näyttämiseen

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/html/Json.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/html/Json.kt
@@ -1,0 +1,31 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
+package fi.oph.kitu.html
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.NumericNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
+import kotlinx.html.*
+
+fun FlowContent.json(node: JsonNode) {
+    when (node) {
+        is ArrayNode -> ul { node.forEach { li { json(it) } } }
+        is ObjectNode ->
+            ul {
+                node.properties().forEach { prop ->
+                    li {
+                        b {
+                            +prop.key
+                            +": "
+                        }
+                        span { json(prop.value) }
+                    }
+                }
+            }
+        is TextNode -> +node.textValue()
+        is NumericNode -> +node.asText()
+        else -> +node.toString()
+    }
+}

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiErrorRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiErrorRepository.kt
@@ -1,6 +1,8 @@
 package fi.oph.kitu.koski
 
+import com.fasterxml.jackson.databind.JsonNode
 import fi.oph.kitu.vkt.CustomVktSuoritusRepository
+import fi.oph.kitu.vkt.tiedonsiirtoschema.Henkilosuoritus
 import org.springframework.data.annotation.Id
 import org.springframework.data.jdbc.repository.query.Modifying
 import org.springframework.data.jdbc.repository.query.Query
@@ -50,7 +52,20 @@ data class KoskiErrorEntity(
     val entity: String,
     val message: String,
     val timestamp: LocalDateTime,
-)
+) {
+    fun errorJson(): JsonNode? {
+        val matchResult = Regex("^[\\w\\d\\s]+:\\s\"(.*)\"$").find(message)
+        return matchResult?.let {
+            val json = matchResult.groupValues[1]
+            val parser = objectMapper.factory.createParser(json)
+            return objectMapper.readTree(parser)
+        }
+    }
+
+    companion object {
+        val objectMapper = Henkilosuoritus.getDefaultObjectMapper()
+    }
+}
 
 @Service
 class KoskiErrorService(

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiRequestMapper.kt
@@ -190,6 +190,9 @@ class KoskiRequestMapper {
         val henkilo = henkilosuoritus.henkilo
         val suoritus = henkilosuoritus.suoritus
 
+        val kaikkiOsakokeetArvioitu = suoritus.osat.all { it.arviointi != null }
+        if (!kaikkiOsakokeetArvioitu) return null
+
         val organisaatio: Organisaatio? =
             suoritus.osat.firstNotNullOfOrNull { it.oppilaitos?.let { Organisaatio(it.oid) } }
                 ?: when (suoritus.taitotaso) {

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
@@ -143,7 +143,7 @@ class KoskiService(
         val (success, failed) = results.filterNotNull().partitionBySuccess()
         success.forEach { id -> koskiErrors.reset(id) }
         failed.forEach { error -> koskiErrors.save(error.suoritusId, error.message ?: error.toString()) }
-        if (failed.isNotEmpty()) throw Error.SendToKOSKIFailed(failed.map { it.suoritusId.entityId() })
+        if (failed.isNotEmpty()) throw Error.SendToKOSKIFailed(failed.map { it.suoritusId.mappedId() })
     }
 
     sealed class Error(

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VKTSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VKTSuoritusRepository.kt
@@ -200,6 +200,24 @@ class CustomVktSuoritusRepository {
         jdbcNamedParameterTemplate.update(query, params)
     }
 
+    @WithSpan
+    fun requestTransferToKoski(id: Tutkintoryhma) {
+        val query =
+            """
+            UPDATE vkt_suoritus
+            SET
+                koski_siirto_kasitelty = false
+            WHERE
+                suorittajan_oppijanumero = :oppijanumero
+                AND tutkintokieli = :tutkintokieli
+                AND taitotaso = :taitotaso
+            """.trimIndent()
+
+        val params = id.toSqlParams()
+
+        jdbcNamedParameterTemplate.update(query, params)
+    }
+
     private fun whereAll(vararg conditions: String?): String {
         val nonNullConditions = conditions.filterNotNull()
         return if (nonNullConditions.isNotEmpty()) {

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusEntity.kt
@@ -26,6 +26,8 @@ data class VktSuoritusEntity(
     @MappedCollection(idColumn = "suoritus_id")
     val tutkinnot: Set<VktTutkinto>,
     val createdAt: OffsetDateTime? = null,
+    val koskiOpiskeluoikeus: Oid? = null,
+    val koskiSiirtoKasitelty: Boolean = false,
 ) {
     @Table(name = "vkt_osakoe")
     data class VktOsakoe(

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusService.kt
@@ -91,11 +91,14 @@ class VktSuoritusService(
         arviointipaiva: LocalDate? = null,
     ) = osakoeRepository.updateArvosana(id, arvosana, arviointipaiva)
 
-    @WithSpan("VktSuoritusServer.setSuoritusTransferredToKoski")
+    @WithSpan("VktSuoritusServer.markKoskiTransferProcessed")
     fun markKoskiTransferProcessed(
         id: Tutkintoryhma,
         koskiOpiskeluoikeusOid: String? = null,
     ) = customSuoritusRepository.markSuoritusTransferredToKoski(id, koskiOpiskeluoikeusOid)
+
+    @WithSpan("VktSuoritusServer.requestTransferToKoski")
+    fun requestTransferToKoski(id: Tutkintoryhma) = customSuoritusRepository.requestTransferToKoski(id)
 
     private val listRowCounts =
         Cache(ttl = 5.minutes) { params: Triple<Koodisto.VktTaitotaso, Boolean?, String?> ->

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktViewController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktViewController.kt
@@ -200,6 +200,7 @@ class VktViewController(
         form.toEntries().forEach {
             vktSuoritukset.setOsakoeArvosana(it.id, it.arvosana, it.arviointipaiva)
         }
+        vktSuoritukset.requestTransferToKoski(CustomVktSuoritusRepository.Tutkintoryhma(oppijanumero, kieli, taso))
         viewMessage.showSuccess("Muutokset tallennettu onnistuneesti.")
         return RedirectView(
             linkTo(

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/html/VktSuorituksenTiedot.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/html/VktSuorituksenTiedot.kt
@@ -9,6 +9,8 @@ import fi.oph.kitu.i18n.finnishDate
 import fi.oph.kitu.vkt.VktSuoritus
 import fi.oph.kitu.vkt.tiedonsiirtoschema.Henkilosuoritus
 import kotlinx.html.FlowContent
+import kotlinx.html.a
+import kotlinx.html.h3
 import kotlinx.html.i
 
 fun FlowContent.vktSuorituksenTiedot(
@@ -20,6 +22,25 @@ fun FlowContent.vktSuorituksenTiedot(
             "Tutkinnon taso" to { +t.get(data.suoritus.taitotaso) },
             "Kieli" to { +t.get(data.suoritus.kieli) },
             "Suorituspaikkakunta" to { +t.getByKoodiviite("kunta", data.suoritus.suorituspaikkakunta) },
+        )
+    }
+    h3 { +"Integraatiot" }
+    card(compact = true) {
+        infoTable(
+            "KOSKI" to {
+                if (data.suoritus.koskiSiirtoKasitelty) {
+                    if (data.suoritus.koskiOpiskeluoikeusOid != null) {
+                        +"Tiedot siirretty KOSKI-tietovarantoon, opiskeluoikeus: "
+                        a(href = "/koski/oppija/${data.henkilo.oid}") {
+                            +data.suoritus.koskiOpiskeluoikeusOid.toString()
+                        }
+                    } else {
+                        +"Tiedot eivät ole valmiit siirrettäväksi KOSKI-tietovarantoon"
+                    }
+                } else {
+                    +"Yritys tietojen siirrosta KOSKI-tietovarantoon ajastettu"
+                }
+            },
         )
     }
 }

--- a/server/src/main/resources/db/migration/V44__split_koski_error_entity.sql
+++ b/server/src/main/resources/db/migration/V44__split_koski_error_entity.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "koski_error"
+    RENAME TO "koski_error_tmp";
+
+CREATE TABLE "koski_error"
+(
+    "id"        text                     NOT NULL,
+    "entity"    text                     NOT NULL,
+    "message"   text                     NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "koski_error_id_entity_idx" ON "koski_error" ("id", "entity");
+
+INSERT INTO koski_error
+SELECT split_part(entity, ':', 2) AS id,
+       split_part(entity, ':', 1) AS entity,
+       message,
+       timestamp
+FROM "koski_error_tmp";
+
+DROP TABLE "koski_error_tmp";

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiRequestMapperTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiRequestMapperTest.kt
@@ -239,14 +239,15 @@ class KoskiRequestMapperTest(
                 suorituksenVastaanottaja = null,
                 suorituspaikkakunta = "091",
                 osat =
-                    generator.randomOsakokeet(
-                        Koodisto.VktTaitotaso.Erinomainen,
-                        getRandomLocalDate(
-                            LocalDate.of(2000, 1, 1),
-                            LocalDate.of(2025, 1, 1),
-                            random,
-                        ),
-                    ),
+                    generator
+                        .randomOsakokeet(
+                            Koodisto.VktTaitotaso.Erinomainen,
+                            getRandomLocalDate(
+                                LocalDate.of(2000, 1, 1),
+                                LocalDate.of(2025, 1, 1),
+                                random,
+                            ),
+                        ).filter { it.arviointi != null },
                 lahdejarjestelmanId =
                     LahdejarjestelmanTunniste(
                         "vkt.0",
@@ -266,7 +267,6 @@ class KoskiRequestMapperTest(
                 suoritus = suoritus,
             )
 
-        val onr = MockOppijanumeroService.build()
         val koskiSuoritus = koskiRequestMapper.vktSuoritusToKoskiRequest(henkilosuoritus)
 
         assertNotNull(koskiSuoritus)


### PR DESCRIPTION
- **Splittaa KOSKI-siirtovirheiden tunniste kahteen kenttään**
- **Näytä json-muotoiset KOSKI-virheet selkeämmässä muodossa**
- **Kytke KOSKI-siirtopyyntö takaisin päälle, kun osakokeelle on annettu arvosana**
- **Näytä karkea tieto KOSKI-siirron tilasta**
- **Älä yritä lähettää Koskeen suoritusta, josta puuttuu arviointeja**
