### PR TITLE
OPHKOTO-144: Skippaa Build image PR-ajoissa, jos Docker-konffit eivät muuttuneet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       mise: ${{ steps.filter.outputs.mise }}
       infra: ${{ steps.filter.outputs.infra }}
+      image: ${{ steps.filter.outputs.image }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -34,6 +35,9 @@ jobs:
               - '.mise.*.toml'
             infra:
               - 'infra/**'
+            image:
+              - 'Dockerfile'
+              - '.dockerignore'
 
   update_tools_cache:
     name: Update tools cache if changed
@@ -168,9 +172,15 @@ jobs:
     name: Build image
     runs-on: ubuntu-24.04
     needs:
+      - list_changes
       - server_tests
       - frontend_tests
       - lint
+    # Always build on main (the deploy needs the image pushed to ECR).
+    # On PRs, only run when Dockerfile/.dockerignore changed — the app code is
+    # already verified by server_tests/frontend_tests, so a green check from
+    # this job on every PR is mostly wasted CI time.
+    if: github.ref_name == 'main' || needs.list_changes.outputs.image == 'true'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION

Imagen rakentaminen joka PR:ssä on turhaa: appin kääntyminen on jo
varmistettu server_tests-jobissa (mvn package). Imagebuild on
hyödyllinen vain silloin kun Dockerfile tai .dockerignore muuttuu —
tai kun ollaan mainissa, jolloin imagen pitää päätyä ECR:ään deployta
varten.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
