### PR TITLE
OPHKOTO-152: Korjaa CSV-vientien merkistötunnistus Excelissä

### DIFF
--- a/e2e/tests/kotoutumiskoulutus/kielitesti-suoritukset-error.spec.ts
+++ b/e2e/tests/kotoutumiskoulutus/kielitesti-suoritukset-error.spec.ts
@@ -245,9 +245,9 @@ describe('"Koto Suoritukset" -page', () => {
 
     const csvContent = await fs.readFile(path!, "utf8")
     let headers =
-      "virheenLuontiaika,suorittajanOid,hetu,nimi,etunimet,sukunimi,kutsumanimi,schoolOid,teacherEmail,viesti,lisatietoja,onrLisatietoja,virheellinenKentta,virheellinenArvo"
+      "virheenLuontiaika;suorittajanOid;hetu;nimi;etunimet;sukunimi;kutsumanimi;schoolOid;teacherEmail;viesti;lisatietoja;onrLisatietoja;virheellinenKentta;virheellinenArvo"
     let ranjaError =
-      '2024-11-22T10:49:49Z,"1.2.246.562.24.20281155246",010180-9026,"Ranja Testi Öhman-Testi","Ranja Testi",Öhman-Testi,Ranja,"1.2.246.562.10.14893989377",opettaja@testi.oph.fi,"Unexpectedly missing quiz grade ""puhuminen"" on course ""Integraatio testaus"" for user ""1""",,,puhuminen,"virheellinen arvosana'
+      '"2024-11-22T10:49:49Z";"1.2.246.562.24.20281155246";"010180-9026";"Ranja Testi Öhman-Testi";"Ranja Testi";"Öhman-Testi";Ranja;"1.2.246.562.10.14893989377";"opettaja@testi.oph.fi";"Unexpectedly missing quiz grade ""puhuminen"" on course ""Integraatio testaus"" for user ""1""";;;puhuminen;"virheellinen arvosana"'
     expect(csvContent).toContain(headers)
     expect(csvContent).toContain(ranjaError)
   })

--- a/e2e/tests/kotoutumiskoulutus/kielitesti-suoritukset.spec.ts
+++ b/e2e/tests/kotoutumiskoulutus/kielitesti-suoritukset.spec.ts
@@ -183,15 +183,15 @@ describe("Kotoutumiskoulutuksen kielitesti -page", () => {
 
     const csvContent = await fs.readFile(path!, "utf8")
     let headers =
-      "Oppijanumero,Sukunimi,Etunimet,Kutsumanimi,Sähköposti,Kurssin ID,Kurssin nimi,Testikieli,Oppilaitos OID,Oppilaitos,Opettajan sähköposti,Suoritusaika,Luetun ymmärtäminen,Kuullun ymmärtäminen,Puhe,Kirjoittaminen"
+      "Oppijanumero;Sukunimi;Etunimet;Kutsumanimi;Sähköposti;Kurssin ID;Kurssin nimi;Testikieli;Oppilaitos OID;Oppilaitos;Opettajan sähköposti;Suoritusaika;Luetun ymmärtäminen;Kuullun ymmärtäminen;Puhe;Kirjoittaminen"
     let anniina =
-      "1.2.246.562.24.24941612410,Torvinen-Testi,Anniina Testi,Anniina,devnull-12@oph.fi,33,Integrationstestning,SWE,1.2.3.4.5.7,1.2.3.4.5.7,opettaja@testi.oph.fi,2025-01-22T10:30:27Z,A1,B1,Yli B1,A2\n"
+      "1.2.246.562.24.24941612410;Torvinen-Testi;Anniina Testi;Anniina;devnull-12@oph.fi;33;Integrationstestning;SWE;1.2.3.4.5.7;1.2.3.4.5.7;opettaja@testi.oph.fi;2025-01-22T10:30:27Z;A1;B1;Yli B1;A2\n"
     let eino =
-      "1.2.246.562.24.67409348034,Välimaa-Testi,Eino Testi,Eino,devnull-10@oph.fi,32,Integraatio testaus,FIN,1.2.3.4.5.6,1.2.3.4.5.6,opettaja@testi.oph.fi,2024-11-22T10:49:49Z,A1,B1,Alle A1,B1\n"
+      "1.2.246.562.24.67409348034;Välimaa-Testi;Eino Testi;Eino;devnull-10@oph.fi;32;Integraatio testaus;FIN;1.2.3.4.5.6;1.2.3.4.5.6;opettaja@testi.oph.fi;2024-11-22T10:49:49Z;A1;B1;Alle A1;B1\n"
     let magdalena =
-      "1.2.246.562.24.33342764709,Sallinen-Testi,Magdalena Testi,Magdalena,devnull-14@oph.fi,33,Integrationstestning,SWE,1.2.3.4.5.7,1.2.3.4.5.7,opettaja@testi.oph.fi,2025-01-22T10:30:27Z,A1,B1,Yli B1,A2\n"
+      "1.2.246.562.24.33342764709;Sallinen-Testi;Magdalena Testi;Magdalena;devnull-14@oph.fi;33;Integrationstestning;SWE;1.2.3.4.5.7;1.2.3.4.5.7;opettaja@testi.oph.fi;2025-01-22T10:30:27Z;A1;B1;Yli B1;A2\n"
     let toni =
-      "1.2.246.562.24.16014275446,Laasonen-Testi,Toni Testi,Toni,devnull-6@oph.fi,32,Integraatio testaus,FIN,1.2.3.4.5.6,1.2.3.4.5.6,opettaja@testi.oph.fi,2024-11-24T11:36:43Z,A1,B1,Alle A1,B1\n"
+      "1.2.246.562.24.16014275446;Laasonen-Testi;Toni Testi;Toni;devnull-6@oph.fi;32;Integraatio testaus;FIN;1.2.3.4.5.6;1.2.3.4.5.6;opettaja@testi.oph.fi;2024-11-24T11:36:43Z;A1;B1;Alle A1;B1\n"
 
     expect(csvContent).toContain(headers)
     expect(csvContent).toContain(anniina)
@@ -282,15 +282,15 @@ describe("Kotoutumiskoulutuksen kielitesti -page", () => {
 
       const csvContent = await fs.readFile(path!, "utf8")
       let headers =
-        "Kurssin ID,Kurssin nimi,Testikieli,Oppilaitos OID,Oppilaitos,Suoritusaika,Luetun ymmärtäminen,Kuullun ymmärtäminen,Puhe,Kirjoittaminen"
+        "Kurssin ID;Kurssin nimi;Testikieli;Oppilaitos OID;Oppilaitos;Suoritusaika;Luetun ymmärtäminen;Kuullun ymmärtäminen;Puhe;Kirjoittaminen"
       let anniina =
-        "\n33,Integrationstestning,SWE,1.2.3.4.5.7,1.2.3.4.5.7,2025-01-22T10:30:27Z,A1,B1,Yli B1,A2\n"
+        "\n33;Integrationstestning;SWE;1.2.3.4.5.7;1.2.3.4.5.7;2025-01-22T10:30:27Z;A1;B1;Yli B1;A2\n"
       let eino =
-        "\n32,Integraatio testaus,FIN,1.2.3.4.5.6,1.2.3.4.5.6,2024-11-22T10:49:49Z,A1,B1,Alle A1,B1\n"
+        "\n32;Integraatio testaus;FIN;1.2.3.4.5.6;1.2.3.4.5.6;2024-11-22T10:49:49Z;A1;B1;Alle A1;B1\n"
       let magdalena =
-        "\n33,Integrationstestning,SWE,1.2.3.4.5.7,1.2.3.4.5.7,2025-01-22T10:30:27Z,A1,B1,Yli B1,A2\n"
+        "\n33;Integrationstestning;SWE;1.2.3.4.5.7;1.2.3.4.5.7;2025-01-22T10:30:27Z;A1;B1;Yli B1;A2\n"
       let toni =
-        "\n32,Integraatio testaus,FIN,1.2.3.4.5.6,1.2.3.4.5.6,2024-11-24T11:36:43Z,A1,B1,Alle A1,B1\n"
+        "\n32;Integraatio testaus;FIN;1.2.3.4.5.6;1.2.3.4.5.6;2024-11-24T11:36:43Z;A1;B1;Alle A1;B1\n"
 
       expect(csvContent).toContain(headers)
       expect(csvContent).toContain(anniina)

--- a/e2e/tests/vkt/vkt-suoritukset.spec.ts
+++ b/e2e/tests/vkt/vkt-suoritukset.spec.ts
@@ -17,8 +17,7 @@ import VktSuorituksetPage from "../../models/vkt/VktSuorituksetPage"
 
 const fs = node_fs.promises
 
-const stripExcelCsvPrelude = (csv: string): string =>
-  csv.replace(/^\uFEFF/, "").replace(/^sep=.\r?\n/, "")
+const stripExcelCsvPrelude = (csv: string): string => csv.replace(/^\uFEFF/, "")
 
 describe("Valtionkielitutkinnon suoritukset page", () => {
   beforeEach(async ({ db, vktSuoritus, config }) => {
@@ -557,9 +556,9 @@ describe("Valtionkielitutkinnon suoritukset csv download", () => {
     const [headerLine, ...rest] = csv
       .split("\n")
       .filter((line) => line.length > 0)
-    const headers = headerLine.split(",")
+    const headers = headerLine.split(";")
     return rest.map((line) => {
-      const cols = line.split(",")
+      const cols = line.split(";")
       return Object.fromEntries(headers.map((h, i) => [h, cols[i] ?? ""]))
     })
   }
@@ -714,7 +713,7 @@ describe("Valtionkielitutkinnon suoritukset csv download filtering", () => {
     const headerBefore = (await downloadCsv(page, vktSuorituksetPage)).split(
       "\n",
     )[0]
-    const columnsBefore = headerBefore.split(",").length
+    const columnsBefore = headerBefore.split(";").length
 
     const dialog = await vktSuorituksetPage.openFilterDialog()
     await dialog.hideHenkilotiedot(true)
@@ -723,7 +722,7 @@ describe("Valtionkielitutkinnon suoritukset csv download filtering", () => {
     const headerAfter = (await downloadCsv(page, vktSuorituksetPage)).split(
       "\n",
     )[0]
-    const columnsAfter = headerAfter.split(",").length
+    const columnsAfter = headerAfter.split(";").length
 
     expect(columnsAfter).toBeLessThan(columnsBefore)
   })

--- a/e2e/tests/yki/yki-suoritukset.spec.ts
+++ b/e2e/tests/yki/yki-suoritukset.spec.ts
@@ -123,7 +123,7 @@ describe('"YKI Suoritukset" -page', () => {
         "Todistuskieli",
         "Tila lähetetty",
         "Opiskeluoikeus-OID",
-      ].join(","),
+      ].join(";"),
     ) // Validate headers
   })
 
@@ -158,7 +158,7 @@ describe('"YKI Suoritukset" -page', () => {
         "Yleisarvosana",
         "Todistuskieli",
         "Tila lähetetty",
-      ].join(","),
+      ].join(";"),
     ) // Validate headers
   })
 

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/CsvParser.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.full.findAnnotation
 class CsvParser(
     final val tracer: Tracer,
 ) {
-    val columnSeparator: Char = ','
+    var columnSeparator: Char = ','
     val lineSeparator: String = "\n"
     var useHeader: Boolean = false
     val quoteChar: Char = '"'
@@ -28,6 +28,13 @@ class CsvParser(
     fun withUseHeader(value: Boolean): CsvParser =
         CsvParser(tracer).also {
             it.useHeader = value
+            it.columnSeparator = columnSeparator
+        }
+
+    fun withColumnSeparator(value: Char): CsvParser =
+        CsvParser(tracer).also {
+            it.useHeader = useHeader
+            it.columnSeparator = value
         }
 
     init {

--- a/server/src/main/kotlin/fi/oph/kitu/csvparsing/ExcelCsvPrelude.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/csvparsing/ExcelCsvPrelude.kt
@@ -4,12 +4,12 @@ import java.io.OutputStream
 
 private val UTF_8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
 
-// Excel on European locales (mm. fi-FI) defaults the field delimiter to ';' and otherwise
-// collapses every row into a single cell when opening a comma-separated CSV. The `sep=`
-// directive overrides the locale default for Excel regardless of OS settings, and the
-// UTF-8 BOM makes Excel parse the bytes as UTF-8 so Finnish characters render correctly.
-// Numbers, LibreOffice, and other modern spreadsheet tools recognize and skip the prelude.
-fun OutputStream.writeExcelCsvPrelude(separator: Char = ',') {
+// Excel detects UTF-8 reliably only when the file starts with a BOM and contains no `sep=`
+// directive; with `sep=` present, several Excel versions skip BOM-based charset detection and
+// fall back to the system ANSI codepage (Windows-1252 on most installs), mangling ä/ö/é/…
+// We therefore drop `sep=` and use `;` as the field separator everywhere — that matches the
+// list-separator default of fi-FI (and most other European) Excel installs, so columns split
+// correctly without the directive. (Trade-off: en-US Excel will collapse rows into one cell.)
+fun OutputStream.writeExcelCsvPrelude() {
     write(UTF_8_BOM)
-    write("sep=$separator\r\n".toByteArray())
 }

--- a/server/src/main/kotlin/fi/oph/kitu/html/table/DisplayTableEnum.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/html/table/DisplayTableEnum.kt
@@ -95,7 +95,7 @@ inline fun <reified T : Enum<T>> hasTag(
     }
 
 object DisplayTableCsvRenderer {
-    const val SEPARATOR = ","
+    const val SEPARATOR = ";"
 
     inline fun <reified E : Enum<E>, T> renderCsv(
         output: OutputStream,

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/error/KielitestiErrorService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/error/KielitestiErrorService.kt
@@ -43,6 +43,7 @@ class KielitestiErrorService(
                 val outputStream = ByteArrayOutputStream()
                 csvParser
                     .withUseHeader(true)
+                    .withColumnSeparator(';')
                     .streamDataAsCsv(outputStream, errors)
 
                 return@use outputStream

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiCsvTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/KielitestiCsvTest.kt
@@ -81,9 +81,9 @@ class KielitestiCsvTest(
         val actualCsv = kielitestiErrorService.generateErrorsCsvStream()
         val expectedCsv =
             """
-            virheenLuontiaika,suorittajanOid,hetu,nimi,etunimet,sukunimi,kutsumanimi,schoolOid,teacherEmail,viesti,lisatietoja,onrLisatietoja,virheellinenKentta,virheellinenArvo
-            2024-11-22T10:49:49Z,,010180-9026,"Ranja Testi Öhman-Testi",Ranja,"Testi Öhman-Testi",Ranja,"1.2.246.562.10.14893989377",testi@example.com,"Kirjoitusvirhe nimessä tai henkilötunnuksessa","{""request"": {""etunimet"": ""Ranja"", ""hetu"": ""010180-9026"", ""kutsumanimi"": ""Ranja"", ""sukunimi"": ""Testi Öhman-Testi""}}","etunimet: Ranja Testi, kutsumanimi: Ranja, sukunimi: Öhman-Testi",,
-            2024-11-22T10:49:49Z,"1.2.246.562.24.67409348034",010180-9026,"Eino Testi Välimaa-Testi","Eino Test",Välimaa-Testi,Eino,"1.2.246.562.10.14893989377",testi@example.com,"Unexpectedly missing quiz grade ""puhuminen"" on course ""Testaus"" for user ""1"".",,,puhuminen,"virheellinen arvosana"
+            virheenLuontiaika;suorittajanOid;hetu;nimi;etunimet;sukunimi;kutsumanimi;schoolOid;teacherEmail;viesti;lisatietoja;onrLisatietoja;virheellinenKentta;virheellinenArvo
+            "2024-11-22T10:49:49Z";;"010180-9026";"Ranja Testi Öhman-Testi";Ranja;"Testi Öhman-Testi";Ranja;"1.2.246.562.10.14893989377";"testi@example.com";"Kirjoitusvirhe nimessä tai henkilötunnuksessa";"{""request"": {""etunimet"": ""Ranja"", ""hetu"": ""010180-9026"", ""kutsumanimi"": ""Ranja"", ""sukunimi"": ""Testi Öhman-Testi""}}";"etunimet: Ranja Testi, kutsumanimi: Ranja, sukunimi: Öhman-Testi";;
+            "2024-11-22T10:49:49Z";"1.2.246.562.24.67409348034";"010180-9026";"Eino Testi Välimaa-Testi";"Eino Test";"Välimaa-Testi";Eino;"1.2.246.562.10.14893989377";"testi@example.com";"Unexpectedly missing quiz grade ""puhuminen"" on course ""Testaus"" for user ""1"".";;;puhuminen;"virheellinen arvosana"
 
             """.trimIndent()
 


### PR DESCRIPTION

Aiempi BOM + `sep=,` -preludi sai Excelin jakamaan sarakkeet oikein, mutta
useat Excelin versiot ohittavat BOM-pohjaisen UTF-8-tunnistuksen heti kun
`sep=` on läsnä ja palaavat järjestelmän ANSI-koodisivuun (yleisimmin
Windows-1252), jolloin ä/ö/é/… näkyvät rikki. Poistetaan `sep=` ja
vaihdetaan kenttäerottimeksi puolipiste, joka on fi-FI:n (ja useimpien
muiden eurooppalaisten lokaalien) Excelin oletuslistaerotin – sarakkeet
jakautuvat ilman direktiiviäkin ja BOM hoitaa merkistötunnistuksen.
Vastapaino: en-US-Excel tiivistää nyt rivit yhteen soluun.

Vaihto kattaa kolme reittiä:
- `DisplayTableCsvRenderer` (VKT/YKI/koto suoritus -vienti)
- `KielitestiErrorService` Jackson-pohjainen virhe-CSV (uusi
  `CsvParser.withColumnSeparator`, joka säilyttää YKI-tuontireitin
  oletuserottimen ennallaan)
- `writeExcelCsvPrelude` kirjoittaa nyt pelkän BOMin

Päivitetään e2e-testien odotetut erotinmerkit ja Jacksonin tiukemmasta
lainausmerkityksestä johtuva koto-virheiden CSV-rivilainaus.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
