### PR TITLE
TEMP: Pudota Slack-konfiguraatiot CFN-tilasta

### DIFF
--- a/infra/lib/environment-stage.ts
+++ b/infra/lib/environment-stage.ts
@@ -39,13 +39,17 @@ export class EnvironmentStage extends Stage {
     })
     const alarmsStack = new AlarmsStack(this, "Alarms", {
       env,
-      slack: {
-        workspaceId: environmentConfig.slackWorkspaceId,
-        alarmsChannel: environmentConfig.slackAlarmsChannel,
-        infoChannel: environmentConfig.slackInfoChannel,
-        additionalAlarmTopics: [usEastAlarmsStack.alarmSnsTopic],
-        additionalInfoTopics: [usEastAlarmsStack.infoSnsTopic],
-      },
+      // TEMP: slack-konfiguraatio jätetty pois yhden deployn ajaksi, jotta
+      // CloudFormation luopuu orvoksi jääneestä Chatbot-resurssista
+      // (manuaalisesti poistettu). Palauta tämä blokki välittömästi sen
+      // jälkeen kun Alarms-pinot ovat deployautuneet puhtaasti.
+      // slack: {
+      //   workspaceId: environmentConfig.slackWorkspaceId,
+      //   alarmsChannel: environmentConfig.slackAlarmsChannel,
+      //   infoChannel: environmentConfig.slackInfoChannel,
+      //   additionalAlarmTopics: [usEastAlarmsStack.alarmSnsTopic],
+      //   additionalInfoTopics: [usEastAlarmsStack.infoSnsTopic],
+      // },
     })
 
     new DnsStack(this, "Dns", {

--- a/infra/lib/utility-stage.ts
+++ b/infra/lib/utility-stage.ts
@@ -24,10 +24,14 @@ export class UtilityStage extends Stage {
 
     const alarmsStack = new AlarmsStack(this, "Alarms", {
       env: props.env,
-      slack: {
-        workspaceId: props.slackWorkspaceId,
-        alarmsChannel: props.slackChannel,
-      },
+      // TEMP: slack-konfiguraatio jätetty pois yhden deployn ajaksi, jotta
+      // CloudFormation luopuu orvoksi jääneestä Chatbot-resurssista
+      // (manuaalisesti poistettu). Palauta tämä blokki välittömästi sen
+      // jälkeen kun Util-Alarms on deployautunut puhtaasti.
+      // slack: {
+      //   workspaceId: props.slackWorkspaceId,
+      //   alarmsChannel: props.slackChannel,
+      // },
     })
 
     this.imageBuildsStack = new ContainerRepositoryStack(this, "ImageBuilds", {


### PR DESCRIPTION
## Summary

Tilapäinen deploy, jonka jälkeen \`slack\`-blokit palautetaan takaisin. Tämä pudottaa orvot \`AWS::Chatbot::SlackChannelConfiguration\`-resurssit CloudFormationin kirjanpidosta, jotta seuraava oikea deploy voi luoda ne uudestaan.

Tausta: Chatbot-konfiguraatiot poistettiin manuaalisesti AWS-konsolista tilanteessa, jossa nimikollisiot estivät deployn. Nyt CFN yrittää UPDATE-operaatiota resurssille, jota ei ole olemassa, ja epäonnistuu NotFound-virheeseen. Kun resurssi poistetaan templaatista, CFN tekee DELETE-operaation, joka sietää NotFoundia, ja kirjanpito siivoutuu.

## Deploy-järjestys

1. Merge tämä PR → CI deployaa Util/Dev/Test/Prod. Jokaisessa Alarms-pinossa \`SlackChannelConfiguration\` poistuu kirjanpidosta.
2. Varmista, että kaikki Alarms-pinot päätyvät tilaan \`UPDATE_COMPLETE\`.
3. Mergeä seuraava PR, joka palauttaa \`slack\`-blokit → CI luo Chatbot-konfiguraatiot puhtaasti uudelleen.

Väliaikana (vaiheiden 1 ja 3 välillä) Slack-ilmoitukset hälytyksistä eivät toimi — varaa tämän takia lyhyt katkoikkuna.

## Test plan

- [ ] CI deploy menee läpi Util/Dev/Test/Prod osalta.
- [ ] AWS Chatbot -konsolissa ei ole enää \`kielitutkintorekisteri-alerts*\` konfiguraatioita.
- [ ] CloudFormation Alarms-pinot ovat \`UPDATE_COMPLETE\` -tilassa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)