### PR TITLE
OPHKOTO-152: Optimoi yki-suoritukset-näkymän performanssia

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/i18n/Time.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/i18n/Time.kt
@@ -9,13 +9,17 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-fun LocalDate.finnishDate(): String = format(DateTimeFormatter.ofPattern("d.M.yyyy"))
+private val finnishDateFormatter = DateTimeFormatter.ofPattern("d.M.yyyy")
+private val isoDateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+private val finnishDateTimeWithZoneFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ssX")
+private val finnishDateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss")
 
-fun LocalDate.isoDate(): String = format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+fun LocalDate.finnishDate(): String = format(finnishDateFormatter)
+
+fun LocalDate.isoDate(): String = format(isoDateFormatter)
 
 fun Instant.finnishDateTime(includeTimeZone: Boolean = true): String =
-    DateTimeFormatter
-        .ofPattern(if (includeTimeZone) "dd.MM.yyyy HH:mm:ssX" else "dd.MM.yyyy HH:mm:ss")
+    (if (includeTimeZone) finnishDateTimeWithZoneFormatter else finnishDateTimeFormatter)
         .format(this.atZone(ZoneId.systemDefault()))
 
 fun FlowContent.finnishDate(d: LocalDate) {

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/Links.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/Links.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.webmvc
 
+import fi.oph.kitu.config.ApplicationProperties
 import fi.oph.kitu.koodisto.Koodisto
 import fi.oph.kitu.kotoutumiskoulutus.KielitestiApiController
 import fi.oph.kitu.kotoutumiskoulutus.KielitestiViewController
@@ -64,7 +65,7 @@ object Links {
     object Yki {
         fun suoritukset(): String = linkTo(methodOn(YkiViewController::class.java).suorituksetGetView()).toString()
 
-        fun suoritus(id: Int): String = linkTo(methodOn(YkiViewController::class.java).suoritusView(id)).toString()
+        fun suoritus(id: Int): String = "${ApplicationProperties.kitu.appUrl}/yki/suoritukset/$id"
 
         fun arvioijat(): String = linkTo(methodOn(YkiViewController::class.java).arvioijatView()).toString()
 

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
@@ -206,16 +206,25 @@ class YkiSuoritusRepository(
         distinct: Boolean = true,
     ): Long {
         val sql =
-            buildSql(
-                withCtes("viimeisin_suoritus" to selectSuorituksetFull(viimeisin = distinct, filter.whereSql())),
-                "SELECT COUNT(*) FROM viimeisin_suoritus",
-            )
-
-        val params = filter.params()
+            if (filter.requiresSubTables()) {
+                buildSql(
+                    withCtes("viimeisin_suoritus" to selectSuorituksetFull(viimeisin = distinct, filter.whereSql())),
+                    "SELECT COUNT(*) FROM viimeisin_suoritus",
+                )
+            } else {
+                buildSql(
+                    if (distinct) {
+                        "SELECT COUNT(DISTINCT solki_id) FROM yki_suoritus"
+                    } else {
+                        "SELECT COUNT(*) FROM yki_suoritus"
+                    },
+                    filter.whereSql(),
+                )
+            }
 
         return jdbcNamedParameterTemplate.queryForObject(
             sql,
-            params,
+            filter.params(),
             Long::class.java,
         )
             ?: 0

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -3,6 +3,10 @@ spring.main.banner-mode=off
 
 server.servlet.context-path=/kielitutkinnot
 
+server.compression.enabled=true
+server.compression.mime-types=text/html,text/css,text/plain,application/javascript,application/json,text/csv
+server.compression.min-response-size=1024
+
 spring.session.jdbc.initialize-schema=never
 spring.threads.virtual.enabled=true
 

--- a/server/src/main/resources/db/migration/V101__yki_suoritus_list_indexes.sql
+++ b/server/src/main/resources/db/migration/V101__yki_suoritus_list_indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX "yki_suoritus_solki_id_last_modified_idx"
+    ON "yki_suoritus" ("solki_id", "last_modified" DESC, "id" DESC);
+
+CREATE INDEX "yki_suoritus_tutkintopaiva_idx"
+    ON "yki_suoritus" ("tutkintopaiva" DESC);

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
@@ -267,4 +267,19 @@ class YkiSuoritusRepositoryTest(
             )
         assertEquals(2L, countRanjaAll, "Assert failed for count all suoritukset with a search term")
     }
+
+    @Test
+    fun `count suoritukset with tutkintokieli filter matches find result size`() {
+        val fin = generateRandomYkiSuoritusEntity().copy(tutkintokieli = Tutkintokieli.FIN)
+        val swe = generateRandomYkiSuoritusEntity().copy(tutkintokieli = Tutkintokieli.SWE)
+        val fin2 = generateRandomYkiSuoritusEntity().copy(tutkintokieli = Tutkintokieli.FIN)
+        ykiSuoritusRepository.saveAllNewEntities(listOf(fin, swe, fin2))
+
+        val filter = YkiSuoritusFilter(tutkintokieli = Tutkintokieli.FIN)
+        val count = ykiSuoritusRepository.countSuoritukset(filter)
+        val found = ykiSuoritusRepository.find(filter).count().toLong()
+
+        assertEquals(found, count, "count ja find tuloksen koko poikkesivat alitauluhaarassa")
+        assertEquals(2L, count)
+    }
 }


### PR DESCRIPTION

- countSuoritukset: fast-path COUNT(DISTINCT solki_id) / COUNT(*) kun
  filtteri ei tarvitse osakoe-/tarkistusarviointi-liitoksia. Aiempi
  toteutus kääräisi koko selectSuorituksetFull-CTE:n pelkän countin alle.
- V101: indeksit (solki_id, last_modified DESC, id DESC) DISTINCT ON
  -haulle ja lisätieto-liitokselle sekä (tutkintopaiva DESC)
  oletuslajittelulle.
- GZIP päälle HTML/CSS/JS/JSON/CSV-vastauksille.
- Cachetettu DateTimeFormatter-instanssit Time.kt:hen.
- Links.Yki.suoritus(id) käyttää ApplicationProperties.kitu.appUrl:ia
  Spring HATEOAS linkTo-reflektion sijaan.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
