### PR TITLE
OPHKOTO-146: Eristä yksittäisen suorituksen mappausvirhe Koski-eräajossa

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
@@ -36,7 +36,15 @@ class KoskiService(
     @WithSpan
     @RetryOutboundIntegration
     fun sendYkiSuoritusToKoski(ykiSuoritusEntity: YkiSuoritusEntity): Either<KoskiException, YkiSuoritusEntity> {
-        val koskiRequest = koskiYkiRequestMapper.ykiSuoritusToKoskiRequest(ykiSuoritusEntity).getOrNull()
+        val koskiRequest =
+            try {
+                koskiYkiRequestMapper.ykiSuoritusToKoskiRequest(ykiSuoritusEntity).getOrNull()
+            } catch (e: Throwable) {
+                return KoskiValidationException(
+                    YkiMappingId(ykiSuoritusEntity.solkiId),
+                    "Suorituksen muuntaminen Koski-pyynnöksi epäonnistui: ${e.message ?: e.javaClass.simpleName}",
+                ).left()
+            }
 
         if (koskiRequest == null) {
             val suoritus = ykiSuoritusEntity.copy(koskiSiirtoKasitelty = true)

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
@@ -8,6 +8,7 @@ import fi.oph.kitu.util.result.getOrThrow
 import fi.oph.kitu.vkt.CustomVktSuoritusRepository
 import fi.oph.kitu.vkt.VktSuoritusRepository
 import fi.oph.kitu.vkt.VktSuoritusService
+import fi.oph.kitu.yki.Tutkintotaso
 import fi.oph.kitu.yki.YkiService
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusFilter
@@ -215,6 +216,54 @@ class KoskiServiceTest(
         val updatedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
         assertEquals(3, updatedSuoritukset.size)
         assertEquals(2, updatedSuoritukset.filter { it.koskiOpiskeluoikeus != null }.size)
+    }
+
+    @Test
+    fun `Yhden suorituksen mappausvirhe ei keskeytä Koski-eräajoa`() {
+        val koskiResponse = successfulKoskiResponseFor("1.2.246.562.24.20281155246", 183424)
+        val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
+        mockServer
+            .expect(ExpectedCount.times(2), requestTo("oppija"))
+            .andRespond(withSuccess(koskiResponse, MediaType.APPLICATION_JSON))
+
+        val service =
+            KoskiService(
+                mockRestClientBuilder.build(),
+                koskiYkiRequestMapper,
+                koskiVktRequestMapper,
+                ykiSuoritusRepository,
+                customVktSuoritusRepository,
+                vktSuoritusService,
+                koskiErrorService,
+            )
+
+        val invalid =
+            generateRandomYkiSuoritusEntity().copy(
+                tutkintotaso = Tutkintotaso.PT,
+                tekstinYmmartaminen = 1,
+                kirjoittaminen = 1,
+                rakenteetJaSanasto = 1,
+                puheenYmmartaminen = 1,
+                puhuminen = 5,
+                yleisarvosana = 1,
+            )
+        ykiSuoritusRepository.saveAllNewEntities(
+            listOf(
+                generateRandomYkiSuoritusEntity(),
+                invalid,
+                generateRandomYkiSuoritusEntity(),
+            ),
+        )
+
+        service.sendYkiSuorituksetToKoski()
+
+        val updatedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
+        assertEquals(3, updatedSuoritukset.size)
+        assertEquals(2, updatedSuoritukset.filter { it.koskiOpiskeluoikeus != null }.size)
+
+        val errorEntity = koskiErrorService.findById(YkiMappingId(invalid.solkiId))
+        assertNotNull(errorEntity)
+        assertTrue(errorEntity.message!!.contains("Koski-pyynnöksi"))
     }
 
     @Test


### PR DESCRIPTION

Aiemmin KoskiYkiRequestMapper saattoi heittää IllegalArgumentExceptionin
(esim. YkiArvosana.of:sta), jolloin yksi rikkinäinen suoritus kaatoi
koko sendYkiSuorituksetToKoski-eräajon eivätkä sen jälkeiset suoritukset
päässeet Koskeen. Nyt mappausvirhe muunnetaan KoskiValidationExceptioniksi,
tallentuu olemassaolevaan koski_error-tauluun ja eräajo jatkaa muilla
suorituksilla.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
