### PR TITLE
Lähetä Amazon Q:n tutkimusilmoitukset Slackiin

### DIFF
--- a/infra/lib/alarms-stack.ts
+++ b/infra/lib/alarms-stack.ts
@@ -18,10 +18,19 @@ import {
 import { LoggingLevel } from "aws-cdk-lib/aws-chatbot"
 import { SlackChannel } from "./accounts"
 
+export interface AlarmsStackSlackProps {
+  workspaceId: string
+  alarmsChannel: SlackChannel
+  infoChannel?: SlackChannel
+  // Topics from other AlarmsStacks (e.g. the us-east-1 mirror) that should
+  // share this stack's Slack configuration. Needed because Chatbot only allows
+  // one SlackChannelConfiguration per Slack channel per account.
+  additionalAlarmTopics?: aws_sns.ITopic[]
+  additionalInfoTopics?: aws_sns.ITopic[]
+}
+
 export interface AlarmsStackProps extends StackProps {
-  slackWorkspaceId: string
-  slackAlarmsChannel: SlackChannel
-  slackInfoChannel?: SlackChannel
+  slack?: AlarmsStackSlackProps
 }
 
 export class AlarmsStack extends cdk.Stack {
@@ -36,19 +45,21 @@ export class AlarmsStack extends cdk.Stack {
     this.alarmSnsTopic = this.createSnsTopic("AlarmSnsTopic")
     this.infoSnsTopic = this.createSnsTopic("InfoSnsTopic")
 
-    const alarmsSlack = this.createSlackChannelConfiguration(
-      "SlackBot",
-      props.slackWorkspaceId,
-      props.slackAlarmsChannel,
-      [this.alarmSnsTopic],
-    )
+    const alarmsSlack = props.slack
+      ? this.createSlackChannelConfiguration(
+          "SlackBot",
+          props.slack.workspaceId,
+          props.slack.alarmsChannel,
+          [this.alarmSnsTopic, ...(props.slack.additionalAlarmTopics ?? [])],
+        )
+      : undefined
 
-    if (props.slackInfoChannel) {
+    if (props.slack?.infoChannel) {
       this.createSlackChannelConfiguration(
         "InfoSlackBot",
-        props.slackWorkspaceId,
-        props.slackInfoChannel,
-        [this.infoSnsTopic],
+        props.slack.workspaceId,
+        props.slack.infoChannel,
+        [this.infoSnsTopic, ...(props.slack.additionalInfoTopics ?? [])],
       )
     }
 
@@ -77,16 +88,14 @@ export class AlarmsStack extends cdk.Stack {
     return new aws_chatbot.SlackChannelConfiguration(this, id, {
       slackChannelId: slackChannel.id,
       slackWorkspaceId,
-      // Chatbot configuration names are account-globally unique, so two
-      // AlarmsStacks in the same env (primary + us-east-1) need distinct names.
-      slackChannelConfigurationName: `${slackChannel.name}-${this.region}`,
+      slackChannelConfigurationName: slackChannel.name,
       notificationTopics,
       loggingLevel: LoggingLevel.INFO,
     })
   }
 
   private createInvestigationGroup(
-    alarmsSlack: aws_chatbot.SlackChannelConfiguration,
+    alarmsSlack: aws_chatbot.SlackChannelConfiguration | undefined,
   ) {
     const role = new Role(this, "InvestigationGroupRole", {
       assumedBy: new ServicePrincipal("aiops.amazonaws.com"),
@@ -124,10 +133,15 @@ export class AlarmsStack extends cdk.Stack {
       roleArn: role.roleArn,
       retentionInDays: 90,
       investigationGroupPolicy: JSON.stringify(alarmsPolicy.toJSON()),
+      // When a Slack config exists, route investigation events through
+      // Chatbot for Q-curated formatting. Otherwise just publish to SNS and
+      // rely on whichever stack owns the Slack config to fan it out.
       chatbotNotificationChannels: [
         {
           snsTopicArn: this.alarmSnsTopic.topicArn,
-          chatConfigurationArns: [alarmsSlack.slackChannelConfigurationArn],
+          ...(alarmsSlack && {
+            chatConfigurationArns: [alarmsSlack.slackChannelConfigurationArn],
+          }),
         },
       ],
     })

--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -32,17 +32,20 @@ export class EnvironmentStage extends Stage {
       env,
     })
 
-    const alarmsStack = new AlarmsStack(this, "Alarms", {
-      env,
-      slackWorkspaceId: environmentConfig.slackWorkspaceId,
-      slackAlarmsChannel: environmentConfig.slackAlarmsChannel,
-      slackInfoChannel: environmentConfig.slackInfoChannel,
-    })
+    // us-east-1 must be created first so the primary stack can subscribe its
+    // topics to the single shared Slack configuration.
     const usEastAlarmsStack = new AlarmsStack(this, "AlarmsUsEast1", {
       env: { ...env, region: "us-east-1" },
-      slackWorkspaceId: environmentConfig.slackWorkspaceId,
-      slackAlarmsChannel: environmentConfig.slackAlarmsChannel,
-      slackInfoChannel: environmentConfig.slackInfoChannel,
+    })
+    const alarmsStack = new AlarmsStack(this, "Alarms", {
+      env,
+      slack: {
+        workspaceId: environmentConfig.slackWorkspaceId,
+        alarmsChannel: environmentConfig.slackAlarmsChannel,
+        infoChannel: environmentConfig.slackInfoChannel,
+        additionalAlarmTopics: [usEastAlarmsStack.alarmSnsTopic],
+        additionalInfoTopics: [usEastAlarmsStack.infoSnsTopic],
+      },
     })
 
     new DnsStack(this, "Dns", {

--- a/infra/lib/utility-stage.ts
+++ b/infra/lib/utility-stage.ts
@@ -24,8 +24,10 @@ export class UtilityStage extends Stage {
 
     const alarmsStack = new AlarmsStack(this, "Alarms", {
       env: props.env,
-      slackWorkspaceId: props.slackWorkspaceId,
-      slackAlarmsChannel: props.slackChannel,
+      slack: {
+        workspaceId: props.slackWorkspaceId,
+        alarmsChannel: props.slackChannel,
+      },
     })
 
     this.imageBuildsStack = new ContainerRepositoryStack(this, "ImageBuilds", {


### PR DESCRIPTION
## Summary

- Investigation group lähettää nyt Amazon Q:n valmiin tutkimuksen Slackiin samalle kanavalle kuin alkuperäinen hälytys, käyttäen AWS Chatbotin `SlackChannelConfiguration`-integraatiota.
- `AlarmsStack` omistaa kanavakonfiguraation aiemman erillisen `SlackBotStack`-pinon sijaan — yhtä Slack-kanavaa kohden syntyy täsmälleen yksi Chatbot-konfiguraatio per ympäristö.
- us-east-1-alueen `AlarmsStack` ei luo enää omaa Chatbot-konfiguraatiotaan vaan ohjaa tutkimuksensa oman SNS-aiheensa kautta primaari-alueen Slack-konfiguraatioon, joka on tilattu kuuntelemaan myös sen SNS-aihetta.

## Test plan

- [ ] Poista ympäristöistä vanhat `*/SlackBot` ja `*/InfoSlackBot` pinot (`cdk destroy`) ja mahdolliset orvot Chatbot-konfiguraatiot (`aws chatbot delete-slack-channel-configuration --region us-east-1 ...`).
- [ ] Deployaa `Util/**`, `Dev/**`, `Test/**` ja lopuksi `Prod/**` uudelleen.
- [ ] Varmista, että jokaisessa tilissä AWS Chatbot -konsolissa on vain yksi `SlackChannelConfiguration` ympäristön hälytyskanavaa kohden (Prod myös info-kanavaa kohden).
- [ ] Laukaise hälytys ja tarkista, että Slackiin tulee sekä hälytys että kun Q:n tutkimus valmistuu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)