### PR TITLE
OPHKOTO-155: Siivoa YKI-suoritusten poikkeamamerkinnät automaattisesti

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiApiController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiApiController.kt
@@ -156,6 +156,7 @@ class YkiApiController(
         Span.current().setAttribute("arvioitu", entity.arviointitila.arvioitu())
 
         ykiSuoritusRepository.save(entity, false)
+        ykiSuoritusPoikkeamaRepository.deleteBySolkiId(entity.solkiId)
         ilmoittautumisjarjestelma.sendArvioinninTila(entity)
         return TiedonsiirtoSuccess().toResponseEntity()
     }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusPoikkeamaRepository.kt
@@ -66,6 +66,12 @@ class YkiSuoritusPoikkeamaRepository(
             kentta,
         )
 
+    fun deleteBySolkiId(solkiId: Int): Int =
+        jdbcTemplate.update(
+            "DELETE FROM yki_suoritus_poikkeama WHERE solki_id = ?",
+            solkiId,
+        )
+
     fun count(): Long =
         jdbcTemplate.queryForObject("SELECT COUNT(*) FROM yki_suoritus_poikkeama", Long::class.java) ?: 0L
 

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiApiControllerTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiApiControllerTest.kt
@@ -21,6 +21,8 @@ import fi.oph.kitu.yki.arvioijat.YkiArvioijaRepository
 import fi.oph.kitu.yki.arvioijat.YkiArvioijaTila
 import fi.oph.kitu.yki.arvioijat.YkiArviointioikeus
 import fi.oph.kitu.yki.suoritukset.Todistuskieli
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusPoikkeama
+import fi.oph.kitu.yki.suoritukset.YkiSuoritusPoikkeamaRepository
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -36,6 +38,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import org.testcontainers.postgresql.PostgreSQLContainer
 import tools.jackson.databind.JsonNode
+import java.time.Instant
 import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,6 +48,7 @@ import kotlin.test.assertEquals
 class YkiApiControllerTest(
     @param:Autowired val timeService: TestTimeService,
     @param:Autowired val arvioijaRepository: YkiArvioijaRepository,
+    @param:Autowired val poikkeamaRepository: YkiSuoritusPoikkeamaRepository,
 ) {
     @Autowired
     private lateinit var context: WebApplicationContext
@@ -139,6 +143,102 @@ class YkiApiControllerTest(
         postSuoritus(suoritus) {
             isOk()
         }
+    }
+
+    @Test
+    fun `Suorituksen tallennus poistaa kaikki sen solki_idn poikkeamat`() {
+        val solkiId = 999991
+        val toinenSolkiId = 999992
+
+        poikkeamaRepository.save(
+            YkiSuoritusPoikkeama(
+                solkiId = solkiId,
+                kentta = YkiSuoritusPoikkeama.SUORITUS_PUUTTUU_KITUSTA,
+                arvoKitussa = "",
+                arvoSolkissa = "Öhman-Testi Ranja Testi, YT, 2024-09-01",
+                havaittu = Instant.now(),
+                tutkintopaiva = LocalDate.of(2024, 9, 1),
+                tutkintokieli = Tutkintokieli.FIN,
+                tutkintotaso = Tutkintotaso.YT,
+            ),
+        )
+        poikkeamaRepository.save(
+            YkiSuoritusPoikkeama(
+                solkiId = solkiId,
+                kentta = "sukunimi",
+                arvoKitussa = "Vanha",
+                arvoSolkissa = "Öhman-Testi",
+                havaittu = Instant.now(),
+                tutkintopaiva = LocalDate.of(2024, 9, 1),
+                tutkintokieli = Tutkintokieli.FIN,
+                tutkintotaso = Tutkintotaso.YT,
+            ),
+        )
+        poikkeamaRepository.save(
+            YkiSuoritusPoikkeama(
+                solkiId = toinenSolkiId,
+                kentta = "sukunimi",
+                arvoKitussa = "Toinen",
+                arvoSolkissa = "Toisen Solki",
+                havaittu = Instant.now(),
+                tutkintopaiva = LocalDate.of(2024, 9, 1),
+                tutkintokieli = Tutkintokieli.FIN,
+                tutkintotaso = Tutkintotaso.YT,
+            ),
+        )
+
+        val suoritus =
+            Henkilosuoritus(
+                henkilo =
+                    Henkilo(
+                        oid = Oid.parse("1.2.246.562.24.20281155246").getOrThrow(),
+                        etunimet = "Ranja Testi",
+                        sukunimi = "Öhman-Testi",
+                        hetu = "010180-9026",
+                        sukupuoli = Sukupuoli.N,
+                        kansalaisuus = "EST",
+                        katuosoite = "Testikuja 5",
+                        postinumero = "40100",
+                        postitoimipaikka = "Testilä",
+                        email = "testi@testi.fi",
+                    ),
+                suoritus =
+                    YkiSuoritus(
+                        tutkintotaso = Tutkintotaso.YT,
+                        kieli = Tutkintokieli.FIN,
+                        todistuskieli = Todistuskieli.FIN,
+                        jarjestaja =
+                            YkiJarjestaja(
+                                oid = Oid.parse("1.2.246.562.10.14893989377").getOrThrow(),
+                                nimi = "Jyväskylän yliopisto, Soveltavan kielentutkimuksen keskus",
+                            ),
+                        tutkintopaiva = LocalDate.of(2024, 9, 1),
+                        arviointipaiva = LocalDate.of(2024, 12, 13),
+                        arviointitila = Arviointitila.ARVIOITU,
+                        osat =
+                            listOf(
+                                YkiOsa(tyyppi = TutkinnonOsa.puhuminen, arvosana = 5),
+                                YkiOsa(tyyppi = TutkinnonOsa.puheenYmmartaminen, arvosana = 5),
+                                YkiOsa(tyyppi = TutkinnonOsa.kirjoittaminen, arvosana = 5),
+                                YkiOsa(tyyppi = TutkinnonOsa.tekstinYmmartaminen, arvosana = 5),
+                                YkiOsa(tyyppi = TutkinnonOsa.rakenteetJaSanasto, arvosana = 5),
+                                YkiOsa(tyyppi = TutkinnonOsa.yleisarvosana, arvosana = 5),
+                            ),
+                        lahdejarjestelmanId =
+                            LahdejarjestelmanTunniste(
+                                id = solkiId.toString(),
+                                lahde = Lahdejarjestelma.Solki,
+                            ),
+                    ),
+            )
+
+        postSuoritus(suoritus) {
+            isOk()
+        }
+
+        val jaljella = poikkeamaRepository.findAll()
+        assertEquals(emptyList(), jaljella.filter { it.solkiId == solkiId })
+        assertEquals(1, jaljella.count { it.solkiId == toinenSolkiId })
     }
 
     @Test


### PR DESCRIPTION

Aiemmin poikkeamat poistuivat vain manuaalisesti poikkeamat-näkymän
kautta, jolloin jo ratkenneet havainnot jäivät näkyviin kunnes virkailija
kuittasi ne. Kun Solki POSTaa suorituksen /yki/api/suoritus-rajapintaan,
saman solki_id:n kaikki poikkeamat tyhjennetään saman tien.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
