### PR TITLE
OPHKOTO-155: Tarkista YKI-poikkeamat päivittäin ja säilytä vanhat löydökset

### DIFF
--- a/e2e/db/database.ts
+++ b/e2e/db/database.ts
@@ -108,6 +108,7 @@ const withEmptyDatabase = (pool: pg.Pool) => async () => {
         yki_suoritus,
         yki_suoritus_error,
         yki_suoritus_lisatieto,
+        yki_suoritus_poikkeama,
         yki_arvioija,
         yki_arviointioikeus,
         vkt_suoritus,

--- a/e2e/fixtures/baseFixture.ts
+++ b/e2e/fixtures/baseFixture.ts
@@ -17,6 +17,8 @@ import VktSuorituksetPage from "../models/vkt/VktSuorituksetPage"
 import VktSuorituksenTiedotPage from "../models/vkt/VktSuorituksenTiedotPage"
 import YkiArvioijatPage from "../models/yki/YkiArvioijatPage"
 import YkiTarkistusarvioinnitPage from "../models/yki/YkiTarkistusarvioinnitPage"
+import YkiPoikkeamatPage from "../models/yki/YkiPoikkeamatPage"
+import * as ykiPoikkeamaFixture from "./ykiPoikkeama"
 import { OauthRequestContext } from "./oauthRequestContext"
 
 interface Fixtures {
@@ -24,6 +26,8 @@ interface Fixtures {
   ykiArvioijatPage: YkiArvioijatPage
   ykiSuorituksetErrorPage: YkiSuorituksetErrorPage
   ykiTarkistusarvioinnitPage: YkiTarkistusarvioinnitPage
+  ykiPoikkeamatPage: YkiPoikkeamatPage
+  ykiPoikkeama: typeof ykiPoikkeamaFixture
   kielitestiSuorituksetPage: KielitestiSuorituksetPage
   kielitestiErrorPage: KielitestiErrorPage
   indexPage: IndexPage
@@ -84,6 +88,13 @@ export const test = baseTest.extend<Fixtures, WorkerArgs>({
       config,
     )
     await use(ykiTarkistusarvioinnitPage)
+  },
+  ykiPoikkeamatPage: async ({ page, config }, use) => {
+    const ykiPoikkeamatPage = new YkiPoikkeamatPage(page, config)
+    await use(ykiPoikkeamatPage)
+  },
+  ykiPoikkeama: async ({}, use) => {
+    await use({ ...ykiPoikkeamaFixture })
   },
   config: [
     async ({}, use) => {

--- a/e2e/fixtures/ykiPoikkeama.ts
+++ b/e2e/fixtures/ykiPoikkeama.ts
@@ -1,0 +1,88 @@
+import SQL from "sql-template-strings"
+import { TestDB } from "./baseFixture"
+
+export interface YkiPoikkeama {
+  solkiId: number
+  kentta: string
+  arvoKitussa: string
+  arvoSolkissa: string
+  havaittu: string
+  tutkintopaiva: string | null
+  tutkintokieli: "FIN" | "SWE" | "ENG" | null
+  tutkintotaso: "YT" | "PT" | "KT" | null
+}
+
+const make = (overrides: Partial<YkiPoikkeama> = {}): YkiPoikkeama => ({
+  solkiId: 183424,
+  kentta: "sukunimi",
+  arvoKitussa: "Mäkitie",
+  arvoSolkissa: "Mäkinen",
+  havaittu: "2026-06-03T08:00:00Z",
+  tutkintopaiva: "2024-09-01",
+  tutkintokieli: "FIN",
+  tutkintotaso: "YT",
+  ...overrides,
+})
+
+export const fixtureData = {
+  ranjaSukunimi: make({
+    solkiId: 183424,
+    kentta: "sukunimi",
+    arvoKitussa: "Mäkitie",
+    arvoSolkissa: "Öhman-Testi",
+  }),
+  ranjaEtunimet: make({
+    solkiId: 183424,
+    kentta: "etunimet",
+    arvoKitussa: "Ranja",
+    arvoSolkissa: "Ranja Testi",
+  }),
+  petroPostinumero: make({
+    solkiId: 123123,
+    kentta: "postinumero",
+    arvoKitussa: "00100",
+    arvoSolkissa: "00120",
+    tutkintopaiva: "2024-08-25",
+    tutkintokieli: "SWE",
+    tutkintotaso: "YT",
+  }),
+  magdalenaTaso: make({
+    solkiId: 172836,
+    kentta: "tutkintotaso",
+    arvoKitussa: "YT",
+    arvoSolkissa: "PT",
+    tutkintopaiva: "2025-01-12",
+    tutkintokieli: "FIN",
+    tutkintotaso: "PT",
+  }),
+  puuttuvaSuoritus: make({
+    solkiId: 999999,
+    kentta: "(suoritus puuttuu Kitusta)",
+    arvoKitussa: "",
+    arvoSolkissa: "Puuttuva Henkilö, YT, 2025-03-10",
+    tutkintopaiva: "2025-03-10",
+    tutkintokieli: "FIN",
+    tutkintotaso: "YT",
+  }),
+} as const
+
+export type YkiPoikkeamaName = keyof typeof fixtureData
+
+export const insert = async (db: TestDB, name: YkiPoikkeamaName) => {
+  const p = fixtureData[name]
+  await db.dbClient.query(SQL`
+    INSERT INTO yki_suoritus_poikkeama
+      (solki_id, kentta, arvo_kitussa, arvo_solkissa, havaittu,
+       tutkintopaiva, tutkintokieli, tutkintotaso)
+    VALUES (
+      ${p.solkiId},
+      ${p.kentta},
+      ${p.arvoKitussa},
+      ${p.arvoSolkissa},
+      ${p.havaittu},
+      ${p.tutkintopaiva},
+      ${p.tutkintokieli},
+      ${p.tutkintotaso}
+    )
+  `)
+}

--- a/e2e/models/yki/YkiPoikkeamatPage.ts
+++ b/e2e/models/yki/YkiPoikkeamatPage.ts
@@ -1,0 +1,54 @@
+import BasePage from "../BasePage"
+import { Locator, Page } from "@playwright/test"
+import { Config } from "../../config"
+
+export default class YkiPoikkeamatPage extends BasePage {
+  table: Locator
+  rows: Locator
+  patchButton: Locator
+  selectAllVisible: Locator
+
+  constructor(page: Page, config: Config) {
+    super(page, config)
+    this.table = this.getPageContent().getByRole("table")
+    this.rows = this.table.locator("tbody tr")
+    this.patchButton = this.getPageContent().getByTestId("tallenna-korjaukset")
+    this.selectAllVisible = this.getPageContent().getByTestId("valitse-nakyvat")
+  }
+
+  async open() {
+    await this.goto("yki/poikkeamat")
+  }
+
+  rowBySolkiId(solkiId: number) {
+    return this.table.locator(`tbody tr[data-solki-id="${solkiId}"]`)
+  }
+
+  rowByKey(solkiId: number, kentta: string) {
+    return this.table.locator(
+      `tbody tr[data-solki-id="${solkiId}"][data-kentta="${kentta}"]`,
+    )
+  }
+
+  poikkeamaCheckbox(solkiId: number, kentta: string) {
+    return this.getPageContent().getByTestId(
+      `poikkeama-checkbox-${solkiId}-${kentta}`,
+    )
+  }
+
+  groupCheckbox(solkiId: number) {
+    return this.getPageContent().getByTestId(`select-group-${solkiId}`)
+  }
+
+  async openFilterDropdown(testId: string) {
+    await this.getPageContent().getByTestId(testId).locator("summary").click()
+  }
+
+  filterOption(filterTestId: string, value: string) {
+    return this.getPageContent().getByTestId(`${filterTestId}-${value}`)
+  }
+
+  visibleRows() {
+    return this.table.locator("tbody tr:not([hidden])")
+  }
+}

--- a/e2e/tests/yki/yki-poikkeamat.spec.ts
+++ b/e2e/tests/yki/yki-poikkeamat.spec.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, test } from "../../fixtures/baseFixture"
+
+describe("YKI-poikkeamat-näkymä", () => {
+  beforeEach(async ({ db, basePage }) => {
+    await db.withEmptyDatabase()
+    await basePage.login()
+  })
+
+  test("näyttää viestin, kun poikkeamia ei ole", async ({
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeamatPage.open()
+    await expect(
+      ykiPoikkeamatPage.getPageContent().getByText("Ei havaittuja poikkeamia."),
+    ).toBeVisible()
+    await expect(ykiPoikkeamatPage.table).toHaveCount(0)
+  })
+
+  test("renderöi rivin Solkin tiedoilla suomalaisessa muodossa", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeamatPage.open()
+
+    const row = ykiPoikkeamatPage.rowByKey(183424, "sukunimi")
+    await expect(row).toHaveCount(1)
+    const cells = row.locator("td")
+    await expect(cells.nth(0)).toContainText("183424")
+    await expect(cells.nth(1)).toContainText("1.9.2024")
+    await expect(cells.nth(2)).toContainText("FIN")
+    await expect(cells.nth(3)).toContainText("YT")
+    await expect(cells.nth(4)).toContainText("sukunimi")
+    await expect(cells.nth(5)).toContainText("Mäkitie")
+    await expect(cells.nth(6)).toContainText("Öhman-Testi")
+    await expect(cells.nth(7).getByTestId("datetime")).toBeVisible()
+  })
+
+  test("näyttää Solki-ID:n linkkinä, kun vastaava suoritus on Kitussa", async ({
+    oauth,
+    db,
+    ykiSuoritus,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiSuoritus.insert(oauth, "ranja")
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeamatPage.open()
+
+    const link = ykiPoikkeamatPage
+      .rowByKey(183424, "sukunimi")
+      .locator("td")
+      .first()
+      .getByRole("link", { name: "183424" })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute("href", /yki\/suoritukset\/\d+/)
+  })
+
+  test("näyttää Solki-ID:n tekstinä, kun suoritus puuttuu Kitusta", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "puuttuvaSuoritus")
+    await ykiPoikkeamatPage.open()
+
+    const cell = ykiPoikkeamatPage
+      .rowByKey(999999, "(suoritus puuttuu Kitusta)")
+      .locator("td")
+      .first()
+    await expect(cell).toContainText("999999")
+    await expect(cell.getByRole("link")).toHaveCount(0)
+  })
+
+  test("ryhmittelee saman Solki-ID:n poikkeamat ja merkitsee jatkorivin repeat-group-luokalla", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeama.insert(db, "ranjaEtunimet")
+    await ykiPoikkeamatPage.open()
+
+    await expect(ykiPoikkeamatPage.rowBySolkiId(183424)).toHaveCount(2)
+    const rows = ykiPoikkeamatPage.rowBySolkiId(183424)
+    await expect(rows.nth(0)).not.toHaveClass(/repeat-group/)
+    await expect(rows.nth(1)).toHaveClass(/repeat-group/)
+  })
+
+  test("ei näytä rasti-ruutua kentälle (suoritus puuttuu Kitusta)", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "puuttuvaSuoritus")
+    await ykiPoikkeamatPage.open()
+
+    await expect(
+      ykiPoikkeamatPage.poikkeamaCheckbox(999999, "(suoritus puuttuu Kitusta)"),
+    ).toHaveCount(0)
+  })
+
+  test("Tallenna korjaukset -nappi on pois käytöstä, kunnes vähintään yksi rivi on valittu", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeamatPage.open()
+
+    await expect(ykiPoikkeamatPage.patchButton).toBeDisabled()
+    await ykiPoikkeamatPage.poikkeamaCheckbox(183424, "sukunimi").check()
+    await expect(ykiPoikkeamatPage.patchButton).toBeEnabled()
+    await ykiPoikkeamatPage.poikkeamaCheckbox(183424, "sukunimi").uncheck()
+    await expect(ykiPoikkeamatPage.patchButton).toBeDisabled()
+  })
+
+  test("ryhmävalinta valitsee kaikki ryhmän rivit ja muuttuu indeterminate-tilaan, kun osa on valittu", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeama.insert(db, "ranjaEtunimet")
+    await ykiPoikkeamatPage.open()
+
+    const groupCb = ykiPoikkeamatPage.groupCheckbox(183424).first()
+    const sukunimiCb = ykiPoikkeamatPage.poikkeamaCheckbox(183424, "sukunimi")
+    const etunimetCb = ykiPoikkeamatPage.poikkeamaCheckbox(183424, "etunimet")
+
+    await groupCb.check()
+    await expect(sukunimiCb).toBeChecked()
+    await expect(etunimetCb).toBeChecked()
+
+    await sukunimiCb.uncheck()
+    expect(
+      await groupCb.evaluate((el: HTMLInputElement) => el.indeterminate),
+    ).toBe(true)
+  })
+
+  test("Valitse näkyvät -valinta valitsee kaikki näkyvät rivit", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeama.insert(db, "petroPostinumero")
+    await ykiPoikkeamatPage.open()
+
+    await ykiPoikkeamatPage.selectAllVisible.check()
+    await expect(
+      ykiPoikkeamatPage.poikkeamaCheckbox(183424, "sukunimi"),
+    ).toBeChecked()
+    await expect(
+      ykiPoikkeamatPage.poikkeamaCheckbox(123123, "postinumero"),
+    ).toBeChecked()
+  })
+
+  test("Kenttä-sarakkeen suodatin piilottaa muut rivit", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeama.insert(db, "petroPostinumero")
+    await ykiPoikkeamatPage.open()
+
+    await ykiPoikkeamatPage.openFilterDropdown("kentta-filter")
+    await ykiPoikkeamatPage.filterOption("kentta-filter", "sukunimi").check()
+
+    await expect(ykiPoikkeamatPage.rowByKey(183424, "sukunimi")).toBeVisible()
+    await expect(ykiPoikkeamatPage.rowByKey(123123, "postinumero")).toBeHidden()
+  })
+
+  test("Kieli-sarakkeen suodatin huomioi vain valitut tutkintokielet", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeama.insert(db, "petroPostinumero")
+    await ykiPoikkeamatPage.open()
+
+    await ykiPoikkeamatPage.openFilterDropdown("tutkintokieli-filter")
+    await ykiPoikkeamatPage.filterOption("tutkintokieli-filter", "SWE").check()
+
+    await expect(ykiPoikkeamatPage.rowByKey(183424, "sukunimi")).toBeHidden()
+    await expect(
+      ykiPoikkeamatPage.rowByKey(123123, "postinumero"),
+    ).toBeVisible()
+  })
+
+  test("Korjauksen tallennus poistaa poikkeaman ja näyttää onnistumisviestin", async ({
+    oauth,
+    db,
+    ykiSuoritus,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiSuoritus.insert(oauth, "ranja")
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeamatPage.open()
+
+    await ykiPoikkeamatPage.poikkeamaCheckbox(183424, "sukunimi").check()
+    await ykiPoikkeamatPage.patchButton.click()
+
+    await expect(ykiPoikkeamatPage.viewMessage).toHaveText(
+      "1 poikkeamaa korjattu.",
+    )
+    await expect(ykiPoikkeamatPage.rowByKey(183424, "sukunimi")).toHaveCount(0)
+  })
+
+  test("Puuttuvan suorituksen poikkeamaa ei voi korjata - epäonnistunut korjaus tuottaa virheilmoituksen", async ({
+    db,
+    ykiPoikkeama,
+    ykiPoikkeamatPage,
+  }) => {
+    await ykiPoikkeama.insert(db, "ranjaSukunimi")
+    await ykiPoikkeamatPage.open()
+
+    await ykiPoikkeamatPage.poikkeamaCheckbox(183424, "sukunimi").check()
+    await ykiPoikkeamatPage.patchButton.click()
+
+    await expect(ykiPoikkeamatPage.viewMessage).toContainText(
+      "Yhtäkään poikkeamaa ei voitu korjata",
+    )
+    await expect(ykiPoikkeamatPage.viewMessage).toContainText(
+      "Suoritusta ei löytynyt",
+    )
+    await expect(ykiPoikkeamatPage.rowByKey(183424, "sukunimi")).toHaveCount(1)
+  })
+})

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiScheduledTasks.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiScheduledTasks.kt
@@ -8,8 +8,19 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.time.Instant
-import kotlin.time.Duration.Companion.days
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.Period
+import java.time.ZoneId
+
+private val HELSINKI = ZoneId.of("Europe/Helsinki")
+
+fun anomalyCheckLookback(today: LocalDate): Period =
+    when {
+        today.dayOfMonth == 1 -> Period.ofYears(1)
+        today.dayOfWeek == DayOfWeek.SUNDAY -> Period.ofMonths(3)
+        else -> Period.ofMonths(1)
+    }
 
 @Configuration
 @ConditionalOnBooleanProperty(name = ["kitu.yki.scheduling.enabled"])
@@ -19,16 +30,18 @@ class YkiScheduledTasks(
     @Value($$"${kitu.yki.scheduling.import.schedule}")
     lateinit var ykiImportSchedule: String
 
-    @Value($$"${kitu.yki.scheduling.largeImport.schedule}")
-    lateinit var ykiMonthlyImportSchedule: String
+    @Value($$"${kitu.yki.scheduling.anomalyCheck.schedule}")
+    lateinit var ykiAnomalyCheckSchedule: String
 
     @Value($$"${kitu.yki.scheduling.importArvioijat.schedule}")
     lateinit var ykiImportArvioijatSchedule: String
 
     @WithSpan
     @Bean
-    fun monthlyCheck(ykiService: YkiService): Task<Void> =
-        tracer.recurringStatefulTask("Tarkista poikkeamat YKI-suorituksissa", ykiMonthlyImportSchedule) {
-            ykiService.checkYkiAnomalies(Instant.now().minusSeconds(365.days.inWholeSeconds))
+    fun dailyAnomalyCheck(ykiService: YkiService): Task<Void> =
+        tracer.recurringStatefulTask("Tarkista poikkeamat YKI-suorituksissa", ykiAnomalyCheckSchedule) {
+            val today = LocalDate.now(HELSINKI)
+            val from = today.minus(anomalyCheckLookback(today)).atStartOfDay(HELSINKI).toInstant()
+            ykiService.checkYkiAnomalies(from)
         }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiService.kt
@@ -90,7 +90,6 @@ class YkiService(
 
         val entities = suoritusMapper.convertToEntityIterable(suoritukset)
 
-        suoritusPoikkeamaRepository.deleteAll()
         entities.forEach { entity ->
             val existing =
                 suoritusRepository

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaRepository.kt
@@ -1,5 +1,7 @@
 package fi.oph.kitu.yki.suoritukset
 
+import fi.oph.kitu.jdbc.Columns
+import fi.oph.kitu.jdbc.UpdateOnConflict
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import org.springframework.jdbc.core.JdbcTemplate
@@ -19,7 +21,9 @@ class YkiSuoritusPoikkeamaRepository(
         jdbcTemplate.update(
             """
             INSERT INTO yki_suoritus_poikkeama
+                (solki_id, kentta, arvo_kitussa, arvo_solkissa, havaittu, tutkintopaiva, tutkintokieli, tutkintotaso)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            $UPSERT_ON_CONFLICT
             """.trimIndent(),
             poikkeama.solkiId,
             poikkeama.kentta,
@@ -64,6 +68,14 @@ class YkiSuoritusPoikkeamaRepository(
 
     fun count(): Long =
         jdbcTemplate.queryForObject("SELECT COUNT(*) FROM yki_suoritus_poikkeama", Long::class.java) ?: 0L
+
+    companion object {
+        private val UPSERT_ON_CONFLICT =
+            UpdateOnConflict(
+                conflictTarget = Columns.of("solki_id", "kentta"),
+                columns = listOf("arvo_kitussa", "arvo_solkissa", "tutkintopaiva", "tutkintokieli", "tutkintotaso"),
+            ).toString()
+    }
 }
 
 data class YkiSuoritusPoikkeama(

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -42,7 +42,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://dev.otuva.opintopo
 
 kitu.yki.scheduling.enabled=true
 kitu.yki.scheduling.import.schedule=DAILY|00:00
-kitu.yki.scheduling.largeImport.schedule=DAILY|01:00
+kitu.yki.scheduling.anomalyCheck.schedule=DAILY|01:00
 kitu.yki.scheduling.importArvioijat.schedule=DAILY|00:00
 kitu.yki.baseUrl=http://localhost:8080/kielitutkinnot/dev/yki/import/
 #kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/oph/

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -20,7 +20,7 @@ kitu.organisaatiopalvelu.service.url=https://organisaatio.prod.organisaatio.opin
 kitu.yki.scheduling.enabled=true
 kitu.yki.baseUrl=https://yki.jyu.fi/oph/
 kitu.yki.scheduling.import.schedule=DAILY|03:00
-kitu.yki.scheduling.largeImport.schedule=0 0 4 ? * 1#1
+kitu.yki.scheduling.anomalyCheck.schedule=DAILY|04:00
 kitu.yki.scheduling.importArvioijat.schedule=DAILY|03:00
 
 kitu.vkt.scheduling.cleanup.retentionTime=7d

--- a/server/src/main/resources/application-qa.properties
+++ b/server/src/main/resources/application-qa.properties
@@ -24,7 +24,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://qa.otuva.opintopol
 
 kitu.yki.scheduling.enabled=true
 kitu.yki.scheduling.import.schedule=-
-kitu.yki.scheduling.largeImport.schedule=0 0 4 ? * 1#1
+kitu.yki.scheduling.anomalyCheck.schedule=DAILY|04:00
 kitu.yki.scheduling.importArvioijat.schedule=-
 kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/oph/
 

--- a/server/src/main/resources/application-untuva.properties
+++ b/server/src/main/resources/application-untuva.properties
@@ -29,7 +29,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://dev.otuva.opintopo
 
 kitu.yki.scheduling.enabled=true
 kitu.yki.scheduling.import.schedule=DAILY|03:00
-kitu.yki.scheduling.largeImport.schedule=0 0 4 ? * 1#1
+kitu.yki.scheduling.anomalyCheck.schedule=DAILY|04:00
 kitu.yki.scheduling.importArvioijat.schedule=DAILY|03:00
 kitu.yki.baseUrl=https://yki-test.cc.jyu.fi/oph/
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -38,7 +38,7 @@ db-scheduler-ui.log-limit=1000
 
 kitu.yki.scheduling.enabled=false
 kitu.yki.scheduling.import.schedule=-
-kitu.yki.scheduling.largeImport.schedule=-
+kitu.yki.scheduling.anomalyCheck.schedule=-
 kitu.yki.scheduling.importArvioijat.schedule=-
 kitu.yki.scheduling.retrySendingFailedArviointitilat.schedule=FIXED_DELAY|3600s
 kitu.yki.username=${YKI_API_USER}

--- a/server/src/main/resources/db/migration/V103__yki_poikkeama_pk.sql
+++ b/server/src/main/resources/db/migration/V103__yki_poikkeama_pk.sql
@@ -1,0 +1,4 @@
+DROP INDEX "yki_poikkeama_solki_id_kentta_havaittu_idx";
+
+ALTER TABLE "yki_suoritus_poikkeama"
+    ADD PRIMARY KEY ("solki_id", "kentta");

--- a/server/src/test/kotlin/fi/oph/kitu/yki/AnomalyCheckLookbackTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/AnomalyCheckLookbackTest.kt
@@ -1,0 +1,30 @@
+package fi.oph.kitu.yki
+
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.Period
+import kotlin.test.assertEquals
+
+class AnomalyCheckLookbackTest {
+    @Test
+    fun `kuun 1 päivänä tarkistetaan koko vuoden ajalta`() {
+        assertEquals(Period.ofYears(1), anomalyCheckLookback(LocalDate.of(2026, 1, 1)))
+        assertEquals(Period.ofYears(1), anomalyCheckLookback(LocalDate.of(2026, 6, 1)))
+    }
+
+    @Test
+    fun `sunnuntaina tarkistetaan kolmen kuukauden ajalta`() {
+        assertEquals(Period.ofMonths(3), anomalyCheckLookback(LocalDate.of(2026, 6, 7)))
+    }
+
+    @Test
+    fun `arkipäivänä tarkistetaan yhden kuukauden ajalta`() {
+        assertEquals(Period.ofMonths(1), anomalyCheckLookback(LocalDate.of(2026, 6, 8)))
+        assertEquals(Period.ofMonths(1), anomalyCheckLookback(LocalDate.of(2026, 6, 13)))
+    }
+
+    @Test
+    fun `kuun 1 päivän sääntö voittaa kun se osuu sunnuntaille`() {
+        assertEquals(Period.ofYears(1), anomalyCheckLookback(LocalDate.of(2026, 3, 1)))
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiServiceTests.kt
@@ -196,6 +196,95 @@ class YkiServiceTests(
     }
 
     @Test
+    fun `checkYkiAnomalies upsertaa saman poikkeaman ja säilyttää alkuperäisen havaittu-ajan`() {
+        val solkiId = 888888
+        val firstCsv =
+            """"1.2.246.562.24.20281155246","010180-9026","N","EkaSuku","Eka Etu","FIN","Mäkitie 1","00100","Helsinki","pekka@example.fi",$solkiId,2024-06-01T10:00:00Z,2024-06-15,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto",,,,,,,,,,0,0,,"""
+        val secondCsv =
+            """"1.2.246.562.24.20281155246","010180-9026","N","TokaSuku","Toka Etu","FIN","Mäkitie 1","00100","Helsinki","pekka@example.fi",$solkiId,2024-06-01T10:00:00Z,2024-06-15,"fin","YT","1.2.246.562.10.14893989377","Jyväskylän yliopisto",,,,,,,,,,0,0,,"""
+
+        val from = Instant.parse("2024-01-01T00:00:00Z")
+        val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
+        mockServer
+            .expect(requestTo("suoritukset?m=2024-01-01T00:00:00Z"))
+            .andRespond(withSuccess(firstCsv, MediaType.parseMediaType("text/csv")))
+        mockServer
+            .expect(requestTo("suoritukset?m=2024-01-01T00:00:00Z"))
+            .andRespond(withSuccess(secondCsv, MediaType.parseMediaType("text/csv")))
+
+        val service =
+            YkiService(
+                mockRestClientBuilder.build(),
+                ykiSuoritusRepository,
+                ykiSuoritusErrorService,
+                suoritusMapper,
+                ykiArvioijaRepository,
+                suoritusPoikkeamaRepository,
+                auditLogger,
+                parser,
+            )
+
+        service.checkYkiAnomalies(from)
+        val firstHavaittu =
+            suoritusPoikkeamaRepository
+                .findByKey(solkiId, YkiSuoritusPoikkeama.SUORITUS_PUUTTUU_KITUSTA)!!
+                .havaittu
+
+        Thread.sleep(50)
+        service.checkYkiAnomalies(from)
+
+        val poikkeamat = suoritusPoikkeamaRepository.findAll()
+        assertEquals(1, poikkeamat.size)
+        val poikkeama = poikkeamat.first()
+        assertTrue(poikkeama.arvoSolkissa.contains("TokaSuku"))
+        assertTrue(poikkeama.arvoSolkissa.contains("Toka Etu"))
+        assertEquals(firstHavaittu, poikkeama.havaittu)
+    }
+
+    @Test
+    fun `checkYkiAnomalies ei poista poikkeamia jotka eivät kuulu Solki-vastaukseen`() {
+        val olemassaolevaSolkiId = 777777
+        val olemassaolevaHavaittu = Instant.parse("2024-01-15T08:00:00Z")
+        suoritusPoikkeamaRepository.save(
+            YkiSuoritusPoikkeama(
+                solkiId = olemassaolevaSolkiId,
+                kentta = YkiSuoritusPoikkeama.SUORITUS_PUUTTUU_KITUSTA,
+                arvoKitussa = "",
+                arvoSolkissa = "Vanha poikkeama, YT, 2024-01-10",
+                havaittu = olemassaolevaHavaittu,
+                tutkintopaiva = LocalDate.of(2024, 1, 10),
+                tutkintokieli = Tutkintokieli.FIN,
+                tutkintotaso = Tutkintotaso.YT,
+            ),
+        )
+
+        val from = Instant.parse("2024-05-01T00:00:00Z")
+        val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
+        mockServer
+            .expect(requestTo("suoritukset?m=2024-05-01T00:00:00Z"))
+            .andRespond(withSuccess("", MediaType.parseMediaType("text/csv")))
+
+        val service =
+            YkiService(
+                mockRestClientBuilder.build(),
+                ykiSuoritusRepository,
+                ykiSuoritusErrorService,
+                suoritusMapper,
+                ykiArvioijaRepository,
+                suoritusPoikkeamaRepository,
+                auditLogger,
+                parser,
+            )
+
+        service.checkYkiAnomalies(from)
+
+        val poikkeamat = suoritusPoikkeamaRepository.findAll()
+        assertEquals(1, poikkeamat.size)
+        assertEquals(olemassaolevaSolkiId, poikkeamat.first().solkiId)
+        assertEquals(olemassaolevaHavaittu, poikkeamat.first().havaittu)
+    }
+
+    @Test
     fun `Arvointitila is updated correctly also on csv update`() {
         val expected =
             mapOf(


### PR DESCRIPTION

Aikaisemmin tarkistus ajettiin kerran kuussa koko vuoden ajalta ja
tyhjensi taulun joka kerralla. Nyt:

- Ajetaan päivittäin. Kuun 1. päivänä katsotaan vuosi, sunnuntaina
  3 kk, muulloin 1 kk.
- save() upsertoi (solki_id, kentta) -avaimella. havaittu säilyy
  ensimmäisen havainnon arvossa.
- Aikaikkunan ulkopuolella olevat aiemmat poikkeamat säilyvät.

Schedule-property nimettiin kitu.yki.scheduling.largeImport.schedule →
kitu.yki.scheduling.anomalyCheck.schedule.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
