### PR TITLE
feat(server): use untuva-koski locally

### DIFF
--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -25,7 +25,7 @@ kitu.yki.scheduling.importArvioijat.schedule=FIXED_DELAY|60s
 kitu.yki.baseUrl=http://localhost:8080/kielitutkinnot/dev/yki/import/
 #kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/yki-sp/oph/
 
-#kitu.koski.baseUrl=https://untuvaopintopolku.fi/koski/api/
+kitu.koski.baseUrl=https://untuvaopintopolku.fi/koski/api/
 kitu.koski.scheduling.enabled=true
 kitu.koski.scheduling.send.schedule=FIXED_DELAY|60s
 


### PR DESCRIPTION
sovellus tarvitsee nykyään `kitu.koski.baseUrl` - arvon. Käytetään untuvan koskea lähtökohtaisesti lokaalissa ympäristössä