### PR TITLE
OPHKOTO-26: Lisää S3-ämpäri ja työkalu YKI-historiatiedostojen latausta varten

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -39,8 +39,12 @@ infra/
     ├── log-groups-stack.ts          # Log groups + LogErrors/LogWarnings filters + alarms
     ├── backups-stack.ts             # AWS Backup vault for the Aurora cluster
     ├── koski-audit-logs-integration-stack.ts  # Subscription filter + Lambda → KOSKI SQS
-    └── koski-audit-logs-integration/  # Lambda source for the above
+    ├── koski-audit-logs-integration/  # Lambda source for the above
+    └── yki-historia-upload-stack.ts   # Prod-only S3 bucket for YKI-historia uploads
 ```
+
+`infra/scripts/` holds Node helpers invoked by top-level `scripts/*.sh`
+(currently just `presign-yki-historia-upload.mjs`, see below).
 
 ## Util stage (`bin/infra.ts`, `lib/utility-stage.ts`)
 
@@ -95,6 +99,30 @@ order (because of dependencies):
     the audit log group → Lambda → SQS in the KOSKI account. The Lambda assumes
     a role (`kitu-sqs-sender`) that the KOSKI account creates with a matching
     trust policy.
+
+### Prod-only stacks
+
+`Prod/YkiHistoriaUpload` (`lib/yki-historia-upload-stack.ts`) is wired
+directly in `bin/infra.ts` as a child of the `Prod` stage — not in
+`environment-stage.ts`, since there is no Dev/Test analogue. It creates a
+single S3 bucket `kitu-yki-historia-upload-prod` that an external
+organization writes to via on-demand presigned PUT URLs (≤5 GB per file).
+The bucket is versioned, BlockPublicAccess all, S3-managed encryption,
+`enforceSSL`, ACLs disabled (`BUCKET_OWNER_ENFORCED`), removalPolicy
+RETAIN, and aborts incomplete multipart uploads after 7 days. The Spring
+Boot app does not access this bucket — OPH admins download the files via
+the AWS console.
+
+To mint a URL, an OPH admin runs locally:
+
+```bash
+./scripts/yki_historia_upload_presign.sh --key <object-key>
+```
+
+The script invokes `infra/scripts/presign-yki-historia-upload.mjs` (uses
+`@aws-sdk/s3-request-presigner` — `aws s3 presign` in AWS CLI 2.34.x is
+GET-only) and prints the URL plus a ready-to-paste `curl --upload-file`
+one-liner for the uploader. Default TTL is 7 days (the SigV4 maximum).
 
 ## Service stack details (`lib/service-stack.ts`)
 
@@ -297,3 +325,7 @@ Listed here because deploys silently or loudly fail when these don't exist:
 - **`TAG` env var** set to a tag that exists in the Util ECR repo. CI sets this
   automatically; locally use `TAG=$(git rev-parse main)` to deploy main's
   image, or pin to a specific commit.
+
+`Prod/YkiHistoriaUpload` has no manual prerequisites — the bucket is
+CDK-managed and the `oph-ktr-prod` SSO profile is already configured by
+`scripts/ensure_aws_profiles.sh`.

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -6,6 +6,7 @@ import { deploymentAccounts, utilityAccount } from "../lib/accounts"
 import { getEnv } from "../lib/env"
 import { EnvironmentStage } from "../lib/environment-stage"
 import { UtilityStage } from "../lib/utility-stage"
+import { YkiHistoriaUploadStack } from "../lib/yki-historia-upload-stack"
 
 const app = new App()
 
@@ -35,8 +36,12 @@ new EnvironmentStage(app, "Test", {
   environmentConfig: deploymentAccounts.test,
   serviceImage,
 })
-new EnvironmentStage(app, "Prod", {
+const prodStage = new EnvironmentStage(app, "Prod", {
   env: deploymentAccounts.prod,
   environmentConfig: deploymentAccounts.prod,
   serviceImage,
+})
+
+new YkiHistoriaUploadStack(prodStage, "YkiHistoriaUpload", {
+  env: deploymentAccounts.prod,
 })

--- a/infra/lib/yki-historia-upload-stack.ts
+++ b/infra/lib/yki-historia-upload-stack.ts
@@ -1,0 +1,30 @@
+import { Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib"
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketEncryption,
+  ObjectOwnership,
+} from "aws-cdk-lib/aws-s3"
+import { Construct } from "constructs"
+
+export class YkiHistoriaUploadStack extends Stack {
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props)
+
+    new Bucket(this, "Bucket", {
+      bucketName: "kitu-yki-historia-upload-prod",
+      versioned: true,
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
+      removalPolicy: RemovalPolicy.RETAIN,
+      lifecycleRules: [
+        {
+          id: "abort-incomplete-multipart-uploads",
+          abortIncompleteMultipartUploadAfter: Duration.days(7),
+        },
+      ],
+    })
+  }
+}

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -8,10 +8,12 @@
       "name": "infra",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.882.0",
         "@aws-sdk/client-sqs": "^3.882.0",
         "@aws-sdk/client-ssm": "^3.882.0",
         "@aws-sdk/client-sts": "^3.882.0",
         "@aws-sdk/credential-providers": "^3.883.0",
+        "@aws-sdk/s3-request-presigner": "^3.882.0",
         "@types/aws-lambda": "^8.10.152",
         "aws-cdk-lib": "2.254.0",
         "constructs": "^10.0.0",
@@ -29,6 +31,10 @@
         "ts-jest": "^29.4.9",
         "ts-node": "^10.9.2",
         "typescript": "~6.0.0"
+      },
+      "engines": {
+        "node": "^24",
+        "npm": ">=11"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -93,6 +99,31 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -106,44 +137,6 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-js": {
@@ -180,44 +173,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.1047.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1047.0.tgz",
@@ -240,6 +195,35 @@
         "@smithy/core": "^3.24.1",
         "@smithy/fetch-http-handler": "^5.4.1",
         "@smithy/node-http-handler": "^4.7.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1049.0.tgz",
+      "integrity": "sha512-e5ToFwYeHSfkKDPs/G0yhO7vxvfVOF6DhmlvI2xFi4m12NvjxPhaA2Y35QMaYLrw/oGPXmu9McfKnBm/oXYXbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.14",
+        "@aws-sdk/middleware-expect-continue": "^3.972.12",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.20",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.41",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -337,15 +321,30 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.10.tgz",
-      "integrity": "sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg==",
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/xml-builder": "^3.972.24",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz",
+      "integrity": "sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -370,14 +369,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.36.tgz",
-      "integrity": "sha512-gE+CGuPZD1eqUWGSrM8CXDjlwuPujIuwI+IlorD1wE2RcANKKT4jscB9GY1nTJbjmXzD18sycsYbgCG5m3n4/g==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -386,16 +385,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.38.tgz",
-      "integrity": "sha512-cHZo3bV6zN9joDQ2AYVctfzHTKStxWKwnGu0z7GwCUC+DAtB3qL/+26l+a63RbmFbVvb1JK+0vJKodN3hRMwyw==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -404,22 +403,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.40.tgz",
-      "integrity": "sha512-0NFGS9I3PD2yMveQqqpwpRdyZVStzgk0Yr2rZHh80kV/QNqQCK5lSrksvU3nBcRNSUF5Uk8rL3Xk0EVR+UVAnA==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/credential-provider-env": "^3.972.36",
-        "@aws-sdk/credential-provider-http": "^3.972.38",
-        "@aws-sdk/credential-provider-login": "^3.972.40",
-        "@aws-sdk/credential-provider-process": "^3.972.36",
-        "@aws-sdk/credential-provider-sso": "^3.972.40",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.40",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/credential-provider-imds": "^4.3.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -428,15 +427,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.40.tgz",
-      "integrity": "sha512-IEIl+UQnrEjZP53TSl91e8LBephi4i1Mt9WZrMgN8pOg6xPOLZdkN1GhsEzjkMD1TQy4Fp2dwWA/9ToTQFOlLA==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -445,20 +444,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.41.tgz",
-      "integrity": "sha512-h6BlclpsPGkx7Pv7ukr8oKVqN3jvxnH5n9ZIUQa8focr1ZkKd2MYiPJ2Nv9GI97dohJVJBfZAsTp/qoZL5R1pw==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.36",
-        "@aws-sdk/credential-provider-http": "^3.972.38",
-        "@aws-sdk/credential-provider-ini": "^3.972.40",
-        "@aws-sdk/credential-provider-process": "^3.972.36",
-        "@aws-sdk/credential-provider-sso": "^3.972.40",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.40",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/credential-provider-imds": "^4.3.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -467,14 +466,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.36.tgz",
-      "integrity": "sha512-eDQ6X7clTAOxXegOx4rGT1hyfusGEYdJGCGo0Ym2+CKeMQBjk+SJSxSVev11NJew5xJHJ/c3hryl2awKaxuSEA==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -483,16 +482,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.40.tgz",
-      "integrity": "sha512-jaABbsoOkGlKg5kaHetYmUV6mWM57H89ia0Yksom1XxC847mfjmEVb4p7VijS1sjPbXjUii4cftJuwsl4MXkRg==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
-        "@aws-sdk/token-providers": "3.1047.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -501,15 +500,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.40.tgz",
-      "integrity": "sha512-bfIrM8IIzbRtXRQWx/vNEUBLTImLZyX5uKk8uSdeSAZ4Mj3Yi4UnRJLK4FkQLWErbM3McpVLQ1DaM6XO66Ed5g==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -545,6 +544,57 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.14.tgz",
+      "integrity": "sha512-Aaj0d+xbo1jJquBWJP0/9V/XZRYukO3LWIRp3dOLHmoFrYKb4YZ0aLefgVHfGcNOVBS2ZTq7L/n5JcrE7DaC+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.12.tgz",
+      "integrity": "sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.20.tgz",
+      "integrity": "sha512-NdnMVQCR1YjIcqFAiNLdBiOwr2DyQDB2IiXQrBhzolKOv32ae4d4Ll7IzLMi04eMHiq/o/Y/GjFuVjF9HuG0QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/crc64-nvme": "^3.972.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.11.tgz",
@@ -553,6 +603,20 @@
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -590,6 +654,24 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.41.tgz",
+      "integrity": "sha512-M4T2I2WPuH5WQpU8Tsp+u2bcO29zGRkU14ATzuqb9I4xh8tzsLqtp4hzaJM5aO2dhMZnHDzyQwSFVgc3XbnoGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
       "version": "3.972.23",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.23.tgz",
@@ -598,6 +680,20 @@
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -623,27 +719,19 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.8.tgz",
-      "integrity": "sha512-/Vw2M27w+0APfMDzDpvv8auA4WiJ4D22+lC61pMS2M8Wk+4IydeRqh5utbrh+A5gQRxgUYd/xz3tdv8nQlmiHg==",
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/middleware-host-header": "^3.972.11",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
-        "@aws-sdk/middleware-user-agent": "^3.972.40",
-        "@aws-sdk/region-config-resolver": "^3.972.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.9",
-        "@aws-sdk/util-user-agent-browser": "^3.972.11",
-        "@aws-sdk/util-user-agent-node": "^3.973.26",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -666,15 +754,32 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1049.0.tgz",
+      "integrity": "sha512-pffbb4YNXB2OeqoFMEyFLg1J7SZu5fMf4D/NiCmwzSumLuUb8FVU+oNbmhVA2bgr1B78Hz9h7zObaVgLKh/bTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz",
-      "integrity": "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==",
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -683,15 +788,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1047.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1047.0.tgz",
-      "integrity": "sha512-GwJUeMijpeO2SOGGLRg4q2Nj9foBUBd7hTALYVId+m8fQmA4P2hITp5dmrZFd4AjEkSVmt2eFqmk3TttF7HZeQ==",
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1907,6 +2012,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.2.tgz",
@@ -1945,6 +2062,32 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2593,16 +2736,6 @@
       },
       "peerDependencies": {
         "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -2738,6 +2738,16 @@
         "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,

--- a/infra/package.json
+++ b/infra/package.json
@@ -29,10 +29,12 @@
     "typescript": "~6.0.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.882.0",
     "@aws-sdk/client-sqs": "^3.882.0",
     "@aws-sdk/client-ssm": "^3.882.0",
     "@aws-sdk/client-sts": "^3.882.0",
     "@aws-sdk/credential-providers": "^3.883.0",
+    "@aws-sdk/s3-request-presigner": "^3.882.0",
     "@types/aws-lambda": "^8.10.152",
     "aws-cdk-lib": "2.254.0",
     "constructs": "^10.0.0",

--- a/infra/scripts/presign-yki-historia-upload.mjs
+++ b/infra/scripts/presign-yki-historia-upload.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Mints a presigned S3 PUT URL. Invoked by scripts/yki_historia_upload_presign.sh.
+// Inputs come via env vars (set by the wrapper):
+//   BUCKET, KEY, TTL_SECONDS, REGION, AWS_PROFILE
+// Output: the presigned URL on stdout. Errors on stderr with non-zero exit.
+
+import { S3Client } from "@aws-sdk/client-s3"
+import { PutObjectCommand } from "@aws-sdk/client-s3"
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
+import { fromIni } from "@aws-sdk/credential-providers"
+
+function required(name) {
+  const v = process.env[name]
+  if (!v) {
+    process.stderr.write(`Missing required env var: ${name}\n`)
+    process.exit(2)
+  }
+  return v
+}
+
+const bucket = required("BUCKET")
+const key = required("KEY")
+const ttl = Number.parseInt(required("TTL_SECONDS"), 10)
+const region = required("REGION")
+const profile = required("AWS_PROFILE")
+
+if (!Number.isInteger(ttl) || ttl < 60 || ttl > 604800) {
+  process.stderr.write(
+    `TTL_SECONDS must be an integer between 60 and 604800, got: ${process.env.TTL_SECONDS}\n`,
+  )
+  process.exit(2)
+}
+
+const client = new S3Client({
+  region,
+  credentials: fromIni({ profile }),
+})
+
+const url = await getSignedUrl(
+  client,
+  new PutObjectCommand({ Bucket: bucket, Key: key }),
+  { expiresIn: ttl },
+)
+
+process.stdout.write(url + "\n")

--- a/scripts/yki_historia_upload_presign.sh
+++ b/scripts/yki_historia_upload_presign.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/common-functions.sh"
+
+DEFAULT_BUCKET="kitu-yki-historia-upload-prod"
+DEFAULT_PROFILE="oph-ktr-prod"
+DEFAULT_REGION="eu-west-1"
+DEFAULT_TTL_SECONDS="604800" # 7 days, SigV4 max
+
+function usage {
+  cat <<EOF
+Usage: $(basename "$0") --key <object-key> [--ttl <seconds>] [--bucket <name>] [--profile <aws-profile>]
+
+Generates a presigned S3 PUT URL that an external organization can use to upload
+a single file (<= 5 GB) to the YKI-historia bucket. Prints the URL and a
+ready-to-paste curl one-liner.
+
+Options:
+  --key       Object key in the bucket, e.g. yki-historia-2024-batch-01.zip. Required.
+  --ttl       URL validity in seconds. Default: ${DEFAULT_TTL_SECONDS} (7 days, max).
+  --bucket    Bucket name. Default: ${DEFAULT_BUCKET}.
+  --profile   AWS profile. Default: ${DEFAULT_PROFILE}.
+  -h, --help  Show this help.
+EOF
+}
+
+key=""
+ttl="${DEFAULT_TTL_SECONDS}"
+bucket="${DEFAULT_BUCKET}"
+profile="${DEFAULT_PROFILE}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --key)
+      key="$2"
+      shift 2
+      ;;
+    --ttl)
+      ttl="$2"
+      shift 2
+      ;;
+    --bucket)
+      bucket="$2"
+      shift 2
+      ;;
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fatal "Unknown argument: $1"
+      ;;
+  esac
+done
+
+require_command aws
+require_command node
+
+[ -n "${key}" ] || fatal "--key is required."
+[[ "${ttl}" =~ ^[0-9]+$ ]] || fatal "--ttl must be a positive integer (seconds)."
+[ "${ttl}" -ge 60 ] && [ "${ttl}" -le 604800 ] \
+  || fatal "--ttl must be between 60 and 604800 seconds."
+
+if ! aws sts get-caller-identity --profile "${profile}" >/dev/null 2>&1; then
+  info "AWS session for profile '${profile}' is missing or expired — running 'aws sso login'."
+  aws --profile "${profile}" sso login
+fi
+
+info "Minting presigned PUT URL: bucket=${bucket} key=${key} ttl=${ttl}s profile=${profile}"
+
+url=$(
+  BUCKET="${bucket}" \
+  KEY="${key}" \
+  TTL_SECONDS="${ttl}" \
+  REGION="${DEFAULT_REGION}" \
+  AWS_PROFILE="${profile}" \
+    node "${REPO_ROOT}/infra/scripts/presign-yki-historia-upload.mjs"
+)
+
+[ -n "${url}" ] || fatal "Presign helper returned no URL."
+
+info "URL valid for ${ttl} seconds. Share the URL below with the uploader."
+printf '\n%s\n\n' "${url}"
+info "Curl one-liner to send to the uploader:"
+printf '\ncurl --fail --upload-file /path/to/local-file %q\n\n' "${url}"


### PR DESCRIPTION

Ulkopuolinen organisaatio toimittaa historialliset YKI-suoritustiedot
suurina tiedostoina (≤5 GB). Itse sovellus ei tarvitse pääsyä näihin —
virkailijat hakevat ne AWS-konsolista.

- Uusi prod-only CDK-stack `Prod/YkiHistoriaUpload` luo S3-ämpärin
  `kitu-yki-historia-upload-prod`: versiointi, BlockPublicAccess,
  enforceSSL, BUCKET_OWNER_ENFORCED, RETAIN ja keskeneräisten
  multipart-lähetysten keskeytys 7 päivän jälkeen.
- Stack kytketään suoraan `bin/infra.ts`:ssä Prod-vaiheen lapseksi,
  koska Dev/Test-vastineita ei ole.
- `scripts/yki_historia_upload_presign.sh` (+ Node-apuri
  `infra/scripts/presign-yki-historia-upload.mjs`) generoi
  presigned PUT -URL:n ja valmiin curl-komennon lataajalle.
  Käyttää @aws-sdk/s3-request-presigneriä, koska AWS CLI 2.34:n
  `aws s3 presign` osaa vain GET:n.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
