### PR TITLE
OPHKOTO-152: Korjaus CSV-renderöintiin

### DIFF
--- a/e2e/tests/vkt/vkt-suoritukset.spec.ts
+++ b/e2e/tests/vkt/vkt-suoritukset.spec.ts
@@ -17,6 +17,9 @@ import VktSuorituksetPage from "../../models/vkt/VktSuorituksetPage"
 
 const fs = node_fs.promises
 
+const stripExcelCsvPrelude = (csv: string): string =>
+  csv.replace(/^\uFEFF/, "").replace(/^sep=.\r?\n/, "")
+
 describe("Valtionkielitutkinnon suoritukset page", () => {
   beforeEach(async ({ db, vktSuoritus, config }) => {
     await db.withEmptyDatabase()
@@ -547,7 +550,7 @@ describe("Valtionkielitutkinnon suoritukset csv download", () => {
     ])
     const path = await download.path()
     expect(path).not.toBeNull()
-    return fs.readFile(path!, "utf8")
+    return stripExcelCsvPrelude(await fs.readFile(path!, "utf8"))
   }
 
   function parseCsv(csv: string): Record<string, string>[] {
@@ -630,7 +633,7 @@ describe("Valtionkielitutkinnon suoritukset csv download filtering", () => {
     ])
     const path = await download.path()
     expect(path).not.toBeNull()
-    return fs.readFile(path!, "utf8")
+    return stripExcelCsvPrelude(await fs.readFile(path!, "utf8"))
   }
 
   const csvRowCount = (csv: string) =>

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/ExcelCsvPrelude.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/ExcelCsvPrelude.kt
@@ -1,0 +1,15 @@
+package fi.oph.kitu.csvparsing
+
+import java.io.OutputStream
+
+private val UTF_8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+
+// Excel on European locales (mm. fi-FI) defaults the field delimiter to ';' and otherwise
+// collapses every row into a single cell when opening a comma-separated CSV. The `sep=`
+// directive overrides the locale default for Excel regardless of OS settings, and the
+// UTF-8 BOM makes Excel parse the bytes as UTF-8 so Finnish characters render correctly.
+// Numbers, LibreOffice, and other modern spreadsheet tools recognize and skip the prelude.
+fun OutputStream.writeExcelCsvPrelude(separator: Char = ',') {
+    write(UTF_8_BOM)
+    write("sep=$separator\r\n".toByteArray())
+}

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiApiController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiApiController.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.kotoutumiskoulutus
 
+import fi.oph.kitu.csvparsing.writeExcelCsvPrelude
 import fi.oph.kitu.i18n.isoDate
 import fi.oph.kitu.kotoutumiskoulutus.suoritukset.KielitestiSuorituksetParams
 import fi.oph.kitu.kotoutumiskoulutus.suoritukset.KielitestiSuoritusColumn
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.time.LocalDate
 
 @RestController
@@ -37,18 +39,16 @@ class KielitestiApiController(
         )
 
     @GetMapping("/suoritukset/virheet", produces = ["text/csv"])
-    fun getErrorsAsCsv(): ResponseEntity<Resource> =
-        ResponseEntity
+    fun getErrorsAsCsv(): ResponseEntity<Resource> {
+        val body =
+            ByteArrayOutputStream().apply {
+                writeExcelCsvPrelude()
+                errorService.generateErrorsCsvStream().writeTo(this)
+            }
+        return ResponseEntity
             .ok()
             .contentType(MediaType.parseMediaType("text/csv"))
             .header("Content-Disposition", "attachment; filename=koto-virheet-${LocalDate.now().isoDate()}.csv")
-            .body(
-                InputStreamResource(
-                    ByteArrayInputStream(
-                        errorService
-                            .generateErrorsCsvStream()
-                            .toByteArray(),
-                    ),
-                ),
-            )
+            .body(InputStreamResource(ByteArrayInputStream(body.toByteArray())))
+    }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/error/KielitestiErrorService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/error/KielitestiErrorService.kt
@@ -2,7 +2,6 @@ package fi.oph.kitu.kotoutumiskoulutus.suoritukset.error
 
 import fi.oph.kitu.auditlogs.AuditLogger
 import fi.oph.kitu.csvparsing.CsvParser
-import fi.oph.kitu.csvparsing.writeExcelCsvPrelude
 import fi.oph.kitu.jdbc.SortDirection
 import fi.oph.kitu.jdbc.findAllSorted
 import fi.oph.kitu.observability.setAttribute
@@ -42,7 +41,6 @@ class KielitestiErrorService(
                 val errors = getErrors(orderBy, orderByDirection)
                 span.setAttribute("dataCount", errors.count())
                 val outputStream = ByteArrayOutputStream()
-                outputStream.writeExcelCsvPrelude()
                 csvParser
                     .withUseHeader(true)
                     .streamDataAsCsv(outputStream, errors)

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/error/KielitestiErrorService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/error/KielitestiErrorService.kt
@@ -2,6 +2,7 @@ package fi.oph.kitu.kotoutumiskoulutus.suoritukset.error
 
 import fi.oph.kitu.auditlogs.AuditLogger
 import fi.oph.kitu.csvparsing.CsvParser
+import fi.oph.kitu.csvparsing.writeExcelCsvPrelude
 import fi.oph.kitu.jdbc.SortDirection
 import fi.oph.kitu.jdbc.findAllSorted
 import fi.oph.kitu.observability.setAttribute
@@ -41,6 +42,7 @@ class KielitestiErrorService(
                 val errors = getErrors(orderBy, orderByDirection)
                 span.setAttribute("dataCount", errors.count())
                 val outputStream = ByteArrayOutputStream()
+                outputStream.writeExcelCsvPrelude()
                 csvParser
                     .withUseHeader(true)
                     .streamDataAsCsv(outputStream, errors)

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/CsvAttachmentResponse.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/CsvAttachmentResponse.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.webmvc
 
+import fi.oph.kitu.csvparsing.writeExcelCsvPrelude
 import fi.oph.kitu.html.table.ColumnTag
 import fi.oph.kitu.html.table.DisplayTableCsvRenderer
 import org.springframework.http.HttpHeaders
@@ -18,6 +19,7 @@ inline fun <reified C : Enum<C>, T> csvAttachmentResponse(
         .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=$filename")
         .body(
             StreamingResponseBody { output ->
+                output.writeExcelCsvPrelude()
                 DisplayTableCsvRenderer.renderCsv<C, _>(
                     output = output,
                     data = data,


### PR DESCRIPTION

Excel oletuksena olettaa kenttäerottimen olevan Windowsin alueasetusten
list separator (suomeksi puolipiste), joten pilkulla erotellut rivit
romahtavat yhteen sarakkeeseen. Lisätään latausten alkuun UTF-8 BOM ja
`sep=,` -direktiivi, joka pakottaa Excelin käyttämään pilkkua kielialueesta
riippumatta. Numbers, LibreOffice ja muut moderneista taulukkolaskenta-
ohjelmista ohittavat alkuosan läpinäkyvästi.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
