### PR TITLE
OPHKOTO-142: Yki viimeisin siirto oikeaksi

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/dev/mockdata/YkiSuoritusMock.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/dev/mockdata/YkiSuoritusMock.kt
@@ -49,6 +49,7 @@ fun generateRandomYkiSuoritusEntity(
         email = randomPerson.email,
         solkiId = Random.nextInt(100000, 999999),
         lastModified = lastModified,
+        receivedAt = lastModified,
         tutkintopaiva = tutkintopaiva,
         tutkintokieli =
             Tutkintokieli.entries

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/KielitestiSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/suoritukset/KielitestiSuoritusRepository.kt
@@ -97,6 +97,11 @@ class CustomKielitestiSuoritusRepository(
             ?: 0
     }
 
+    // Dashboard käyttää tätä "Viimeisin saapunut suoritus" -aikaleimana. Semantiikka on oikea koska
+    // koto_suoritus on read-only virkailijalle: vain KoealustaService.importSuoritukset (ajastettu Koealusta-
+    // polling) kirjoittaa ja exists()-tarkistus estää duplikaatit. Jos tulevaisuudessa lisätään esim.
+    // virkailijan-UI:sta laukeava koto_suoritus-write, semantiikka rikkoutuu ja tämä metodi pitää korvata
+    // erillisellä received_at-sarakkeella (vrt. YkiSuoritusRepository.findLatestReceivedAt).
     fun findLatestLastModified(): java.time.Instant? =
         jdbcNamedParameterTemplate
             .queryForObject(

--- a/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/vkt/VktSuoritusRepository.kt
@@ -120,6 +120,12 @@ class CustomVktSuoritusRepository(
         return jdbcNamedParameterTemplate.queryForList(query, params, Int::class.java).filterNotNull()
     }
 
+    // Dashboard käyttää tätä "Viimeisin saapunut suoritus" -aikaleimana. Semantiikka on tällä hetkellä
+    // oikea koska vkt_suoritus.created_at asetetaan add_rekisteriintuontiaika-DB-triggerillä BEFORE INSERT
+    // ja vain VktApiController.putHenkilosuoritus insertoi rivejä. Virkailija-UI päivittää vkt_osakoe-tauluun
+    // eikä Koski-tilan päivitykset koske vkt_suoritus.created_at. Jos tulevaisuudessa lisätään
+    // virkailija-UI:sta laukeava vkt_suoritus-insert, semantiikka rikkoutuu ja tämä metodi pitää korvata
+    // erillisellä received_at-sarakkeella (vrt. YkiSuoritusRepository.findLatestReceivedAt).
     @WithSpan
     fun findLatestCreatedAt(): OffsetDateTime? =
         jdbcTemplate.queryForObject(

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/DashboardService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/DashboardService.kt
@@ -53,7 +53,7 @@ class DashboardService(
         YkiStats(
             suoritusCount = ykiSuoritusRepository.countSuoritukset(),
             arvioijaCount = ykiArvioijaRepository.count(),
-            latestReceivedAt = ykiSuoritusRepository.findLatestLastModified(),
+            latestReceivedAt = ykiSuoritusRepository.findLatestReceivedAt(),
             suoritusImportErrorCount = ykiSuoritusErrorService.countErrors(),
             arvioijaImportErrorCount = ykiArvioijaErrorService.countErrors(),
             koskiErrorCount = koskiErrorService.countByEntity("yki", hidden = false).toLong(),

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
@@ -47,6 +47,12 @@ data class YkiSuoritusEntity(
     @IgnoreForEquality("SOLKICSV")
     @IgnoreForEquality("DB")
     val lastModified: Instant,
+    // Aika jolloin kitu vastaanotti suorituksen ulkoiselta järjestelmältä. Sisäiset versiokirjoitukset
+    // (esim. tarkistusarvioinnin hyväksyminen) säilyttävät edellisen version arvon; dashboard käyttää
+    // tätä "Viimeisin saapunut suoritus" -aikaleimana.
+    @IgnoreForEquality("SOLKICSV")
+    @IgnoreForEquality("DB")
+    val receivedAt: Instant,
     val tutkintopaiva: LocalDate,
     val tutkintokieli: Tutkintokieli,
     val tutkintotaso: Tutkintotaso,
@@ -185,6 +191,7 @@ data class YkiSuoritusEntity(
                     email = henkilo.email,
                     solkiId = lahdejarjestelmanId.id.toInt(),
                     lastModified = Instant.now(),
+                    receivedAt = Instant.now(),
                     tutkintopaiva = tutkintopaiva,
                     tutkintokieli = kieli,
                     tutkintotaso = tutkintotaso,
@@ -250,6 +257,7 @@ data class YkiSuoritusEntity(
                 email = rs.getString("email"),
                 solkiId = rs.getInt("solki_id"),
                 lastModified = rs.getTimestamp("last_modified").toInstant(),
+                receivedAt = rs.getTimestamp("received_at").toInstant(),
                 tutkintopaiva = rs.getObject("tutkintopaiva", LocalDate::class.java),
                 tutkintokieli = Tutkintokieli.valueOf(rs.getString("tutkintokieli")),
                 tutkintotaso = Tutkintotaso.valueOf(rs.getString("tutkintotaso")),

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusMappingService.kt
@@ -6,6 +6,7 @@ import fi.oph.kitu.yki.Sukupuoli
 import fi.oph.kitu.yki.TutkinnonOsa.Companion.toTutkinnonOsaSet
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.springframework.stereotype.Service
+import java.time.Instant
 import java.time.LocalDate
 
 @Service
@@ -34,6 +35,7 @@ class YkiSuoritusMappingService(
         csv.email,
         csv.suoritusID,
         csv.lastModified,
+        receivedAt = Instant.now(),
         csv.tutkintopaiva,
         csv.tutkintokieli,
         csv.tutkintotaso,

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
@@ -230,11 +230,15 @@ class YkiSuoritusRepository(
             ?: 0
     }
 
+    // received_at asetetaan vain ulkoisesta importista (YkiSuoritusEntity.from / YkiSuoritusMappingService) ja
+    // säilyy ennallaan sisäisten versiokirjoitusten yli (data class .copy() preservoi sen
+    // hyvaksyTarkistusarvioinnit-kutsussa). Siksi tämä kysely vastaa "Viimeisin saapunut suoritus"
+    // -semantiikkaa eikä bumppaa virkailijatoiminnasta.
     @WithSpan
-    fun findLatestLastModified(): Instant? =
+    fun findLatestReceivedAt(): Instant? =
         jdbcTemplate
             .queryForObject(
-                "SELECT MAX(last_modified) FROM yki_suoritus",
+                "SELECT MAX(received_at) FROM yki_suoritus",
                 Timestamp::class.java,
             )?.toInstant()
 
@@ -400,6 +404,7 @@ class YkiSuoritusRepository(
                 "email" to suoritus.email,
                 "solki_id" to suoritus.solkiId.toString(),
                 "last_modified" to Timestamp.from(suoritus.lastModified),
+                "received_at" to Timestamp.from(suoritus.receivedAt),
                 "koski_opiskeluoikeus" to suoritus.koskiOpiskeluoikeus?.toString(),
                 "koski_siirto_kasitelty" to (suoritus.koskiSiirtoKasitelty ?: false),
                 "arviointitila" to suoritus.arviointitila.toString(),

--- a/server/src/main/resources/db/migration/V102__add_yki_suoritus_received_at.sql
+++ b/server/src/main/resources/db/migration/V102__add_yki_suoritus_received_at.sql
@@ -1,0 +1,13 @@
+-- Erillinen aikaleima jolla seurataan koska kitu vastaanotti rivin ulkoiselta
+-- järjestelmältä. Tätä ei muuteta sisäisten versiokirjoitusten (esim.
+-- tarkistusarvioinnin hyväksyminen) yhteydessä, joten dashboardin
+-- "Viimeisin saapunut suoritus" -aikaleima ei hyppää virkailijan toiminnasta.
+ALTER TABLE yki_suoritus ADD COLUMN received_at TIMESTAMPTZ;
+
+-- Olemassa oleville riveille last_modified on paras arvio vastaanottoajasta.
+UPDATE yki_suoritus SET received_at = last_modified;
+
+ALTER TABLE yki_suoritus ALTER COLUMN received_at SET NOT NULL;
+
+-- Tukee dashboardin MAX(received_at) -kyselyä.
+CREATE INDEX yki_suoritus_received_at_idx ON yki_suoritus (received_at DESC);

--- a/server/src/test/kotlin/fi/oph/kitu/webmvc/DashboardServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/webmvc/DashboardServiceTest.kt
@@ -1,6 +1,9 @@
 package fi.oph.kitu.webmvc
 
 import fi.oph.kitu.DBContainerConfiguration
+import fi.oph.kitu.dev.mockdata.generateRandomYkiSuoritusEntity
+import fi.oph.kitu.yki.Arviointitila
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -8,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.util.AopTestUtils
+import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 
@@ -16,6 +20,7 @@ import kotlin.test.assertSame
 class DashboardServiceTest(
     @param:Autowired private val dashboardService: DashboardService,
     @param:Autowired private val jdbc: JdbcTemplate,
+    @param:Autowired private val ykiSuoritusRepository: YkiSuoritusRepository,
 ) {
     @BeforeEach
     fun cleanup() {
@@ -66,6 +71,40 @@ class DashboardServiceTest(
         clearVktCache()
 
         assertSame(ykiBefore, dashboardService.getYkiStats(), "YKI-cache ei tyhjentynyt VKT-tyhjennyksen mukana")
+    }
+
+    @Test
+    fun `tarkistusarvioinnin hyvaksynta ei muuta YKI viimeisin saapunut -aikaleimaa`() {
+        val solkiId = 654321
+        val ulkoinenSaapumisaika = Instant.parse("2026-05-01T08:00:00Z")
+        val virkailijanHyvaksyntaaika = Instant.parse("2026-06-01T12:00:00Z")
+
+        val ulkoinenSuoritus =
+            generateRandomYkiSuoritusEntity().copy(
+                solkiId = solkiId,
+                lastModified = ulkoinenSaapumisaika,
+                receivedAt = ulkoinenSaapumisaika,
+                arviointitila = Arviointitila.ARVIOITU,
+            )
+        ykiSuoritusRepository.save(ulkoinenSuoritus, false)
+        clearAllCaches()
+        assertEquals(ulkoinenSaapumisaika, dashboardService.getYkiStats().latestReceivedAt)
+
+        // Virkailija hyväksyy tarkistusarvioinnin: data class .copy() säilyttää receivedAt:n alkuperäisessä arvossa.
+        val hyvaksyntaVersio =
+            ulkoinenSuoritus.copy(
+                id = null,
+                lastModified = virkailijanHyvaksyntaaika,
+                arviointitila = Arviointitila.TARKISTUSARVIOINTI_HYVAKSYTTY,
+            )
+        ykiSuoritusRepository.save(hyvaksyntaVersio, true)
+        clearAllCaches()
+
+        assertEquals(
+            ulkoinenSaapumisaika,
+            dashboardService.getYkiStats().latestReceivedAt,
+            "received_at ei saa edetä virkailijan tarkistusarvioinnin hyväksymisestä",
+        )
     }
 
     @Test


### PR DESCRIPTION

Lisätään YKI:lle erillinen received_at-sarake, joka asetetaan vain
ulkoisen importin entity-tehtaiden yhteydessä. Sisäisten versiokirjoitusten
yli (kuten hyvaksyTarkistusarvioinnit) data class .copy() preservoi
alkuperäisen arvon automaattisesti, koska kentällä on @IgnoreForEquality.

Muutokset:

- Migraatio V102: ALTER TABLE yki_suoritus ADD COLUMN received_at TIMESTAMPTZ,
  backfill last_modified-arvolla, SET NOT NULL, laskeva indeksi
  MAX(received_at)-kyselyä varten.
- YkiSuoritusEntity: uusi receivedAt: Instant -kenttä, annotoitu
  @IgnoreForEquality("SOLKICSV") + @IgnoreForEquality("DB"). RowMapper
  lukee received_at-sarakkeen.
- YkiSuoritusEntity.from(hs) ja YkiSuoritusMappingService.convertToEntity:
  asettavat receivedAt = Instant.now() ulkoisen importin yhteydessä.
- YkiSuoritusRepository.insertSuoritus: received_at-kenttä values-mapissä.
- findLatestLastModified() -> findLatestReceivedAt() lukee MAX(received_at).
- DashboardService.computeYki käyttää uutta metodia.
- VKT:n findLatestCreatedAt ja Koto:n findLatestLastModified -metodeihin
  kommentit jotka selittävät miksi semantiikka on niillä jo oikea ja
  varoittavat tulevista virkailija-UI-write-poluista.
- generateRandomYkiSuoritusEntity asettaa receivedAt = lastModified
  deterministisyyden vuoksi.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
