### PR TITLE
OPHKOTO-152: Pyyhi arvioijan hetu tarvittaessa pois

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/arvioijat/YkiArvioijaRepository.kt
@@ -44,15 +44,20 @@ class CustomYkiArvioijaRepositoryImpl(
                     """
                     INSERT INTO yki_arvioija (
                         arvioija_oid,
+                        henkilotunnus,
                         sukunimi,
                         etunimet,
                         sahkopostiosoite,
                         katuosoite,
                         postinumero,
                         postitoimipaikka
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT (arvioija_oid) DO UPDATE
                     SET
+                        -- henkilotunnus päivitetään EXCLUDED-arvosta, jotta validoinnin
+                        -- pakottama null päätyy myös tietokantaan eikä jää vanhaa arvoa
+                        -- lojumaan päivityksissä.
+                        henkilotunnus = EXCLUDED.henkilotunnus,
                         sukunimi = EXCLUDED.sukunimi,
                         etunimet = EXCLUDED.etunimet,
                         sahkopostiosoite = EXCLUDED.sahkopostiosoite,
@@ -63,6 +68,7 @@ class CustomYkiArvioijaRepositoryImpl(
                     """.trimIndent(),
                     YkiArvioijaEntity.fromRow,
                     arvioija.arvioijaOid.toString(),
+                    arvioija.henkilotunnus,
                     arvioija.sukunimi,
                     arvioija.etunimet,
                     arvioija.sahkopostiosoite,

--- a/server/src/main/resources/db/migration/V100__clear_yki_arvioija_henkilotunnus.sql
+++ b/server/src/main/resources/db/migration/V100__clear_yki_arvioija_henkilotunnus.sql
@@ -1,0 +1,14 @@
+-- 1.1.2026 voimaan tulleen lainmuutoksen myötä yki-arvioijan henkilötunnusta
+-- ei enää saa säilyttää. Validointi ja upsert estävät uusien hetujen
+-- tallennuksen, mutta ennen lainmuutosta tietokantaan tallennetut hetut
+-- siivotaan tällä migraatiolla niiltä arvioijoilta, joiden arviointioikeus
+-- alkaa lainmuutoksen voimaantulopäivänä tai sen jälkeen.
+UPDATE yki_arvioija
+SET henkilotunnus = NULL
+WHERE henkilotunnus IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM yki_arviointioikeus
+      WHERE yki_arviointioikeus.arvioija_id = yki_arvioija.id
+        AND yki_arviointioikeus.kauden_alkupaiva >= DATE '2026-01-01'
+  );

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiArvioijaRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiArvioijaRepositoryTest.kt
@@ -68,7 +68,6 @@ class YkiArvioijaRepositoryTest(
         assertEquals(
             arvioija.copy(
                 arviointioikeudet = listOf(sweArviointioikeus, engArviointioikeus),
-                henkilotunnus = null,
             ),
             saved?.copy(
                 id = null,
@@ -169,9 +168,7 @@ class YkiArvioijaRepositoryTest(
         val saved = arvioijaRepository.findById(savedIds.first()).getOrNull()
         assertEquals(1, savedIds.count())
         assertEquals(
-            updatedArvioija.copy(
-                henkilotunnus = null,
-            ),
+            updatedArvioija,
             saved?.copy(
                 id = null,
                 arviointioikeudet =
@@ -182,5 +179,46 @@ class YkiArvioijaRepositoryTest(
         )
         val updatedArvioijat = arvioijaRepository.findAll()
         assertEquals(1, updatedArvioijat.count())
+    }
+
+    @Test
+    fun `Päivitys nollaa aiemmin tallennetun henkilötunnuksen, jos tulevassa datassa hetua ei ole`() {
+        val arviointioikeus =
+            YkiArviointioikeusEntity(
+                id = null,
+                arvioijaId = null,
+                kaudenAlkupaiva = LocalDate.of(2026, 3, 1),
+                kaudenPaattymispaiva = LocalDate.of(2027, 3, 1),
+                jatkorekisterointi = false,
+                tila = YkiArvioijaTila.AKTIIVINEN,
+                kieli = Tutkintokieli.SWE,
+                tasot = setOf(Tutkintotaso.YT),
+                ensimmainenRekisterointipaiva = LocalDate.of(2026, 3, 1),
+                rekisteriintuontiaika = null,
+            )
+
+        val arvioijaHetulla =
+            YkiArvioijaEntity(
+                id = null,
+                arvioijaOid = Oid.parse("1.2.246.562.24.20281155246").getOrThrow(),
+                henkilotunnus = "010180-9026",
+                sukunimi = "Öhman-Testi",
+                etunimet = "Ranja Testi",
+                sahkopostiosoite = "testi@testi.fi",
+                katuosoite = "Testikuja 5",
+                postinumero = "40100",
+                postitoimipaikka = "Testilä",
+                arviointioikeudet = listOf(arviointioikeus),
+            )
+
+        val firstId = arvioijaRepository.upsert(arvioijaHetulla)
+        assertEquals("010180-9026", arvioijaRepository.findById(firstId).getOrNull()?.henkilotunnus)
+
+        // Päivitys ilman hetua (vastaa lainmuutoksen jälkeen validoinnin läpäissyttä syötettä):
+        // tallennetun rivin henkilotunnus pitää nollautua, eikä se saa jäädä lojumaan.
+        arvioijaRepository.upsert(arvioijaHetulla.copy(henkilotunnus = null))
+
+        val saved = arvioijaRepository.findById(firstId).getOrNull()
+        assertEquals(null, saved?.henkilotunnus)
     }
 }


### PR DESCRIPTION

Aiempi upsert jätti henkilotunnus-sarakkeen koskemattomaksi sekä INSERT- että
UPDATE-haarassa, joten ennen 1.1.2026 lainmuutosta tallennetut hetut jäivät
päivityksissä lojumaan tietokantaan, vaikka validointi pakottaakin syötteen
hetun nulliksi lainmuutoksen jälkeen.

- Palauta henkilotunnus INSERT-sarakelistalle ja päivitä EXCLUDED-arvosta,
  jolloin validoinnin pakottama null kirjoittuu myös tietokantaan.
- V100-migraatio nollaa hetun niiltä olemassa olevilta arvioijilta, joilla on
  yksikin arviointioikeus, jonka kauden_alkupaiva on 1.1.2026 tai myöhemmin.
- Lisää regressiotesti, joka varmistaa että hetu nollautuu upsertilla.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
