### PR TITLE
OPHKOTO-xxx: Kios-yhteyden jumittumisen selvittely

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/RestClientConfigurationExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/RestClientConfigurationExtensions.kt
@@ -1,9 +1,11 @@
 package fi.oph.kitu
 
+import io.opentelemetry.api.trace.Span
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.StringHttpMessageConverter
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
+import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestClient
 import tools.jackson.core.StreamReadConstraints
 import tools.jackson.core.json.JsonFactory
@@ -27,11 +29,22 @@ fun <T> RestClient.RequestBodySpec.nullableBody(body: T?): RestClient.RequestBod
 fun <T : Any> RestClient.RequestBodySpec.retrieveEntitySafely(type: Class<T>): ResponseEntity<
     T,
 >? =
-    this.exchange { request, response ->
-        ResponseEntity
-            .status(response.statusCode)
-            .headers(response.headers)
-            .body(response.bodyTo(type))
+    try {
+        this.exchange { request, response ->
+            ResponseEntity
+                .status(response.statusCode)
+                .headers(response.headers)
+                .body(response.bodyTo(type))
+        }
+    } catch (e: ResourceAccessException) {
+        // ResourceAccessException.toString() omits the wrapped IOException, so traces/logs can't
+        // distinguish a read timeout from a connection reset. Surface the cause as span attributes.
+        val cause = e.cause
+        Span.current().apply {
+            setAttribute("exception.cause.type", cause?.javaClass?.name.orEmpty())
+            setAttribute("exception.cause.message", cause?.message.orEmpty())
+        }
+        throw e
     }
 
 // Spring 7's default StringHttpMessageConverter only advertises text/*, so reading an

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -7,6 +7,9 @@ server.servlet.context-path=/kielitutkinnot
 spring.session.jdbc.initialize-schema=never
 spring.threads.virtual.enabled=true
 
+spring.http.client.connect-timeout=10s
+spring.http.client.read-timeout=30s
+
 management.health.defaults.enabled=false
 
 server.error.whitelabel.enabled=false


### PR DESCRIPTION

Kios-integraation (ja muiden ulkoisten kutsujen) RestClient ei tähän asti rajannut
yhteyden- eikä lukuaikaa, joten jumiin jäävä pyyntö saattoi roikkua rajattomasti ja
tukkia uusintayrityksen. Lisätään globaalit timeoutit ja rikastutetaan trace-span
ResourceAccessExceptionin todellisella aiheuttajalla, jotta read timeoutin ja
connection resetin saa erotettua toisistaan.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
