### PR TITLE
OPHKOTO-146: Lisää refaktorointia

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
@@ -1,6 +1,7 @@
 package fi.oph.kitu.csvparsing
 
 import arrow.core.Either
+import arrow.core.left
 import fi.oph.kitu.observability.use
 import fi.oph.kitu.oid.Oid
 import fi.oph.kitu.oid.OidDeserializer
@@ -119,9 +120,15 @@ class CsvParser(
                 val schema = getSchema<T>(csvMapper)
                 val lineSeparator =
                     onlyOrNull(schema.lineSeparator)
-                        // This error would be probably due to internal changes so we don't pass it to normal error handling.
-                        ?: throw IllegalStateException(
-                            "Can't find only one line seperator from schema (${schema.lineSeparator}).",
+                        ?: return@use listOf(
+                            SimpleCsvExportError(
+                                lineNumber = 0,
+                                context = null,
+                                exception =
+                                    IllegalStateException(
+                                        "Can't find only one line seperator from schema (${schema.lineSeparator}).",
+                                    ),
+                            ).left(),
                         )
 
                 return@use csvMapper

--- a/server/src/main/kotlin/fi/oph/kitu/ilmoittautumisjarjestelma/IlmoittautumisjarjestelmaClient.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ilmoittautumisjarjestelma/IlmoittautumisjarjestelmaClient.kt
@@ -46,11 +46,9 @@ class IlmoittautumisjarjestelmaClientImpl(
                 .body(body)
                 .retrieveEntitySafely(String::class.java)
 
-        if (rawResponse == null) {
-            throw RuntimeException("Failed to send data to kielitutkintojen ilmoittautumisjärjestelmä")
-        }
-
-        return if (rawResponse.statusCode.is4xxClientError) {
+        return if (rawResponse == null) {
+            IlmoittautumisjarjestelmaException.NullResponse(body).left()
+        } else if (rawResponse.statusCode.is4xxClientError) {
             IlmoittautumisjarjestelmaException.BadRequest(body, rawResponse).left()
         } else if (!rawResponse.statusCode.is2xxSuccessful) {
             IlmoittautumisjarjestelmaException.UnexpectedError(body, rawResponse).left()

--- a/server/src/main/kotlin/fi/oph/kitu/ilmoittautumisjarjestelma/IlmoittautumisjarjestelmaException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/ilmoittautumisjarjestelma/IlmoittautumisjarjestelmaException.kt
@@ -28,6 +28,11 @@ sealed class IlmoittautumisjarjestelmaException(
         cause: Throwable? = null,
     ) : IlmoittautumisjarjestelmaException(request, response, "Malformed response", cause)
 
+    class NullResponse(
+        request: IlmoittautumisjarjestelmaRequest,
+        message: String = "Empty or unserializable response",
+    ) : IlmoittautumisjarjestelmaException(request, null, message)
+
     fun debugString(): String =
         listOfNotNull(
             message,

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiScheduledTask.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiScheduledTask.kt
@@ -2,6 +2,7 @@ package fi.oph.kitu.koski
 
 import com.github.kagkarlsson.scheduler.task.Task
 import fi.oph.kitu.config.ConditionalOnNonEmptyProperty
+import fi.oph.kitu.util.result.getOrThrow
 import fi.oph.kitu.util.scheduling.recurringStatefulTask
 import io.opentelemetry.api.trace.Tracer
 import org.springframework.beans.factory.annotation.Value
@@ -21,7 +22,7 @@ class KoskiYkiScheduledTask(
     @Bean
     fun sendYkiSuoritukset(koskiService: KoskiService): Task<String> =
         tracer.recurringStatefulTask("Lähetä YKI-suoritukset KOSKI-palveluun", ykiSchedule, "") { _ ->
-            koskiService.sendYkiSuorituksetToKoski().toString()
+            koskiService.sendYkiSuorituksetToKoski().getOrThrow().toString()
         }
 }
 
@@ -37,6 +38,6 @@ class KoskiVktScheduledTask(
     @Bean
     fun sendVktSuoritukset(koskiService: KoskiService): Task<String> =
         tracer.recurringStatefulTask("Lähetä VKT-suoritukset KOSKI-palveluun", vktSchedule, "") { _ ->
-            koskiService.sendVktSuorituksetToKoski().toString()
+            koskiService.sendVktSuorituksetToKoski().getOrThrow().toString()
         }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
@@ -149,14 +149,14 @@ class KoskiService(
     }
 
     @WithSpan
-    fun sendYkiSuorituksetToKoski(): KoskiTransferReport {
+    fun sendYkiSuorituksetToKoski(): Either<KoskiTechnicalException, KoskiTransferReport> {
         val suoritukset = ykiSuoritusRepository.findKoskeenLahettamattomatSuoritukset()
         val results = suoritukset.map { sendYkiSuoritusToKoski(it) }
         return reportErrors(results.map { it.map { suoritus -> YkiMappingId(suoritus.solkiId) } })
     }
 
     @WithSpan
-    fun sendVktSuorituksetToKoski(): KoskiTransferReport {
+    fun sendVktSuorituksetToKoski(): Either<KoskiTechnicalException, KoskiTransferReport> {
         val siirrettavat = customVktSuoritusRepository.findOpiskeluoikeudetForKoskiTransfer()
         val results =
             siirrettavat.map { id ->
@@ -189,15 +189,20 @@ class KoskiService(
 
     private inline fun <reified T : KoskiErrorMappingId> reportErrors(
         results: List<Either<KoskiException, T>?>,
-    ): KoskiTransferReport {
+    ): Either<KoskiTechnicalException, KoskiTransferReport> {
         val (success, failed) = results.filterNotNull().splitIntoValuesAndErrors()
         success.forEach { id -> koskiErrors.reset(id) }
         failed.forEach { error -> koskiErrors.save(error.suoritusId, error.message ?: error.toString()) }
-        failed.find { it is KoskiTechnicalException }?.let { throw it }
+        failed.forEach {
+            when (it) {
+                is KoskiTechnicalException -> return it.left()
+                else -> Unit
+            }
+        }
         return KoskiTransferReport(
             success.size,
             results.size,
-        )
+        ).right()
     }
 }
 

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/KoealustaSuoritusValidator.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/KoealustaSuoritusValidator.kt
@@ -35,13 +35,10 @@ class KoealustaSuoritusValidator {
                 ).left()
         }
 
-        checkNotNull(koealustaUser.SSN)
-        checkNotNull(koealustaUser.preferredname)
-
         return Oppija(
             etunimet = koealustaUser.firstnames.trim(),
-            hetu = koealustaUser.SSN.trim(),
-            kutsumanimi = koealustaUser.preferredname.trim(),
+            hetu = koealustaUser.SSN!!.trim(),
+            kutsumanimi = koealustaUser.preferredname!!.trim(),
             sukunimi = koealustaUser.lastname.trim(),
         ).right()
     }
@@ -96,12 +93,6 @@ class KoealustaSuoritusValidator {
 
         if (user.preferredname == null || oppijanumero == null) return null
 
-        checkNotNull(luetunYmmartaminen)
-        checkNotNull(kuullunYmmartaminen)
-        checkNotNull(kirjoittaminen)
-        checkNotNull(puhe)
-        checkNotNull(schoolOid)
-
         return KielitestiSuoritus(
             etunimet = user.firstnames.trim(),
             sukunimi = user.lastname.trim(),
@@ -109,13 +100,13 @@ class KoealustaSuoritusValidator {
             email = user.email,
             oppijanumero = oppijanumero,
             suoritusaika = Instant.ofEpochSecond(completion.timecompleted),
-            oppilaitosOid = schoolOid,
+            oppilaitosOid = schoolOid!!,
             kurssiId = completion.courseid,
             kurssi = completion.coursename,
-            luetunYmmartaminen = luetunYmmartaminen,
-            kuullunYmmartaminen = kuullunYmmartaminen,
-            puhe = puhe,
-            kirjoittaminen = kirjoittaminen,
+            luetunYmmartaminen = luetunYmmartaminen!!,
+            kuullunYmmartaminen = kuullunYmmartaminen!!,
+            puhe = puhe!!,
+            kirjoittaminen = kirjoittaminen!!,
             testikieli = testikieli,
             opettajanEmail = completion.teacheremail,
             tehtavapaketti = completion.questionbank,

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiIngestService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiIngestService.kt
@@ -85,6 +85,7 @@ class TehtavapankkiIngestService(
         val pendingRyhmat = mutableListOf<TehtavaryhmaEntity>()
         val pendingTehtavat = mutableListOf<PendingTehtava>()
         var currentRyhmaIdx: Int? = null
+        var skippedUnknownQuestions = 0
         for (q in quiz.questions) {
             when (q) {
                 is CategoryQuestion -> {
@@ -98,7 +99,13 @@ class TehtavapankkiIngestService(
                     currentRyhmaIdx = pendingRyhmat.lastIndex
                 }
 
-                else -> {
+                is UnknownQuestion -> {
+                    // Tuntematonta question-tyyppiä ei voida tallentaa tehtava-tauluun;
+                    // ohitetaan se hiljaisesti mutta merkitään span-attribuuttiin näkyväksi.
+                    skippedUnknownQuestions++
+                }
+
+                is IngestableQuestion -> {
                     if (currentRyhmaIdx == null) {
                         pendingRyhmat +=
                             TehtavaryhmaEntity(
@@ -161,6 +168,7 @@ class TehtavapankkiIngestService(
         Span.current().setAttribute("tehtavat.count", tehtavat.size.toLong())
         Span.current().setAttribute("vastaukset.count", vastaukset.size.toLong())
         Span.current().setAttribute("tiedostot.count", tiedostot.size.toLong())
+        Span.current().setAttribute("skipped.unknown_question_count", skippedUnknownQuestions.toLong())
 
         return repository.findPakettiById(pakettiId)!!.right()
     }
@@ -171,7 +179,7 @@ class TehtavapankkiIngestService(
 }
 
 private data class PendingTehtava(
-    val question: Question,
+    val question: IngestableQuestion,
     val ryhmaIdx: Int,
     val jarjestys: Int,
 )
@@ -214,46 +222,27 @@ private fun sha256(bytes: ByteArray): String {
     return digest.joinToString("") { "%02x".format(it) }
 }
 
-private fun Question.embeddedFiles(): List<EmbeddedFile> =
+private fun IngestableQuestion.embeddedFiles(): List<EmbeddedFile> =
     when (this) {
         is DescriptionQuestion -> questiontext?.embeddedFiles.orEmpty()
         is MultichoiceQuestion -> questiontext?.embeddedFiles.orEmpty()
         is ShortanswerQuestion -> questiontext?.embeddedFiles.orEmpty()
         is EssayQuestion -> questiontext?.embeddedFiles.orEmpty()
         is CloudpoodllQuestion -> questiontext?.embeddedFiles.orEmpty()
-        is CategoryQuestion, is UnknownQuestion -> emptyList()
     }
 
-private fun Question.toTehtavaEntity(
+private fun IngestableQuestion.toTehtavaEntity(
     pakettiId: Int,
     ryhmaId: Int,
     jarjestys: Int,
 ): TehtavaEntity {
     val (name, qtext, lahdeId) =
         when (this) {
-            is DescriptionQuestion -> {
-                Triple(name, questiontext, idnumber)
-            }
-
-            is MultichoiceQuestion -> {
-                Triple(name, questiontext, idnumber)
-            }
-
-            is ShortanswerQuestion -> {
-                Triple(name, questiontext, idnumber)
-            }
-
-            is EssayQuestion -> {
-                Triple(name, questiontext, idnumber)
-            }
-
-            is CloudpoodllQuestion -> {
-                Triple(name, questiontext, idnumber)
-            }
-
-            is CategoryQuestion, is UnknownQuestion -> {
-                throw IllegalStateException("toTehtavaEntity called on $type")
-            }
+            is DescriptionQuestion -> Triple(name, questiontext, idnumber)
+            is MultichoiceQuestion -> Triple(name, questiontext, idnumber)
+            is ShortanswerQuestion -> Triple(name, questiontext, idnumber)
+            is EssayQuestion -> Triple(name, questiontext, idnumber)
+            is CloudpoodllQuestion -> Triple(name, questiontext, idnumber)
         }
     return TehtavaEntity(
         pakettiId = pakettiId,
@@ -274,7 +263,7 @@ private fun CategoryQuestion.toRyhmaMetadata(): JsonNode {
     return node
 }
 
-private fun Question.toMetadata(): JsonNode {
+private fun IngestableQuestion.toMetadata(): JsonNode {
     val node = defaultObjectMapper.createObjectNode()
     when (this) {
         is DescriptionQuestion -> {
@@ -333,13 +322,11 @@ private fun Question.toMetadata(): JsonNode {
                 tags.mapNotNull { it.text }.filter { it.isNotBlank() }.forEach { arr.add(it) }
             }
         }
-
-        is CategoryQuestion, is UnknownQuestion -> {}
     }
     return node
 }
 
-private fun Question.toVastausEntities(tehtavaId: Int): List<TehtavaVastausEntity> {
+private fun IngestableQuestion.toVastausEntities(tehtavaId: Int): List<TehtavaVastausEntity> {
     val answers =
         when (this) {
             is MultichoiceQuestion -> answers

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiQuiz.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiQuiz.kt
@@ -8,6 +8,11 @@ sealed class Question {
     abstract val type: String
 }
 
+// Question-alityypit, jotka tallennetaan TehtavaEntity-riveiksi.
+// CategoryQuestion (ryhmäraja) ja UnknownQuestion (tuntematon <question type="…">)
+// eivät tarkoituksella laajenna tätä.
+sealed class IngestableQuestion : Question()
+
 data class CategoryQuestion(
     val category: FormattedText? = null,
     val info: FormattedText? = null,
@@ -24,7 +29,7 @@ data class DescriptionQuestion(
     val penalty: Double? = null,
     val hidden: Int? = null,
     val idnumber: String? = null,
-) : Question() {
+) : IngestableQuestion() {
     override val type: String = "description"
 }
 
@@ -44,7 +49,7 @@ data class MultichoiceQuestion(
     val partiallycorrectfeedback: FormattedText? = null,
     val incorrectfeedback: FormattedText? = null,
     val answers: List<Answer> = emptyList(),
-) : Question() {
+) : IngestableQuestion() {
     override val type: String = "multichoice"
 }
 
@@ -58,7 +63,7 @@ data class ShortanswerQuestion(
     val idnumber: String? = null,
     val usecase: Int? = null,
     val answers: List<Answer> = emptyList(),
-) : Question() {
+) : IngestableQuestion() {
     override val type: String = "shortanswer"
 }
 
@@ -81,7 +86,7 @@ data class EssayQuestion(
     val filetypeslist: String? = null,
     val graderinfo: FormattedText? = null,
     val responsetemplate: FormattedText? = null,
-) : Question() {
+) : IngestableQuestion() {
     override val type: String = "essay"
 }
 
@@ -108,7 +113,7 @@ data class CloudpoodllQuestion(
     val safesave: Int? = null,
     val noaudiofilters: Int? = null,
     val tags: List<Tag> = emptyList(),
-) : Question() {
+) : IngestableQuestion() {
     override val type: String = "cloudpoodll"
 }
 

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumeroException.kt
@@ -68,4 +68,9 @@ sealed class OppijanumeroException(
         oppijanumeroServiceError: OppijanumeroServiceError? = null,
         cause: Throwable? = null,
     ) : OppijanumeroException(request, message, oppijanumeroServiceError, cause)
+
+    class NullResponse(
+        request: OppijanumerorekisteriRequest,
+        message: String = "Empty or unserializable response from oppijanumero-service",
+    ) : OppijanumeroException(request, message)
 }

--- a/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumerorekisteriClient.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/oppijanumero/OppijanumerorekisteriClient.kt
@@ -52,11 +52,9 @@ class OppijanumerorekisteriClient(
                 .nullableBody(body)
                 .retrieveEntitySafely(String::class.java)
 
-        if (rawResponse == null) {
-            throw RuntimeException("Failed to fetch data from oppijanumerorekisteri")
-        }
-
-        return if (rawResponse.statusCode == HttpStatus.NOT_FOUND) {
+        return if (rawResponse == null) {
+            OppijanumeroException.NullResponse(body ?: EmptyRequest()).left()
+        } else if (rawResponse.statusCode == HttpStatus.NOT_FOUND) {
             OppijanumeroException.OppijaNotFoundException(body ?: EmptyRequest(), rawResponse).left()
         } else if (rawResponse.statusCode.is4xxClientError) {
             OppijanumeroException.BadRequest(body ?: EmptyRequest(), rawResponse).left()

--- a/server/src/main/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiopalveluClient.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiopalveluClient.kt
@@ -50,19 +50,17 @@ class OrganisaatiopalveluClient(
                 .nullableBody(body)
                 .retrieveEntitySafely(String::class.java)
 
-        if (rawResponse == null) {
-            throw RuntimeException("Failed to fetch data from organisaatiopalvelu")
-        }
-
-        if (rawResponse.statusCode == HttpStatus.NOT_FOUND) {
-            return OrganisaatiopalveluException.NotFoundException(body ?: EmptyRequest()).left()
+        return if (rawResponse == null) {
+            OrganisaatiopalveluException.NullResponse(body ?: EmptyRequest()).left()
+        } else if (rawResponse.statusCode == HttpStatus.NOT_FOUND) {
+            OrganisaatiopalveluException.NotFoundException(body ?: EmptyRequest()).left()
         } else if (rawResponse.statusCode.is4xxClientError) {
-            return OrganisaatiopalveluException.BadRequest(body ?: EmptyRequest(), rawResponse).left()
+            OrganisaatiopalveluException.BadRequest(body ?: EmptyRequest(), rawResponse).left()
         } else if (!rawResponse.statusCode.is2xxSuccessful) {
-            throw OrganisaatiopalveluException.UnexpectedError(body ?: EmptyRequest(), rawResponse)
+            OrganisaatiopalveluException.UnexpectedError(body ?: EmptyRequest(), rawResponse).left()
+        } else {
+            deserializeResponse(body ?: EmptyRequest(), rawResponse, responseType)
         }
-
-        return deserializeResponse(body ?: EmptyRequest(), rawResponse, responseType)
     }
 
     /**

--- a/server/src/main/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiopalveluException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiopalveluException.kt
@@ -53,6 +53,11 @@ sealed class OrganisaatiopalveluException(
         organisaatiopalveluError: OrganisaatiopalveluError? = null,
         cause: Throwable? = null,
     ) : OrganisaatiopalveluException(request, message, organisaatiopalveluError, cause)
+
+    class NullResponse(
+        request: OrganisaatiopalveluRequest,
+        message: String = "Empty or unserializable response from organisaatio-service",
+    ) : OrganisaatiopalveluException(request, message)
 }
 
 data class OrganisaatiopalveluError(

--- a/server/src/main/kotlin/fi/oph/kitu/yki/Tutkintokieli.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/Tutkintokieli.kt
@@ -1,5 +1,8 @@
 package fi.oph.kitu.yki
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.oph.kitu.html.table.HideInTableFilter
@@ -39,12 +42,5 @@ enum class Tutkintokieli(
 
     companion object {
         val legacyEntries = setOf(SWE10, ENG11, ENG12)
-
-        @JvmStatic
-        @JsonCreator
-        fun fromSolkiCode(value: String): Tutkintokieli =
-            entries.find { it.solkiCode == value } ?: throw IllegalArgumentException("Unknown Solki code: $value")
     }
 }
-
-fun ResultSet.getTutkintokieli(columnLabel: String): Tutkintokieli = Tutkintokieli.valueOf(getString(columnLabel))

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
@@ -164,7 +164,7 @@ class KoskiServiceTest(
                 generateRandomYkiSuoritusEntity(),
             ),
         )
-        service.sendYkiSuorituksetToKoski()
+        service.sendYkiSuorituksetToKoski().getOrThrow()
         val updatedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
         assertEquals(3, updatedSuoritukset.size)
         updatedSuoritukset.forEach {
@@ -212,7 +212,7 @@ class KoskiServiceTest(
             ),
         )
 
-        service.sendYkiSuorituksetToKoski()
+        service.sendYkiSuorituksetToKoski().getOrThrow()
 
         val updatedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
         assertEquals(3, updatedSuoritukset.size)
@@ -256,7 +256,7 @@ class KoskiServiceTest(
             ),
         )
 
-        service.sendYkiSuorituksetToKoski()
+        service.sendYkiSuorituksetToKoski().getOrThrow()
 
         val updatedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
         assertEquals(3, updatedSuoritukset.size)
@@ -298,7 +298,7 @@ class KoskiServiceTest(
             ),
         )
 
-        service.sendYkiSuorituksetToKoski()
+        service.sendYkiSuorituksetToKoski().getOrThrow()
 
         val updatedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
         assertEquals(3, updatedSuoritukset.size)


### PR DESCRIPTION

- **Korvaa Either-paluuarvoissa olevia poikkeuksia Left-haaroilla**
- **Poista käyttämättömät Tutkintokieli.fromSolkiCode ja ResultSet.getTutkintokieli**
- **Palauta sendYki/VktSuorituksetToKoski Either-tyyppinä**
- **Palauta tyhjä HTTP-vastaus Either-Leftinä RuntimeExceptionin sijaan**
