### PR TITLE
OPHKOTO-152: Korjaa renovate conf

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,8 @@
 {
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "lockFileMaintenance": { "enabled": true },
+  "minimumReleaseAge": "3 days",
   "packageRules": [
-    {
-      "minimumReleaseAge": "3 days"
-    },
     {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true


### PR DESCRIPTION
Nosta minimumReleaseAge ylätasolle, koska packageRules-säännöillä
täytyy olla vähintään yksi match*- tai exclude*-valitsin.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
