### PR TITLE
OPHKOTO-146: Lisää testikattavuutta koodisto- ja organisaatiot-paketteihin

### DIFF
--- a/server/src/test/kotlin/fi/oph/kitu/koodisto/KoodistoEnumsTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koodisto/KoodistoEnumsTest.kt
@@ -1,0 +1,191 @@
+package fi.oph.kitu.koodisto
+
+import arrow.core.Either
+import fi.oph.kitu.organisaatiot.KoodiviiteUri
+import fi.oph.kitu.yki.Tutkintotaso
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class KoodistoEnumsTest {
+    @Test
+    fun `YkiTutkintotaso fromName palauttaa tunnetun arvon Right-haarana`() {
+        assertEquals(
+            Koodisto.YkiTutkintotaso.PT,
+            (Koodisto.YkiTutkintotaso.fromName("PT") as Either.Right).value,
+        )
+        assertEquals(
+            Koodisto.YkiTutkintotaso.YT,
+            (Koodisto.YkiTutkintotaso.fromName("YT") as Either.Right).value,
+        )
+    }
+
+    @Test
+    fun `YkiTutkintotaso fromName erottelee kirjainkoon`() {
+        val result = Koodisto.YkiTutkintotaso.fromName("pt")
+        val left = assertIs<Either.Left<InvalidKoodistoValueError>>(result).value
+        assertEquals("ykitutkintotaso", left.koodistoUri)
+        assertEquals("pt", left.name)
+    }
+
+    @Test
+    fun `YkiTutkintotaso fromName palauttaa Left-virheen tuntemattomasta arvosta`() {
+        val result = Koodisto.YkiTutkintotaso.fromName("X1")
+        val left = assertIs<Either.Left<InvalidKoodistoValueError>>(result).value
+        assertEquals("ykitutkintotaso", left.koodistoUri)
+        assertEquals("X1", left.name)
+    }
+
+    @Test
+    fun `Tutkintokieli fromName palauttaa tunnetun arvon`() {
+        assertEquals(
+            Koodisto.Tutkintokieli.FIN,
+            (Koodisto.Tutkintokieli.fromName("FIN") as Either.Right).value,
+        )
+    }
+
+    @Test
+    fun `Tutkintokieli fromName palauttaa Leftin tuntemattomasta arvosta`() {
+        val result = Koodisto.Tutkintokieli.fromName("XXX")
+        val left = assertIs<Either.Left<InvalidKoodistoValueError>>(result).value
+        assertEquals("kieli", left.koodistoUri)
+        assertEquals("XXX", left.name)
+    }
+
+    @ParameterizedTest
+    @MethodSource("ptCases")
+    fun `YkiArvosana of PT-tasolla`(
+        input: Int,
+        expected: Koodisto.YkiArvosana,
+    ) {
+        assertEquals(
+            expected,
+            (Koodisto.YkiArvosana.of(input, Tutkintotaso.PT) as Either.Right).value,
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("ktCases")
+    fun `YkiArvosana of KT-tasolla`(
+        input: Int,
+        expected: Koodisto.YkiArvosana,
+    ) {
+        assertEquals(
+            expected,
+            (Koodisto.YkiArvosana.of(input, Tutkintotaso.KT) as Either.Right).value,
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("ytCases")
+    fun `YkiArvosana of YT-tasolla`(
+        input: Int,
+        expected: Koodisto.YkiArvosana,
+    ) {
+        assertEquals(
+            expected,
+            (Koodisto.YkiArvosana.of(input, Tutkintotaso.YT) as Either.Right).value,
+        )
+    }
+
+    @ParameterizedTest
+    @EnumSource(Tutkintotaso::class)
+    fun `YkiArvosana of palauttaa Leftin sallitun alueen ulkopuolelta`(taso: Tutkintotaso) {
+        val result = Koodisto.YkiArvosana.of(99, taso)
+        val left = assertIs<Either.Left<InvalidYkiArvosanaError>>(result).value
+        assertEquals(99, left.arvosana)
+        assertEquals(taso, left.tutkintotaso)
+    }
+
+    @Test
+    fun `YkiArvosana validIntegersFor antaa kullekin tasolle sallitut numerot`() {
+        assertEquals(setOf(0, 1, 2, 9, 10, 11), Koodisto.YkiArvosana.validIntegersFor(Tutkintotaso.PT))
+        assertEquals(setOf(0, 1, 2, 3, 4, 9, 10, 11), Koodisto.YkiArvosana.validIntegersFor(Tutkintotaso.KT))
+        assertEquals(setOf(0, 1, 2, 3, 4, 5, 6, 9, 10, 11), Koodisto.YkiArvosana.validIntegersFor(Tutkintotaso.YT))
+    }
+
+    @Test
+    fun `toKoski tuottaa KoskiKoodiviite-objektin samalla arvolla ja URIlla`() {
+        val koski = Koodisto.YkiTutkintotaso.KT.toKoski()
+        assertEquals("kt", koski.koodiarvo)
+        assertEquals("ykitutkintotaso", koski.koodistoUri)
+    }
+
+    @Test
+    fun `Organisaatiotyyppi of tunnistaa organisaatiotyyppi-URIn`() {
+        val uri = KoodiviiteUri("organisaatiotyyppi_02#1")
+        assertEquals(Koodisto.Organisaatiotyyppi.Oppilaitos, Koodisto.Organisaatiotyyppi.of(uri))
+    }
+
+    @Test
+    fun `Organisaatiotyyppi of palauttaa null kun URI ei ole organisaatiotyyppi`() {
+        val uri = KoodiviiteUri("kieli_FI#1")
+        assertNull(Koodisto.Organisaatiotyyppi.of(uri))
+    }
+
+    @Test
+    fun `Organisaatiotyyppi of palauttaa null kun koodiarvoa ei tunneta`() {
+        val uri = KoodiviiteUri("organisaatiotyyppi_99#1")
+        assertNull(Koodisto.Organisaatiotyyppi.of(uri))
+    }
+
+    @Test
+    fun `VktArvosana jarjestys vastaa order-kenttaa`() {
+        val sorted = Koodisto.VktArvosana.entries.sortedWith(Koodisto.ArvosanaKoodiviite::compare)
+        assertEquals(
+            listOf(
+                Koodisto.VktArvosana.EiSuoritusta,
+                Koodisto.VktArvosana.Hylätty,
+                Koodisto.VktArvosana.Tyydyttävä,
+                Koodisto.VktArvosana.Hyvä,
+                Koodisto.VktArvosana.Erinomainen,
+            ),
+            sorted,
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun ptCases(): List<Array<Any>> =
+            listOf(
+                arrayOf(0, Koodisto.YkiArvosana.ALLE1),
+                arrayOf(1, Koodisto.YkiArvosana.PT1),
+                arrayOf(2, Koodisto.YkiArvosana.PT2),
+                arrayOf(9, Koodisto.YkiArvosana.EiVoiArvioida),
+                arrayOf(10, Koodisto.YkiArvosana.Keskeytetty),
+                arrayOf(11, Koodisto.YkiArvosana.Vilppi),
+            )
+
+        @JvmStatic
+        fun ktCases(): List<Array<Any>> =
+            listOf(
+                arrayOf(0, Koodisto.YkiArvosana.ALLE3),
+                arrayOf(1, Koodisto.YkiArvosana.ALLE3),
+                arrayOf(2, Koodisto.YkiArvosana.ALLE3),
+                arrayOf(3, Koodisto.YkiArvosana.KT3),
+                arrayOf(4, Koodisto.YkiArvosana.KT4),
+                arrayOf(9, Koodisto.YkiArvosana.EiVoiArvioida),
+                arrayOf(10, Koodisto.YkiArvosana.Keskeytetty),
+                arrayOf(11, Koodisto.YkiArvosana.Vilppi),
+            )
+
+        @JvmStatic
+        fun ytCases(): List<Array<Any>> =
+            listOf(
+                arrayOf(0, Koodisto.YkiArvosana.ALLE5),
+                arrayOf(1, Koodisto.YkiArvosana.ALLE5),
+                arrayOf(2, Koodisto.YkiArvosana.ALLE5),
+                arrayOf(3, Koodisto.YkiArvosana.ALLE5),
+                arrayOf(4, Koodisto.YkiArvosana.ALLE5),
+                arrayOf(5, Koodisto.YkiArvosana.YT5),
+                arrayOf(6, Koodisto.YkiArvosana.YT6),
+                arrayOf(9, Koodisto.YkiArvosana.EiVoiArvioida),
+                arrayOf(10, Koodisto.YkiArvosana.Keskeytetty),
+                arrayOf(11, Koodisto.YkiArvosana.Vilppi),
+            )
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/koodisto/KoodistoServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koodisto/KoodistoServiceTest.kt
@@ -1,0 +1,192 @@
+package fi.oph.kitu.koodisto
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Tracer
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.ExpectedCount
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpServerErrorException
+import org.springframework.web.client.RestClient
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.springframework.http.HttpMethod as SpringHttpMethod
+
+class KoodistoServiceTest {
+    private val baseUrl = "http://koodistopalvelu.test"
+    private val tracer: Tracer = OpenTelemetry.noop().getTracer("KoodistoServiceTest")
+
+    private lateinit var builder: RestClient.Builder
+    private lateinit var mockServer: MockRestServiceServer
+    private lateinit var service: KoodistoServiceImpl
+
+    @BeforeTest
+    fun setup() {
+        builder = RestClient.builder().baseUrl(baseUrl)
+        mockServer = MockRestServiceServer.bindTo(builder).build()
+        service = KoodistoServiceImpl(builder.build(), tracer)
+    }
+
+    @Test
+    fun `getKoodiviitteet hakee koodistopalvelusta ja palauttaa parsitut viitteet`() {
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/maatjavaltiot1"))
+            .andExpect(method(SpringHttpMethod.GET))
+            .andRespond(
+                withSuccess(MAAT_JA_VALTIOT_PAYLOAD, MediaType.APPLICATION_JSON),
+            )
+
+        val viitteet = service.getKoodiviitteet("maatjavaltiot1")
+
+        assertNotNull(viitteet)
+        assertEquals(listOf("FIN", "EST"), viitteet.map { it.koodiArvo })
+        assertEquals(2, viitteet.first().versio)
+        assertEquals(
+            "Suomi",
+            viitteet
+                .first()
+                .metadata
+                .first()
+                .nimi,
+        )
+        mockServer.verify()
+    }
+
+    @Test
+    fun `tulokset tallennetaan valimuistiin eika palvelua kutsuta uudelleen`() {
+        mockServer
+            .expect(ExpectedCount.once(), requestTo("$baseUrl/codeelement/codes/maatjavaltiot1"))
+            .andRespond(withSuccess(MAAT_JA_VALTIOT_PAYLOAD, MediaType.APPLICATION_JSON))
+
+        val first = service.getKoodiviitteet("maatjavaltiot1")
+        val second = service.getKoodiviitteet("maatjavaltiot1")
+
+        assertEquals(first, second)
+        mockServer.verify()
+    }
+
+    @Test
+    fun `eri koodisto-URIt kutsuvat palvelua erikseen`() {
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/maatjavaltiot1"))
+            .andRespond(withSuccess(MAAT_JA_VALTIOT_PAYLOAD, MediaType.APPLICATION_JSON))
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/kunta"))
+            .andRespond(withSuccess(KUNTA_PAYLOAD, MediaType.APPLICATION_JSON))
+
+        val maat = service.getKoodiviitteet("maatjavaltiot1")
+        val kunnat = service.getKoodiviitteet("kunta")
+
+        assertEquals(listOf("FIN", "EST"), maat?.map { it.koodiArvo })
+        assertEquals(listOf("091"), kunnat?.map { it.koodiArvo })
+        mockServer.verify()
+    }
+
+    @Test
+    fun `tyhja vastaus palauttaa tyhjan listan ja tallentaa sen valimuistiin`() {
+        mockServer
+            .expect(ExpectedCount.once(), requestTo("$baseUrl/codeelement/codes/tyhja"))
+            .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON))
+
+        assertEquals(emptyList(), service.getKoodiviitteet("tyhja"))
+        // Toinen kutsu samalla avaimella ei mene palveluun, koska tyhja lista tallennetaan.
+        assertEquals(emptyList(), service.getKoodiviitteet("tyhja"))
+        mockServer.verify()
+    }
+
+    @Test
+    fun `204 No Content palauttaa nullin ja seuraava kutsu menee uudelleen palveluun`() {
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/puuttuu"))
+            .andRespond(withStatus(HttpStatus.NO_CONTENT))
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/puuttuu"))
+            .andRespond(withSuccess(KUNTA_PAYLOAD, MediaType.APPLICATION_JSON))
+
+        assertNull(service.getKoodiviitteet("puuttuu"))
+
+        // null-tulosta ei tallenneta valimuistiin -> seuraava kutsu menee uudelleen palveluun.
+        val toinen = service.getKoodiviitteet("puuttuu")
+        assertEquals(listOf("091"), toinen?.map { it.koodiArvo })
+        mockServer.verify()
+    }
+
+    @Test
+    fun `404 levia ei nielaista vaan virhe nousee soittajaan asti`() {
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/ei-ole"))
+            .andRespond(withStatus(HttpStatus.NOT_FOUND))
+
+        assertFailsWith<HttpClientErrorException.NotFound> {
+            service.getKoodiviitteet("ei-ole")
+        }
+        mockServer.verify()
+    }
+
+    @Test
+    fun `palvelinvirheella poikkeus levia ja epaonnistunutta vastausta ei tallenneta valimuistiin`() {
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/rikki"))
+            .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR))
+        mockServer
+            .expect(requestTo("$baseUrl/codeelement/codes/rikki"))
+            .andRespond(withSuccess(KUNTA_PAYLOAD, MediaType.APPLICATION_JSON))
+
+        assertFailsWith<HttpServerErrorException.InternalServerError> {
+            service.getKoodiviitteet("rikki")
+        }
+
+        // Seuraavan kutsun pitaa silti kayttaa palvelua.
+        assertEquals(listOf("091"), service.getKoodiviitteet("rikki")?.map { it.koodiArvo })
+        mockServer.verify()
+    }
+
+    companion object {
+        private val MAAT_JA_VALTIOT_PAYLOAD =
+            """
+            [
+              {
+                "koodiUri": "maatjavaltiot1_fin",
+                "koodiArvo": "FIN",
+                "versio": 2,
+                "metadata": [
+                  {"nimi": "Suomi", "kieli": "FI"},
+                  {"nimi": "Finland", "kieli": "SV"},
+                  {"nimi": "Finland", "kieli": "EN"}
+                ]
+              },
+              {
+                "koodiUri": "maatjavaltiot1_est",
+                "koodiArvo": "EST",
+                "versio": 2,
+                "metadata": [
+                  {"nimi": "Viro", "kieli": "FI"}
+                ]
+              }
+            ]
+            """.trimIndent()
+
+        private val KUNTA_PAYLOAD =
+            """
+            [
+              {
+                "koodiUri": "kunta_091",
+                "koodiArvo": "091",
+                "versio": 2,
+                "metadata": [
+                  {"nimi": "Helsinki", "kieli": "FI"}
+                ]
+              }
+            ]
+            """.trimIndent()
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/koodisto/KoodistopalveluKoodiviiteTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koodisto/KoodistopalveluKoodiviiteTest.kt
@@ -1,0 +1,47 @@
+package fi.oph.kitu.koodisto
+
+import fi.oph.kitu.i18n.LocalizedString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KoodistopalveluKoodiviiteTest {
+    @Test
+    fun `toLocalizedString kokoaa kolme kielta yhteen objektiin`() {
+        val metadata =
+            listOf(
+                KoodistopalveluKoodiviiteMetadata("Suomi", KoodistopalveluLanguage.FI),
+                KoodistopalveluKoodiviiteMetadata("Finland", KoodistopalveluLanguage.SV),
+                KoodistopalveluKoodiviiteMetadata("Finland", KoodistopalveluLanguage.EN),
+            )
+
+        assertEquals(
+            LocalizedString(fi = "Suomi", sv = "Finland", en = "Finland"),
+            metadata.toLocalizedString(),
+        )
+    }
+
+    @Test
+    fun `toLocalizedString jattaa puuttuvat kielet nulleiksi`() {
+        val metadata = listOf(KoodistopalveluKoodiviiteMetadata("Suomi", KoodistopalveluLanguage.FI))
+        val result = metadata.toLocalizedString()
+        assertEquals("Suomi", result.fi)
+        assertNull(result.sv)
+        assertNull(result.en)
+    }
+
+    @Test
+    fun `toLocalizedString tyhjasta listasta palauttaa pelkkia nulleja`() {
+        assertEquals(LocalizedString(), emptyList<KoodistopalveluKoodiviiteMetadata>().toLocalizedString())
+    }
+
+    @Test
+    fun `toLocalizedString jattaa viimeisen arvon kielikohtaisesti voimaan`() {
+        val metadata =
+            listOf(
+                KoodistopalveluKoodiviiteMetadata("Ensimmäinen", KoodistopalveluLanguage.FI),
+                KoodistopalveluKoodiviiteMetadata("Toinen", KoodistopalveluLanguage.FI),
+            )
+        assertEquals("Toinen", metadata.toLocalizedString().fi)
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/koodisto/KoskiKoodiviiteTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koodisto/KoskiKoodiviiteTest.kt
@@ -1,0 +1,46 @@
+package fi.oph.kitu.koodisto
+
+import fi.oph.kitu.util.defaultObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KoskiKoodiviiteTest {
+    @Test
+    fun `from kopioi koodiarvon ja URIn lahteesta`() {
+        val koski = KoskiKoodiviite.from(Koodisto.Tutkintokieli.FIN)
+        assertEquals("FI", koski.koodiarvo)
+        assertEquals("kieli", koski.koodistoUri)
+    }
+
+    @Test
+    fun `Koodiviite-rajapinnan toKoski tuottaa saman tuloksen kuin from`() {
+        val viite = Koodisto.YkiArvosana.KT3
+        assertEquals(KoskiKoodiviite.from(viite), viite.toKoski())
+    }
+
+    @Test
+    fun `KoskiKoodiviiteSerializer kirjoittaa Koodiviitteen objektina jossa koodiarvo ja koodistoUri`() {
+        val mapper =
+            JsonMapper
+                .builder()
+                .addModule(KoskiKoodiviite.Companion.KoskiKoodiviiteModule())
+                .build()
+
+        val node = mapper.readTree(mapper.writeValueAsString(Koodisto.YkiTutkintotaso.YT as Koodisto.Koodiviite))
+
+        assertEquals("yt", node["koodiarvo"].asString())
+        assertEquals("ykitutkintotaso", node["koodistoUri"].asString())
+    }
+
+    @Test
+    fun `KoskiKoodiviite serialisoituu defaultObjectMapperilla ilman erityismodulia`() {
+        val node =
+            defaultObjectMapper.readTree(
+                defaultObjectMapper.writeValueAsString(KoskiKoodiviite("FI", "kieli")),
+            )
+
+        assertEquals("FI", node["koodiarvo"].asString())
+        assertEquals("kieli", node["koodistoUri"].asString())
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/organisaatiot/KoodiviiteUriTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/organisaatiot/KoodiviiteUriTest.kt
@@ -1,0 +1,41 @@
+package fi.oph.kitu.organisaatiot
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KoodiviiteUriTest {
+    @Test
+    fun `koodistoUri ja koodiarvo erotetaan alaviivasta`() {
+        val uri = KoodiviiteUri("kieli_FI")
+        assertEquals("kieli", uri.koodistoUri)
+        assertEquals("FI", uri.koodiarvo)
+        assertNull(uri.versio)
+    }
+
+    @Test
+    fun `numeerinen koodiarvo`() {
+        val uri = KoodiviiteUri("organisaatiotyyppi_02")
+        assertEquals("organisaatiotyyppi", uri.koodistoUri)
+        assertEquals("02", uri.koodiarvo)
+    }
+
+    @Test
+    fun `versio luetaan ristikon jalkeen`() {
+        val uri = KoodiviiteUri("organisaatiotyyppi_02#1")
+        assertEquals("organisaatiotyyppi", uri.koodistoUri)
+        assertEquals("02", uri.koodiarvo)
+        assertEquals(1, uri.versio)
+    }
+
+    @Test
+    fun `puuttuva versio palauttaa nullin`() {
+        val uri = KoodiviiteUri("kieli_FI")
+        assertNull(uri.versio)
+    }
+
+    @Test
+    fun `viite sailyy data classin tasa-arvossa`() {
+        assertEquals(KoodiviiteUri("kieli_FI"), KoodiviiteUri("kieli_FI"))
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiohierarkiaTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiohierarkiaTest.kt
@@ -1,0 +1,113 @@
+package fi.oph.kitu.organisaatiot
+
+import fi.oph.kitu.i18n.LocalizedString
+import fi.oph.kitu.oid.Oid
+import fi.oph.kitu.util.result.getOrThrow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OrganisaatiohierarkiaTest {
+    @Test
+    fun `lehti palauttaa pelkan oman nimensa`() {
+        val leaf = node(oid = "1.2.246.562.10.1", nimi = LocalizedString(fi = "Lehti"))
+        assertEquals(listOf(leaf.oid to LocalizedString(fi = "Lehti")), leaf.getNames())
+    }
+
+    @Test
+    fun `getNames litistaa nestatuyt lapset rekursiivisesti`() {
+        val tree =
+            node(
+                oid = "1.2.246.562.10.1",
+                nimi = LocalizedString(fi = "Juuri"),
+                children =
+                    listOf(
+                        node(
+                            oid = "1.2.246.562.10.2",
+                            nimi = LocalizedString(fi = "Lapsi A"),
+                            children =
+                                listOf(
+                                    node(
+                                        oid = "1.2.246.562.10.3",
+                                        nimi = LocalizedString(fi = "Lapsi A1"),
+                                    ),
+                                ),
+                        ),
+                        node(
+                            oid = "1.2.246.562.10.4",
+                            nimi = LocalizedString(fi = "Lapsi B"),
+                        ),
+                    ),
+            )
+
+        val names = tree.getNames()
+
+        assertEquals(
+            listOf(
+                oid("1.2.246.562.10.1") to LocalizedString(fi = "Juuri"),
+                oid("1.2.246.562.10.2") to LocalizedString(fi = "Lapsi A"),
+                oid("1.2.246.562.10.3") to LocalizedString(fi = "Lapsi A1"),
+                oid("1.2.246.562.10.4") to LocalizedString(fi = "Lapsi B"),
+            ),
+            names.map { (o, nimi) -> o to nimi },
+        )
+    }
+
+    @Test
+    fun `GetOrganisaatiohierarkiaResponse getOrganisaatiot kokoaa nimet kartaksi`() {
+        val response =
+            GetOrganisaatiohierarkiaResponse(
+                numHits = 2,
+                organisaatiot =
+                    listOf(
+                        node(
+                            oid = "1.2.246.562.10.1",
+                            nimi = LocalizedString(fi = "Yliopisto"),
+                            children =
+                                listOf(
+                                    node(
+                                        oid = "1.2.246.562.10.2",
+                                        nimi = LocalizedString(fi = "Tiedekunta"),
+                                    ),
+                                ),
+                        ),
+                        node(
+                            oid = "1.2.246.562.10.3",
+                            nimi = LocalizedString(fi = "Yliopisto 2"),
+                        ),
+                    ),
+            )
+
+        val organisaatiot = response.getOrganisaatiot()
+
+        assertEquals(3, organisaatiot.nimet.size)
+        assertEquals(LocalizedString(fi = "Yliopisto"), organisaatiot.nimet[oid("1.2.246.562.10.1")])
+        assertEquals(LocalizedString(fi = "Tiedekunta"), organisaatiot.nimet[oid("1.2.246.562.10.2")])
+        assertEquals(LocalizedString(fi = "Yliopisto 2"), organisaatiot.nimet[oid("1.2.246.562.10.3")])
+    }
+
+    private fun oid(value: String): Oid = Oid.parse(value).getOrThrow()
+
+    private fun node(
+        oid: String,
+        nimi: LocalizedString,
+        children: List<Organisaatiohierarkia> = emptyList(),
+    ): Organisaatiohierarkia =
+        Organisaatiohierarkia(
+            aliOrganisaatioMaara = children.size,
+            alkuPvm = 0L,
+            children = children,
+            kieletUris = emptyList(),
+            kotipaikkaUri = "",
+            lyhytNimi = nimi,
+            match = false,
+            nimi = nimi,
+            oid = oid(oid),
+            organisaatiotyypit = emptyList(),
+            parentOid = null,
+            parentOidPath = null,
+            status = "AKTIIVINEN",
+            toimipistekoodi = null,
+            tyypit = emptyList(),
+            yTunnus = null,
+        )
+}

--- a/server/src/test/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiopalveluClientTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/organisaatiot/OrganisaatiopalveluClientTest.kt
@@ -1,0 +1,199 @@
+package fi.oph.kitu.organisaatiot
+
+import arrow.core.Either
+import fi.oph.kitu.restclient.withLenientStringConverter
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import org.springframework.http.HttpMethod as SpringHttpMethod
+
+class OrganisaatiopalveluClientTest {
+    private val serviceUrl = "http://organisaatio.test"
+
+    private lateinit var builder: RestClient.Builder
+    private lateinit var mockServer: MockRestServiceServer
+    private lateinit var client: OrganisaatiopalveluClient
+
+    @BeforeTest
+    fun setup() {
+        builder = RestClient.builder().withLenientStringConverter()
+        mockServer = MockRestServiceServer.bindTo(builder).build()
+        client = OrganisaatiopalveluClient(builder.build(), serviceUrl)
+    }
+
+    @Test
+    fun `2xx ja oikein muotoiltu JSON palauttaa Right-haarana parsittu vastaus`() {
+        mockServer
+            .expect(requestTo("$serviceUrl/api/hierarkia/hae?aktiiviset=true&suunnitellut=false&lakkautetut=false"))
+            .andExpect(method(SpringHttpMethod.GET))
+            .andExpect(queryParam("aktiiviset", "true"))
+            .andRespond(withSuccess(HIERARKIA_PAYLOAD, MediaType.APPLICATION_JSON))
+
+        val result =
+            client.get(
+                endpoint = "api/hierarkia/hae",
+                query =
+                    mapOf(
+                        "aktiiviset" to true,
+                        "suunnitellut" to false,
+                        "lakkautetut" to false,
+                    ),
+                responseType = GetOrganisaatiohierarkiaResponse::class.java,
+            )
+
+        val value = assertIs<Either.Right<GetOrganisaatiohierarkiaResponse>>(result).value
+        assertEquals(1, value.numHits)
+        assertEquals(1, value.organisaatiot.size)
+        assertEquals(
+            "1.2.246.562.10.1",
+            value.organisaatiot
+                .first()
+                .oid
+                .toString(),
+        )
+        mockServer.verify()
+    }
+
+    @Test
+    fun `404 palauttaa NotFoundException-haaran`() {
+        mockServer
+            .expect(requestTo("$serviceUrl/api/1.2.246.562.10.999"))
+            .andRespond(withStatus(HttpStatus.NOT_FOUND))
+
+        val result =
+            client.get("api/1.2.246.562.10.999", responseType = GetOrganisaatioResponse::class.java)
+
+        val left = assertIs<Either.Left<OrganisaatiopalveluException>>(result).value
+        assertIs<OrganisaatiopalveluException.NotFoundException>(left)
+        mockServer.verify()
+    }
+
+    @Test
+    fun `muu 4xx-virhe palauttaa BadRequest-haaran`() {
+        mockServer
+            .expect(requestTo("$serviceUrl/api/x"))
+            .andRespond(withStatus(HttpStatus.BAD_REQUEST).body("validation failed"))
+
+        val result = client.get("api/x", responseType = GetOrganisaatioResponse::class.java)
+
+        val left = assertIs<Either.Left<OrganisaatiopalveluException>>(result).value
+        val badRequest = assertIs<OrganisaatiopalveluException.BadRequest>(left)
+        assertEquals(HttpStatus.BAD_REQUEST.value(), badRequest.response.statusCode.value())
+        mockServer.verify()
+    }
+
+    @Test
+    fun `5xx-virhe palauttaa UnexpectedError-haaran`() {
+        mockServer
+            .expect(requestTo("$serviceUrl/api/x"))
+            .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR))
+
+        val result = client.get("api/x", responseType = GetOrganisaatioResponse::class.java)
+
+        val left = assertIs<Either.Left<OrganisaatiopalveluException>>(result).value
+        assertIs<OrganisaatiopalveluException.UnexpectedError>(left)
+        mockServer.verify()
+    }
+
+    @Test
+    fun `2xx mutta vahingoittunut JSON palauttaa MalformedResponse-haaran`() {
+        mockServer
+            .expect(requestTo("$serviceUrl/api/hierarkia/hae"))
+            .andRespond(withSuccess("not json at all", MediaType.APPLICATION_JSON))
+
+        val result =
+            client.get(
+                endpoint = "api/hierarkia/hae",
+                responseType = GetOrganisaatiohierarkiaResponse::class.java,
+            )
+
+        val left = assertIs<Either.Left<OrganisaatiopalveluException>>(result).value
+        assertIs<OrganisaatiopalveluException.MalformedResponse>(left)
+        mockServer.verify()
+    }
+
+    @Test
+    fun `2xx ja OrganisaatiopalveluError-runko palauttaa BadResponse-haaran`() {
+        mockServer
+            .expect(requestTo("$serviceUrl/api/hierarkia/hae"))
+            .andRespond(withSuccess(ORGANISAATIO_ERROR_PAYLOAD, MediaType.APPLICATION_JSON))
+
+        val result =
+            client.get(
+                endpoint = "api/hierarkia/hae",
+                responseType = GetOrganisaatiohierarkiaResponse::class.java,
+            )
+
+        val left = assertIs<Either.Left<OrganisaatiopalveluException>>(result).value
+        val badResponse = assertIs<OrganisaatiopalveluException.BadResponse>(left)
+        assertEquals(500, badResponse.organisaatiopalveluError?.status)
+        assertEquals("Internal Server Error", badResponse.organisaatiopalveluError?.error)
+        mockServer.verify()
+    }
+
+    @Test
+    fun `query-parametrit liitetaan URIin`() {
+        mockServer
+            .expect(requestTo("$serviceUrl/api/hierarkia/hae?aktiiviset=true&lakkautetut=true"))
+            .andRespond(withSuccess(HIERARKIA_PAYLOAD, MediaType.APPLICATION_JSON))
+
+        val result =
+            client.get(
+                endpoint = "api/hierarkia/hae",
+                query = mapOf("aktiiviset" to true, "lakkautetut" to true),
+                responseType = GetOrganisaatiohierarkiaResponse::class.java,
+            )
+
+        assertIs<Either.Right<GetOrganisaatiohierarkiaResponse>>(result)
+        mockServer.verify()
+    }
+
+    companion object {
+        private val HIERARKIA_PAYLOAD =
+            """
+            {
+              "numHits": 1,
+              "organisaatiot": [
+                {
+                  "aliOrganisaatioMaara": 0,
+                  "alkuPvm": 0,
+                  "children": [],
+                  "kieletUris": [],
+                  "kotipaikkaUri": "kunta_091",
+                  "lyhytNimi": {"fi": "Yliopisto"},
+                  "match": false,
+                  "nimi": {"fi": "Yliopisto"},
+                  "oid": "1.2.246.562.10.1",
+                  "organisaatiotyypit": [],
+                  "parentOid": null,
+                  "parentOidPath": null,
+                  "status": "AKTIIVINEN",
+                  "toimipistekoodi": null,
+                  "tyypit": [],
+                  "yTunnus": null
+                }
+              ]
+            }
+            """.trimIndent()
+
+        private val ORGANISAATIO_ERROR_PAYLOAD =
+            """
+            {
+              "timestamp": "2026-01-01T12:00:00.000+00:00",
+              "status": 500,
+              "error": "Internal Server Error",
+              "path": "/organisaatio-service/api/hierarkia/hae"
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION

Koodisto-paketti sai aiemmin nollatestit; nyt katetaan KoodistoServiceImpl
(välimuisti, virhepolut), Koodisto.kt:n enumien fromName/of-companion-
metodit, KoskiKoodiviite-serialisointi ja KoodistopalveluKoodiviite-
helperit. Organisaatiot-puolella OrganisaatiopalveluClient saa täyden
statuskoodimatriisin (200, 404, 4xx, 5xx, hajonnut JSON, virherunko) ja
KoodiviiteUri sekä Organisaatiohierarkia.getNames saavat omat testit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
