### PR TITLE
OPHKOTO-138: Korjaa Swagger UI:n rikkoutuminen Spring Boot 4 -päivityksen jäljiltä

### DIFF
--- a/e2e/tests/swagger-ui.spec.ts
+++ b/e2e/tests/swagger-ui.spec.ts
@@ -1,0 +1,23 @@
+import { test } from "../fixtures/baseFixture"
+import { expect } from "@playwright/test"
+
+test("Swagger UI renders all expected API sections", async ({
+  page,
+  config,
+}) => {
+  await page.goto(`${config.baseUrl}swagger-ui/index.html`)
+
+  // Sektioiden otsikot tulevat /v3/api-docs:n tageistä; jos joku sektioista
+  // puuttuu, joko spec on rikki tai Swagger UI ei pysty renderöimään sitä —
+  // molempiin tilanteisiin osuu sama assertio.
+  for (const sectionTitle of [
+    "Valtionhallinnon kielitutkinto",
+    "Yleinen kielitutkinto",
+    "Todistuksen yhteystiedot",
+    "Kotoutumiskoulutuksen kielitesti, sisäiset rajapinnat",
+  ]) {
+    await expect(
+      page.locator(".opblock-tag", { hasText: sectionTitle }),
+    ).toBeVisible()
+  }
+})

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -153,6 +153,13 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>3.0.3</version>
         </dependency>
+        <!-- swagger-core (springdoc:n transitiivi) käyttää yhä Jacksonia 2; tuomalla Jackson 2:n
+             rinnalle Spring Bootin shim-starterin kautta /v3/api-docs ei kaadu, ja Swagger UI
+             saa kelvollisen OpenAPI-määrityksen. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-jackson2</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/MessageConverterConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/MessageConverterConfig.kt
@@ -1,0 +1,24 @@
+package fi.oph.kitu.webmvc
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.converter.ByteArrayHttpMessageConverter
+import org.springframework.http.converter.HttpMessageConverters
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * Springdoc 3.0.x:n /v3/api-docs palauttaa `byte[]`. Spring Boot 4:ssä Jackson 3:n
+ * JsonHttpMessageConverter pääsee voittamaan byte[]+application/json -content negotiationin
+ * ja serialisoi taulukon base64-merkkijonoksi (Jacksonin oletus byte[]:lle), jolloin
+ * Swagger UI valittaa "no valid version field". Estetään tämä prependoimalla
+ * ByteArrayHttpMessageConverter, jolloin se valitaan byte[]:lle ennen Jacksonia.
+ *
+ * Ks. springdoc-openapi #3173 / #3181.
+ */
+@Configuration
+class MessageConverterConfig : WebMvcConfigurer {
+    override fun configureMessageConverters(builder: HttpMessageConverters.ServerBuilder) {
+        builder.configureMessageConvertersList { list ->
+            list.add(0, ByteArrayHttpMessageConverter())
+        }
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/apidocs/OpenApiSpecTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/apidocs/OpenApiSpecTest.kt
@@ -1,0 +1,51 @@
+package fi.oph.kitu.apidocs
+
+import fi.oph.kitu.DBContainerConfiguration
+import fi.oph.kitu.defaultObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.context.annotation.Import
+import org.springframework.web.client.RestTemplate
+import org.testcontainers.postgresql.PostgreSQLContainer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(DBContainerConfiguration::class)
+class OpenApiSpecTest(
+    @param:Autowired private val postgres: PostgreSQLContainer,
+) {
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val restTemplate = RestTemplate()
+
+    // Springdoc 3.0.x palauttaa /v3/api-docs:n byte[]:nä; SB4:ssä Jackson 3 ehti
+    // serialisoida sen base64-merkkijonoksi (Jackson byte[]-oletus), jolloin Swagger UI
+    // näytti "no valid version field" -virheen. MessageConverterConfig prependoi
+    // ByteArrayHttpMessageConverterin, jotta byte[] menee läpi raakana.
+    @Test
+    fun `GET v3 api-docs returns valid OpenAPI JSON, not base64`() {
+        val body =
+            requireNotNull(
+                restTemplate.getForObject(
+                    "http://localhost:$port/v3/api-docs",
+                    String::class.java,
+                ),
+            ) { "Empty response from /v3/api-docs" }
+
+        assertTrue(
+            body.trimStart().startsWith("{"),
+            "Expected raw JSON object, got: ${body.take(120)}",
+        )
+
+        val openapi = defaultObjectMapper.readTree(body)["openapi"]?.asString()
+        assertEquals(
+            true,
+            openapi?.matches(Regex("^3\\.\\d+\\.\\d+$")),
+            "Expected openapi version 3.x.x, got: $openapi",
+        )
+    }
+}


### PR DESCRIPTION

Kaksi peräkkäistä syytä, kumpaakin vaadittiin:

1. swagger-core (springdoc 3.0.3:n transitiivi) käyttää yhä Jacksonia 2,
   jonka SB4 pudotti pois starterien oletustransitiiveistä. Lisätään SB4:n
   spring-boot-jackson2-shim-starter, jolloin Jackson 2 löytyy classpathiltä
   Jackson 3:n rinnalla ja /v3/api-docs ei enää kaadu serialisointivirheeseen.

2. Tämän jälkeen /v3/api-docs palautti edelleen vääränmuotoista dataa: Spring
   Boot 4:n viestimuuntimien järjestyksessä Jackson 3:n JsonHttpMessageConverter
   pääsi kirjoittamaan springdocin byte[]-vastauksen, ja Jackson serialisoi
   tavutaulukon base64-merkkijonoksi (sen oletus byte[]:lle), jolloin Swagger
   UI näytti "No valid version field" -virheen. Lisätään WebMvcConfigurer, joka
   prependoi ByteArrayHttpMessageConverterin viestimuuntimien jonon kärkeen,
   jotta tavutaulukko menee läpi raakana. Ks. springdoc-openapi #3173 ja #3181.

Regressiotestit:

- OpenApiSpecTest käynnistää sovelluksen RANDOM_PORT-ympäristössä, hakee
  /v3/api-docs:n ja varmistaa, että vastaus on JSON-objekti jonka top-tason
  openapi-kentän versio on 3.x.x — eli ei base64-pakattu merkkijono. Vahvistettu
  sekä korjauksen kanssa (pass) että ilman (fail) `mvn clean test`-ajossa.
- swagger-ui.spec.ts avaa /swagger-ui/index.html-sivun selaimessa ja varmistaa,
  että odotetut sektiot (VKT, YKI, todistuksen yhteystiedot, koto-kielitestin
  sisäiset rajapinnat) renderöityvät .opblock-tag-elementteinä. Kattaa myös
  muut rikkoutumistilanteet (esim. UI:n staattiset assetit puuttuvat).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
