### PR TITLE
OPHKOTO-149: Korjaa maakoodin case automaattisesti

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/tiedontuontischema/HenkilosuoritusValidation.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/tiedontuontischema/HenkilosuoritusValidation.kt
@@ -1,7 +1,11 @@
 package fi.oph.kitu.tiedontuontischema
 
+import arrow.core.NonEmptyList
+import arrow.core.raise.Raise
 import arrow.core.raise.accumulate
 import arrow.core.raise.ensure
+import fi.oph.kitu.i18n.LocalizationService
+import fi.oph.kitu.koodisto.KoodistoService
 import fi.oph.kitu.oppijanumero.OppijanumeroValidation
 import fi.oph.kitu.util.validation.Validation
 import fi.oph.kitu.util.validation.Validation.ValidationError
@@ -11,6 +15,7 @@ import org.springframework.stereotype.Service
 @Service
 class HenkilosuoritusValidation(
     val onr: OppijanumeroValidation,
+    val koodistot: KoodistoService,
 ) : Validation<Henkilosuoritus<*>> {
     override fun ValidationRaise.validateBeforeEnrichment(value: Henkilosuoritus<*>) {
         accumulate {
@@ -39,6 +44,36 @@ class HenkilosuoritusValidation(
                 }
             }
             accumulating { with(onr) { validateOppijanumero(value.henkilo.oid, listOf("henkilo", "oid")) } }
+        }
+    }
+
+    override fun enrich(value: Henkilosuoritus<*>): Henkilosuoritus<*> =
+        value.copy(henkilo = value.henkilo.copy(maa = value.henkilo.maa?.uppercase()))
+
+    override fun ValidationRaise.validateAfterEnrichment(value: Henkilosuoritus<*>) {
+        accumulate {
+            accumulating {
+                validateMaa(value)
+            }
+        }
+    }
+
+    private fun ValidationRaise.validateMaa(s: Henkilosuoritus<*>) {
+        if (s.henkilo.maa == null) return
+        val maa =
+            koodistot
+                .getKoodiviitteet("maatjavaltiot1")
+                ?.find { it.koodiArvo.equals(s.henkilo.maa, ignoreCase = true) }
+
+        ensure(maa != null) {
+            NonEmptyList.of(
+                listOf(
+                    ValidationError(
+                        listOf("henkilo", "maa"),
+                        "Virheellinen maakoodi",
+                    ),
+                ),
+            )
         }
     }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/tiedontuontischema/YkiSuoritusValidation.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/tiedontuontischema/YkiSuoritusValidation.kt
@@ -4,12 +4,9 @@ import arrow.core.raise.Raise
 import arrow.core.raise.RaiseAccumulate
 import arrow.core.raise.accumulate
 import arrow.core.raise.ensure
-import fi.oph.kitu.i18n.LocalizationService
 import fi.oph.kitu.i18n.finnishDate
 import fi.oph.kitu.koodisto.Koodisto
 import fi.oph.kitu.organisaatiot.OrganisaatioService
-import fi.oph.kitu.organisaatiot.OrganisaatiopalveluException
-import fi.oph.kitu.util.intersects
 import fi.oph.kitu.util.validation.Validation
 import fi.oph.kitu.util.validation.ValidationRaise
 import fi.oph.kitu.yki.Arviointitila
@@ -21,7 +18,6 @@ import java.time.LocalDate
 @Service
 class YkiSuoritusValidation(
     val organisaatiot: OrganisaatioService,
-    val localizationService: LocalizationService,
     @param:Value("\${kitu.validaatiot.yki.hetunSiirronRajapaiva}")
     val hetunSiirronRajapaiva: LocalDate,
     @param:Value("\${kitu.validaatiot.yki.todistuskielenSiirronRajapaiva}")
@@ -34,7 +30,6 @@ class YkiSuoritusValidation(
             accumulating { validateTarkistusarviointi(value) }
             accumulating { validateKielikoodi(value) }
             accumulating { validateTodistuskieli(value) }
-            accumulating { validateCountryCode(value) }
         }
     }
 
@@ -156,22 +151,6 @@ class YkiSuoritusValidation(
                 "Käytöstä poistuneita kielikoodeja (${Tutkintokieli.Companion.legacyEntries.joinToString(
                     ", ",
                 )}) ei voi käyttää",
-            )
-        }
-    }
-
-    private fun Raise<Validation.ValidationError>.validateCountryCode(s: YkiHenkilosuoritus) {
-        if (s.henkilo.maa == null) return
-        val koodisto =
-            localizationService
-                .translationBuilder()
-                .koodistot("maatjavaltiot1")
-                .build()
-        val maatJaValtiot = koodisto.koodistot["maatjavaltiot1"] ?: return
-        ensure(maatJaValtiot[s.henkilo.maa] != null) {
-            Validation.ValidationError(
-                listOf("henkilo", "maa"),
-                "Virheellinen maakoodi",
             )
         }
     }

--- a/server/src/test/kotlin/fi/oph/kitu/util/validation/ValidationServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/util/validation/ValidationServiceTest.kt
@@ -262,4 +262,28 @@ class ValidationServiceTest(
         val result = validation.validateAndEnrich(suoritus)
         assertEquals(suoritus.right(), result)
     }
+
+    @Test
+    fun `YKI-suorituksen maakoodi muunnetaan automaattisesti isoiksi kirjaimiksi`() {
+        val suoritus =
+            validiYkiSuoritus.copy(
+                henkilo =
+                    validiYkiSuoritus.henkilo.copy(
+                        hetu = null,
+                        maa = "fin",
+                    ),
+                suoritus =
+                    validiYkiSuoritus.suoritus.copy(
+                        tutkintopaiva = LocalDate.of(2026, 4, 1),
+                        arviointipaiva = LocalDate.of(2026, 4, 2),
+                        todistuskieli = Todistuskieli.FIN,
+                    ),
+            )
+
+        val result = validation.validateAndEnrich(suoritus)
+        assertEquals(
+            suoritus.copy(henkilo = suoritus.henkilo.copy(maa = "FIN")).right(),
+            result,
+        )
+    }
 }


### PR DESCRIPTION

Siirrä maakoodin validointi YkiSuoritusValidationista
HenkilosuoritusValidationiin, ja muunna maakoodi enrich-vaiheessa
isoiksi kirjaimiksi, jotta esim. "fin" tallentuu muodossa "FIN".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
