### PR TITLE
fix: audit log

### DIFF
--- a/infra/lib/koski-audit-logs-integration/types.ts
+++ b/infra/lib/koski-audit-logs-integration/types.ts
@@ -14,19 +14,16 @@ type AuditLogEntry = {
   bootTime: string
   type: string
   environment: string
-  hostname: string // "hostname":"not set",
+  hostname: string
   timestamp: string
   serviceName: string
   applicationType: string
   user: {
-    oid: string // {}
+    oid: string
   }
   target: {
-    oppijaHenkiloOid: string // {}
+    oppijaHenkiloOid: string
   }
   organizationOid: string
   operation: string
 }
-
-
-

--- a/infra/lib/koski-audit-logs-integration/types.ts
+++ b/infra/lib/koski-audit-logs-integration/types.ts
@@ -14,16 +14,19 @@ type AuditLogEntry = {
   bootTime: string
   type: string
   environment: string
-  hostname: string
+  hostname: string // "hostname":"not set",
   timestamp: string
   serviceName: string
   applicationType: string
   user: {
-    oid: string
+    oid: string // {}
   }
   target: {
-    oppijaHenkiloOid: string
+    oppijaHenkiloOid: string // {}
   }
   organizationOid: string
   operation: string
 }
+
+
+

--- a/server/src/main/kotlin/fi/oph/kitu/Oid.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/Oid.kt
@@ -1,10 +1,12 @@
 package fi.oph.kitu
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import fi.oph.kitu.TypedResult.Failure
 import fi.oph.kitu.TypedResult.Success
 import org.ietf.jgss.GSSException
 
 @ConsistentCopyVisibility
+@JsonSerialize(using = com.fasterxml.jackson.databind.ser.std.ToStringSerializer::class)
 data class Oid private constructor(
     private val value: org.ietf.jgss.Oid,
 ) {

--- a/server/src/main/kotlin/fi/oph/kitu/TimeConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/TimeConfig.kt
@@ -1,0 +1,12 @@
+package fi.oph.kitu
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+import java.time.ZoneId
+
+@Configuration
+class TimeConfig {
+    @Bean
+    fun clock(): Clock = Clock.system(ZoneId.of("Europe/Helsinki"))
+}

--- a/server/src/main/kotlin/fi/oph/kitu/logging/AuditLogger.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/AuditLogger.kt
@@ -23,20 +23,20 @@ const val AUDIT_LOGGER_NAME = "auditLogger"
 class AuditLogger(
     @Qualifier("applicationTaskExecutor")
     private val taskExecutor: AsyncTaskExecutor,
-    private val environment: Environment,
     private val objectMapper: ObjectMapper,
-    private val resource: Resource,
 ) {
-    @Value("\${kitu.appUrl}")
-    lateinit var appUrl: String
-
     private val slf4jLogger = LoggerFactory.getLogger(AUDIT_LOGGER_NAME)
 
     private val currentZone = ZoneId.of("Europe/Helsinki")
     private val clock = Clock.system(currentZone)
     private val logSeq = AtomicInteger(0)
     private val bootTime = Instant.now(clock)
-    private val instanceId = resource.getAttribute(ServiceIncubatingAttributes.SERVICE_INSTANCE_ID) ?: "not set"
+
+    @Value("\${kitu.appUrl}")
+    lateinit var appUrl: String
+
+    @Value("\${kitu.env.name}")
+    lateinit var environment: String
 
     /**
      * Logs events.
@@ -55,8 +55,8 @@ class AuditLogger(
                         logSeq = logSeq.getAndIncrement(),
                         bootTime = bootTime,
                         type = "log",
-                        environment = environment.getRequiredProperty("kitu.env.name"),
-                        hostname = instanceId,
+                        environment = environment,
+                        hostname = appUrl,
                         timestamp = Instant.now(),
                         serviceName = "kitu",
                         applicationType = "backend",

--- a/server/src/main/kotlin/fi/oph/kitu/logging/AuditLogger.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/logging/AuditLogger.kt
@@ -24,11 +24,10 @@ class AuditLogger(
     @Qualifier("applicationTaskExecutor")
     private val taskExecutor: AsyncTaskExecutor,
     private val objectMapper: ObjectMapper,
+    private val clock: Clock,
 ) {
     private val slf4jLogger = LoggerFactory.getLogger(AUDIT_LOGGER_NAME)
 
-    private val currentZone = ZoneId.of("Europe/Helsinki")
-    private val clock = Clock.system(currentZone)
     private val logSeq = AtomicInteger(0)
     private val bootTime = Instant.now(clock)
 
@@ -57,7 +56,7 @@ class AuditLogger(
                         type = "log",
                         environment = environment,
                         hostname = appUrl,
-                        timestamp = Instant.now(),
+                        timestamp = Instant.now(clock),
                         serviceName = "kitu",
                         applicationType = "backend",
                         user = AuditLogEntry.User(context.userOid),

--- a/server/src/test/kotlin/fi/oph/kitu/OidTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/OidTest.kt
@@ -14,6 +14,13 @@ class OidTest {
     }
 
     @Test
+    fun `parsing correctly formatted string as OID converts to json correctly`() {
+        val oid = Oid.parse(validOidString).getOrThrow()
+        val result = defaultObjectMapper.writeValueAsString(oid)
+        assertEquals("\"$validOidString\"", result)
+    }
+
+    @Test
     fun `parsing incorrectly formatted string as OID returns a failure`() {
         assertTrue(Oid.parse(nonValidOidString).isFailure)
     }

--- a/server/src/test/kotlin/fi/oph/kitu/logging/AuditLoggerTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/logging/AuditLoggerTests.kt
@@ -115,26 +115,27 @@ class AuditLoggerTests {
         assertEquals(1, events.size)
 
         val expectedJson =
-            """{
-            "version":1,
-            "logSeq":0,
-            "bootTime":"2025-09-29T12:00:00Z",
-            "type":"log",
-            "environment":"test",
-            "hostname":"http://localhost:8080/kielitutkinnot",
-            "timestamp":"2025-09-29T12:00:00Z",
-            "serviceName":"kitu",
-            "applicationType":"backend",
-            "user":{
-                "oid":"1.2.246.562.24.19563255030"
-            },
-            "target":{
-                "oppijaHenkiloOid":"TODO"
-            },
-            "organizationOid":{},
-            "operation":"KielitestiSuoritusViewed"
-        }
-        """.replace("\n", "")
+            """
+            {
+                "version":1,
+                "logSeq":0,
+                "bootTime":"2025-09-29T12:00:00Z",
+                "type":"log",
+                "environment":"test",
+                "hostname":"http://localhost:8080/kielitutkinnot",
+                "timestamp":"2025-09-29T12:00:00Z"
+                ,"serviceName":"kitu",
+                "applicationType":"backend",
+                "user":{
+                    "oid":"1.2.246.562.24.19563255030"
+                },
+                "target":{
+                    "oppijaHenkiloOid":"1.2.246.562.24.19563255030"
+                },
+                "organizationOid":"1.2.246.562.10.48587687889",
+                "operation":"KielitestiSuoritusViewed"
+            }
+            """.replace("\n", "")
                 .replace(" ", "")
 
         assertEquals(expectedJson, events[0].formattedMessage)

--- a/server/src/test/kotlin/fi/oph/kitu/logging/AuditLoggerTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/logging/AuditLoggerTests.kt
@@ -6,6 +6,8 @@ import fi.oph.kitu.Oid
 import fi.oph.kitu.auth.CasUserDetails
 import fi.oph.kitu.mock.generateRandomOppijaOid
 import fi.oph.kitu.oppijanumero.CasAuthenticatedService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.LoggerFactory
@@ -53,23 +55,26 @@ class AuditLoggerTests {
     @Suppress("unused")
     private lateinit var clock: Clock
 
+    private val logbackLogger = LoggerFactory.getLogger(AUDIT_LOGGER_NAME) as LogbackLogger
+
+    private val listAppender = ListAppender<ILoggingEvent>()
+
+    @BeforeEach
+    fun setup() {
+        listAppender.start()
+        logbackLogger.addAppender(listAppender)
+    }
+
+    @AfterEach
+    fun cleanup() {
+        listAppender.stop()
+        logbackLogger.detachAppender(listAppender)
+    }
+
     @Test
     fun `log logs JSON string correctly`(
         @Autowired auditLogger: AuditLogger,
     ) {
-        val logger = LoggerFactory.getLogger(AUDIT_LOGGER_NAME) as LogbackLogger
-
-        // TODO: Detach
-        // logbackLogger.detachAppender(listAppender)
-        // listAppender.stop()
-        val listAppender =
-            ListAppender<ILoggingEvent>()
-                .apply {
-                    start()
-                }.also {
-                    logger.addAppender(it)
-                }
-
         RequestContextHolder.setRequestAttributes(
             ServletRequestAttributes(
                 MockHttpServletRequest().apply {

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -3,7 +3,9 @@ spring.profiles.include=test
 
 spring.cloud.aws.s3.enabled=false
 
-kitu.appUrl=
+oph.oid=1.2.246.562.10.48587687889
+kitu.appUrl=http://localhost:8080/kielitutkinnot
+kitu.env.name=test
 kitu.opintopolkuHostname=
 kitu.uses-ssl-proxy=false
 


### PR DESCRIPTION
OID ei ollut serialisoitu oikein. Tehty sille samalla AuditLoggerille ja Oidin serialisoinnille testit. Käytetty springing contekstia AuditLoggerissa, koska toteutus pakottaa siihen. Laitettu kello omaan papuun, jotta `Instant.now()` voidaan palauttaamaan kovakoodattu kellonaika