### PR TITLE
OPHKOTO-152: Korjaa manuaalinen deploy

### DIFF
--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -76,7 +76,11 @@ jobs:
         if: inputs.action == 'diff'
         run: |
           npx cdk ${{ inputs.action }} --require-approval=never --exclusively '${{ inputs.environment }}/${{ inputs.stacks }}' --progress=events &> >(tee cdk.log)
-          cdk-notifier --log-file cdk.log --vcs github --repo kielitutkintorekisteri --owner ${{ github.repository_owner }} --pull-request-id ${{ github.event.number }} --template extendedWithResources --tag-id ${{ inputs.environment }} --suppress-hash-changes --suppress-hash-changes-regex '[+-].*?[a-fA-F0-9]{40}'
+          if [ -n "${{ github.event.number }}" ]; then
+            cdk-notifier --log-file cdk.log --vcs github --repo kielitutkintorekisteri --owner ${{ github.repository_owner }} --pull-request-id ${{ github.event.number }} --template extendedWithResources --tag-id ${{ inputs.environment }} --suppress-hash-changes --suppress-hash-changes-regex '[+-].*?[a-fA-F0-9]{40}'
+          else
+            echo "::notice::Skipping cdk-notifier PR comment — no PR associated with this run (workflow_dispatch). Diff output is in the job log above."
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: deploy


### PR DESCRIPTION

Manuaalisesti workflow_dispatchista käynnistetty diff-ajo kaatui,
koska cdk-notifier yritti kommentoida PR:ää, jota ei ollut olemassa
(github.event.number on tyhjä manuaalisille ajoille). Aja cdk diff
edelleen ja jätä output job-lokeihin, mutta skippaa kommentointi
kun PR-numeroa ei ole.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
