### PR TITLE
OPHKOTO-144: Korjaa Swaggerin Try it out Dev/Test-ympäristöissä

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/auth/WebSecurityConfig.kt
@@ -28,8 +28,6 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository
-import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 
 fun developmentProfileActive(environment: Environment): Boolean {
     val enableDevApiOn = listOf("local", "test", "e2e")
@@ -104,16 +102,15 @@ class WebSecurityConfig {
     ): SecurityFilterChain {
         http {
             csrf {
-                if (!environment.activeProfiles.contains("prod")) {
-                    // Swagger UI:n "Try it out" tarvitsee CSRF-tokenin pääsyn JS:stä, jotta se voi
-                    // lukea tokenin XSRF-TOKEN-evästeestä ja lähettää X-XSRF-TOKEN-headerissa.
-                    // Tuotannossa Swagger UI on pois käytöstä (ks. application-prod.properties),
-                    // joten siellä pidetään oletus-HttpOnly-evästeet.
-                    csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse()
-                    csrfTokenRequestHandler = CsrfTokenRequestAttributeHandler()
-                }
+                // API-endpointit on tarkoitettu OAuth2-bearer-pohjaisille ulkoisille kutsujille
+                // (oauth2SecurityFilterChain käsittelee ne ja CSRF on siellä jo pois). Mitkään
+                // appin omat lomakkeet/JS eivät kutsu näitä, joten CSRF-suojaus ei tuo lisäarvoa
+                // mutta rikkoo Swagger UI:n "Try it out":n session-pohjaisena kutsuna.
                 ignoringRequestMatchers(
                     "/api/**",
+                    "/yki/api/**",
+                    "/koto-kielitesti/api/**",
+                    "/yhteystiedot/api/**",
                     "/db-scheduler-api/**",
                     "/dev/**",
                 )

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -33,8 +33,7 @@ kitu.koski.scheduling.vkt.schedule=DAILY|01:00
 kitu.koodistopalvelu.baseUrl=https://koodisto.prod.koodisto.opintopolku.fi/koodisto-service/rest/
 
 # Swagger UI ja /v3/api-docs ovat saatavilla local-, untuva- ja qa-ympäristöissä testausta varten,
-# mutta tuotannossa pidetään ne pois käytöstä, koska Swaggerin "Try it out" -toiminto vaatisi
-# CSRF-tokenin altistamisen JS:lle (ks. WebSecurityConfig.kt:n CSRF-konfiguraatio).
+# mutta tuotannossa pidetään ne pois käytöstä — kehitystyökalu, ei tarpeen julkisesti.
 springdoc.api-docs.enabled=false
 springdoc.swagger-ui.enabled=false
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -63,11 +63,6 @@ springdoc.pathsToMatch=/**/api/**/*
 springdoc.swagger-ui.try-it-out-enabled=true
 springdoc.swagger-ui.path=/api-docs
 
-# Lue CSRF-token XSRF-TOKEN-evästeestä ja lähetä se X-XSRF-TOKEN-headerissa, jotta "Try it out"
-# toimii session-pohjaisilla endpointeilla. Vaatii että CookieCsrfTokenRepository on käytössä;
-# ks. WebSecurityConfig.kt.
-springdoc.swagger-ui.csrf.enabled=true
-
 springdoc.swagger-ui.oauth.client-id=FillYourClientId
 springdoc.swagger-ui.oauth.client-secret=FillYourClientSecret
 


### PR DESCRIPTION

Aiempi yritys altisti CSRF-tokenin JS:lle, jotta Swagger UI voi lähettää
sen X-XSRF-TOKEN-headerissa. Toimi paikallisesti mutta ei Dev:ssä eikä
Test:ssä — todennäköisesti reverse proxy nyhtää headerin matkalta.

Korjaus: lisätään /yki/api/**, /koto-kielitesti/api/** ja
/yhteystiedot/api/** CSRF-ignore-listalle samalle tavalla kuin /api/**
on jo. Endpointit on suunniteltu OAuth2-bearer-pohjaisille ulkoisille
kutsujille (oauth2SecurityFilterChain hoitaa nämä CSRF:ttä), eikä
appin oma koodi kutsu niitä lomakkeilla/JS:llä, joten CSRF-suojaus ei
ollut tuomassa todellista turvaa. Samalla puretaan
CookieCsrfTokenRepository.withHttpOnlyFalse-virityksiä, koska Swagger
UI:n "Try it out" ei enää tarvitse CSRF-tokenia — riippumatta siitä
mitä proxy headerille tekee.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
