### PR TITLE
OPHKOTO-152: Korjaa virkailijaraami Untuvalla

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/config/AppProfile.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/config/AppProfile.kt
@@ -7,7 +7,7 @@ enum class AppProfile(
 ) {
     Prod("prod"),
     QA("qa"),
-    Untuva("dev"),
+    Untuva("untuva"),
     Test("test"),
     E2ETest("e2e"),
     Local("local"),


### PR DESCRIPTION

Untuva("dev") ei vastannut aktiivista Spring-profiilia "untuva", joten
isUntuva() ja isDeployedToOpintopolku() palauttivat untuvassa false.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
