### PR TITLE
OPHKOTO-144: Lisää Swagger UI:hin CSRF-tuki ja poista Swagger tuotannosta

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/apidocs/SchemaExamplesController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/apidocs/SchemaExamplesController.kt
@@ -72,11 +72,7 @@ class SchemaExamplesController {
                                     tutkintopaiva = LocalDate.now(),
                                 ),
                             ),
-                        lahdejarjestelmanId =
-                            LahdejarjestelmanTunniste(
-                                id = "748",
-                                lahde = Lahdejarjestelma.KIOS,
-                            ),
+                        lahdejarjestelmanId = LahdejarjestelmanTunniste.randomFrom(Lahdejarjestelma.KIOS),
                     ),
             ),
         )
@@ -133,11 +129,7 @@ class SchemaExamplesController {
                                         ),
                                 ),
                             ),
-                        lahdejarjestelmanId =
-                            LahdejarjestelmanTunniste(
-                                id = "748",
-                                lahde = Lahdejarjestelma.KIOS,
-                            ),
+                        lahdejarjestelmanId = LahdejarjestelmanTunniste.randomFrom(Lahdejarjestelma.KIOS),
                     ),
             ),
         )
@@ -275,11 +267,7 @@ class SchemaExamplesController {
                                 perustelu =
                                     "Suorituksesta jäänyt viimeinen tehtävä arvioimatta. Arvioinnin jälkeen puhumisen taitotasoa 6.",
                             ),
-                        lahdejarjestelmanId =
-                            LahdejarjestelmanTunniste(
-                                id = "183424",
-                                lahde = Lahdejarjestelma.Solki,
-                            ),
+                        lahdejarjestelmanId = LahdejarjestelmanTunniste.randomFrom(Lahdejarjestelma.Solki),
                     ),
             ),
         )

--- a/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
@@ -28,6 +28,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 
 fun developmentProfileActive(environment: Environment): Boolean {
     val enableDevApiOn = listOf("local", "test", "e2e")
@@ -102,6 +104,14 @@ class WebSecurityConfig {
     ): SecurityFilterChain {
         http {
             csrf {
+                if (!environment.activeProfiles.contains("prod")) {
+                    // Swagger UI:n "Try it out" tarvitsee CSRF-tokenin pääsyn JS:stä, jotta se voi
+                    // lukea tokenin XSRF-TOKEN-evästeestä ja lähettää X-XSRF-TOKEN-headerissa.
+                    // Tuotannossa Swagger UI on pois käytöstä (ks. application-prod.properties),
+                    // joten siellä pidetään oletus-HttpOnly-evästeet.
+                    csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse()
+                    csrfTokenRequestHandler = CsrfTokenRequestAttributeHandler()
+                }
                 ignoringRequestMatchers(
                     "/api/**",
                     "/db-scheduler-api/**",

--- a/server/src/main/kotlin/fi/oph/kitu/tiedonsiirtoschema/Lahdejarjestelmallinen.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/tiedonsiirtoschema/Lahdejarjestelmallinen.kt
@@ -1,5 +1,7 @@
 package fi.oph.kitu.tiedonsiirtoschema
 
+import kotlin.random.Random
+
 interface Lahdejarjestelmallinen {
     val lahdejarjestelmanId: LahdejarjestelmanTunniste
 }
@@ -19,6 +21,8 @@ data class LahdejarjestelmanTunniste(
                 LahdejarjestelmanTunniste(s, Lahdejarjestelma.Unknown)
             }
         }
+
+        fun randomFrom(from: Lahdejarjestelma) = LahdejarjestelmanTunniste(Random.nextInt(1000000).toString(), from)
     }
 }
 

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -32,6 +32,12 @@ kitu.koski.scheduling.vkt.schedule=DAILY|01:00
 
 kitu.koodistopalvelu.baseUrl=https://koodisto.prod.koodisto.opintopolku.fi/koodisto-service/rest/
 
+# Swagger UI ja /v3/api-docs ovat saatavilla local-, untuva- ja qa-ympäristöissä testausta varten,
+# mutta tuotannossa pidetään ne pois käytöstä, koska Swaggerin "Try it out" -toiminto vaatisi
+# CSRF-tokenin altistamisen JS:lle (ks. WebSecurityConfig.kt:n CSRF-konfiguraatio).
+springdoc.api-docs.enabled=false
+springdoc.swagger-ui.enabled=false
+
 otel.resource.providers.aws.enabled=true
 
 # Tuotanto:

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -63,6 +63,11 @@ springdoc.pathsToMatch=/**/api/**/*
 springdoc.swagger-ui.try-it-out-enabled=true
 springdoc.swagger-ui.path=/api-docs
 
+# Lue CSRF-token XSRF-TOKEN-evästeestä ja lähetä se X-XSRF-TOKEN-headerissa, jotta "Try it out"
+# toimii session-pohjaisilla endpointeilla. Vaatii että CookieCsrfTokenRepository on käytössä;
+# ks. WebSecurityConfig.kt.
+springdoc.swagger-ui.csrf.enabled=true
+
 springdoc.swagger-ui.oauth.client-id=FillYourClientId
 springdoc.swagger-ui.oauth.client-secret=FillYourClientSecret
 


### PR DESCRIPTION

- **Lisää Swagger UI:hin CSRF-tuki ja poista Swagger tuotannosta**
- **Näytä Swaggerin esimerkki-jsoneissa satunnainen lähdejärjestelmän tunniste**
