### PR TITLE
OPHKOTO-132: Lisää CSV-lataus YKI-poikkeamanäkymään

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/Links.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/Links.kt
@@ -90,6 +90,8 @@ object Links {
         ): String = linkTo(methodOn(YkiViewController::class.java).hideKoskiVirheet(suoritusId, hidden)).toString()
 
         fun suorituksetCsv(): String = linkTo(methodOn(YkiApiController::class.java).getSuorituksetAsCsv()).toString()
+
+        fun poikkeamatCsv(): String = linkTo(methodOn(YkiApiController::class.java).getPoikkeamatAsCsv()).toString()
     }
 
     object Kielitesti {

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiApiController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiApiController.kt
@@ -12,6 +12,8 @@ import fi.oph.kitu.yki.arvioijat.YkiArvioija
 import fi.oph.kitu.yki.arvioijat.YkiArvioijaRepository
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusColumn
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusPoikkeamaColumn
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusPoikkeamaRepository
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusRepository
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.StatusCode
@@ -40,6 +42,7 @@ class YkiApiController(
     private val validationService: ValidationService,
     private val ykiArvioijaRepository: YkiArvioijaRepository,
     private val ykiSuoritusRepository: YkiSuoritusRepository,
+    private val ykiSuoritusPoikkeamaRepository: YkiSuoritusPoikkeamaRepository,
     private val ilmoittautumisjarjestelma: IlmoittautumisjarjestelmaService,
 ) {
     @GetMapping("/suoritukset", "/suoritus", produces = ["text/csv"])
@@ -50,6 +53,13 @@ class YkiApiController(
             filename = params.csvFileName(),
             data = service.allSuoritukset(params.versionHistory, params.toFilter()),
             excludeTags = params.excludeTags(),
+        )
+
+    @GetMapping("/poikkeamat", produces = ["text/csv"])
+    fun getPoikkeamatAsCsv(): ResponseEntity<StreamingResponseBody> =
+        csvAttachmentResponse<YkiSuoritusPoikkeamaColumn, _>(
+            filename = "yki-poikkeamat.csv",
+            data = ykiSuoritusPoikkeamaRepository.findAll(),
         )
 
     @PostMapping("/suoritus")

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaColumn.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaColumn.kt
@@ -1,0 +1,80 @@
+package fi.oph.kitu.yki.suoritukset
+
+import fi.oph.kitu.html.table.ColumnTag
+import fi.oph.kitu.html.table.ColumnTags
+import fi.oph.kitu.html.table.RenderableDisplayTableEnum
+import fi.oph.kitu.i18n.finnishDate
+import fi.oph.kitu.i18n.finnishDateTime
+import kotlinx.html.FlowContent
+
+enum class YkiSuoritusPoikkeamaColumn(
+    override val entityName: String,
+    override val uiHeaderValue: String,
+    override val urlParam: String,
+    override val getValue: (value: YkiSuoritusPoikkeama) -> String,
+    override val renderHtml: (FlowContent.(YkiSuoritusPoikkeama) -> Unit)? = null,
+) : RenderableDisplayTableEnum<YkiSuoritusPoikkeama> {
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    Tutkintopaiva(
+        entityName = "tutkintopaiva",
+        uiHeaderValue = "Tutkintopäivä",
+        urlParam = "tutkintopaiva",
+        getValue = { it.tutkintopaiva?.finnishDate().orEmpty() },
+    ),
+
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    Tutkintokieli(
+        entityName = "tutkintokieli",
+        uiHeaderValue = "Kieli",
+        urlParam = "tutkintokieli",
+        getValue = { it.tutkintokieli?.name.orEmpty() },
+    ),
+
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    Tutkintotaso(
+        entityName = "tutkintotaso",
+        uiHeaderValue = "Taso",
+        urlParam = "tutkintotaso",
+        getValue = { it.tutkintotaso?.name.orEmpty() },
+    ),
+
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    SolkiId(
+        entityName = "solki_id",
+        uiHeaderValue = "Solki-ID",
+        urlParam = "solkiid",
+        getValue = { it.solkiId.toString() },
+    ),
+
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    Kentta(
+        entityName = "kentta",
+        uiHeaderValue = "Kenttä",
+        urlParam = "kentta",
+        getValue = { it.kentta },
+    ),
+
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    ArvoKitussa(
+        entityName = "arvo_kitussa",
+        uiHeaderValue = "Arvo Kitussa",
+        urlParam = "arvokitussa",
+        getValue = { it.arvoKitussa },
+    ),
+
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    ArvoSolkissa(
+        entityName = "arvo_solkissa",
+        uiHeaderValue = "Arvo Solkissa",
+        urlParam = "arvosolkissa",
+        getValue = { it.arvoSolkissa },
+    ),
+
+    @ColumnTags(ColumnTag.CSV_EXPORT)
+    Havaittu(
+        entityName = "havaittu",
+        uiHeaderValue = "Havaittu",
+        urlParam = "havaittu",
+        getValue = { it.havaittu.finnishDateTime() },
+    ),
+}

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaPage.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaPage.kt
@@ -1,6 +1,7 @@
 package fi.oph.kitu.yki.suoritukset
 
 import fi.oph.kitu.html.Page
+import fi.oph.kitu.html.csvDownloadButton
 import fi.oph.kitu.html.javascript
 import fi.oph.kitu.html.testId
 import fi.oph.kitu.i18n.finnishDate
@@ -33,6 +34,8 @@ object YkiSuoritusPoikkeamaPage {
             if (poikkeamat.isEmpty()) {
                 p { +"Ei havaittuja poikkeamia." }
             } else {
+                p { csvDownloadButton(Links.Yki.poikkeamatCsv()) }
+
                 val kentat = poikkeamat.map { it.kentta }.distinct().sorted()
 
                 div(classes = "kentta-filters") {

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaPage.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaPage.kt
@@ -42,7 +42,7 @@ object YkiSuoritusPoikkeamaPage {
                     attributes["role"] = "group"
                     kentat.forEach { kentta ->
                         button(type = ButtonType.button, classes = "kentta-filter") {
-                            attributes["aria-pressed"] = "true"
+                            attributes["aria-pressed"] = "false"
                             attributes["data-kentta-filter"] = kentta
                             testId("kentta-filter-$kentta")
                             +kentta
@@ -99,8 +99,9 @@ object YkiSuoritusPoikkeamaPage {
                                 .filter(b => b.getAttribute('aria-pressed') === 'true')
                                 .map(b => b.dataset.kenttaFilter)
                         );
+                        const filtering = active.size > 0;
                         rows.forEach(r => {
-                            r.hidden = !active.has(r.dataset.kentta);
+                            r.hidden = filtering && !active.has(r.dataset.kentta);
                         });
                     }
                     buttons.forEach(b => b.addEventListener('click', () => {


### PR DESCRIPTION
Lisätään "Lataa tiedot CSV:nä" -linkki /yki/poikkeamat-näkymään ja
text/csv-endpoint /yki/api/poikkeamat. CSV sisältää kaikki rivit
repositoryn palauttamassa järjestyksessä (tutkintopäivä DESC, kieli
ASC, taso ASC) ja hyödyntää olemassa olevaa CsvAttachmentResponse-
koneistoa (UTF-8 BOM, semicolon-erotin).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
