### PR TITLE
OPHKOTO-153: Estä YKI-suoritusten KOSKI-siirto tuotannossa 22.6.2026 09:00 asti

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
@@ -5,6 +5,7 @@ import arrow.core.left
 import arrow.core.right
 import fi.oph.kitu.oid.Oid
 import fi.oph.kitu.tiedontuontischema.VktHenkilosuoritus
+import fi.oph.kitu.util.TimeService
 import fi.oph.kitu.util.result.getOrThrow
 import fi.oph.kitu.util.result.splitIntoValuesAndErrors
 import fi.oph.kitu.util.retry.RetryOutboundIntegration
@@ -14,6 +15,7 @@ import fi.oph.kitu.yki.suoritukset.YkiSuoritusEntity
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusRepository
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -32,6 +34,9 @@ class KoskiService(
     private val customVktSuoritusRepository: CustomVktSuoritusRepository,
     private val vktSuoritusService: VktSuoritusService,
     private val koskiErrors: KoskiErrorService,
+    private val timeService: TimeService,
+    @param:Value($$"${kitu.koski.yki.transferBlockedUntil:#{null}}")
+    private val ykiTransferBlockedUntil: LocalDateTime? = null,
 ) {
     @WithSpan
     @RetryOutboundIntegration
@@ -150,9 +155,17 @@ class KoskiService(
 
     @WithSpan
     fun sendYkiSuorituksetToKoski(): Either<KoskiTechnicalException, KoskiTransferReport> {
+        if (isYkiTransferBlocked()) {
+            return KoskiTransferReport(0, 0, blockedUntil = ykiTransferBlockedUntil).right()
+        }
         val suoritukset = ykiSuoritusRepository.findKoskeenLahettamattomatSuoritukset()
         val results = suoritukset.map { sendYkiSuoritusToKoski(it) }
         return reportErrors(results.map { it.map { suoritus -> YkiMappingId(suoritus.solkiId) } })
+    }
+
+    private fun isYkiTransferBlocked(): Boolean {
+        val blockedUntil = ykiTransferBlockedUntil ?: return false
+        return timeService.now().isBefore(blockedUntil.atZone(TimeService.zoneId).toInstant())
     }
 
     @WithSpan
@@ -210,12 +223,17 @@ data class KoskiTransferReport(
     val successfulTransfers: Int,
     val totalCount: Int,
     val timestamp: LocalDateTime = LocalDateTime.now(),
+    val blockedUntil: LocalDateTime? = null,
 ) {
     override fun toString(): String =
-        (
-            listOfNotNull(
-                "Viimeisin onnistunut eräajo: $timestamp",
-                "Siirretty $successfulTransfers / $totalCount",
-            )
-        ).joinToString("; ")
+        if (blockedUntil != null) {
+            "KOSKI-lähetys estetty $blockedUntil asti"
+        } else {
+            (
+                listOfNotNull(
+                    "Viimeisin onnistunut eräajo: $timestamp",
+                    "Siirretty $successfulTransfers / $totalCount",
+                )
+            ).joinToString("; ")
+        }
 }

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -29,6 +29,7 @@ kitu.koski.baseUrl=https://opintopolku.fi/koski/api/
 kitu.koski.scheduling.enabled=true
 kitu.koski.scheduling.yki.schedule=DAILY|02:30
 kitu.koski.scheduling.vkt.schedule=DAILY|01:00
+kitu.koski.yki.transferBlockedUntil=2026-06-22T09:00:00
 
 kitu.koodistopalvelu.baseUrl=https://koodisto.prod.koodisto.opintopolku.fi/koodisto-service/rest/
 

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
@@ -2,8 +2,10 @@ package fi.oph.kitu.koski
 
 import arrow.core.Either
 import fi.oph.kitu.DBContainerConfiguration
+import fi.oph.kitu.TestTimeService
 import fi.oph.kitu.auditlogs.OpenTelemetryTestConfig
 import fi.oph.kitu.dev.mockdata.generateRandomYkiSuoritusEntity
+import fi.oph.kitu.util.TimeService
 import fi.oph.kitu.util.result.getOrThrow
 import fi.oph.kitu.vkt.CustomVktSuoritusRepository
 import fi.oph.kitu.vkt.VktSuoritusRepository
@@ -29,6 +31,7 @@ import org.springframework.test.web.client.response.MockRestResponseCreators.wit
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 import org.springframework.web.client.RestClient
 import org.testcontainers.postgresql.PostgreSQLContainer
+import java.time.LocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -58,10 +61,14 @@ class KoskiServiceTest(
     @Autowired
     private lateinit var ykiService: YkiService
 
+    @Autowired
+    private lateinit var timeService: TestTimeService
+
     @BeforeEach
     fun nukeDb() {
         ykiSuoritusRepository.deleteAll()
         inMemorySpanExporter.reset()
+        timeService.resetClock()
     }
 
     @Test
@@ -88,6 +95,7 @@ class KoskiServiceTest(
                 customVktSuoritusRepository,
                 vktSuoritusService,
                 koskiErrorService,
+                timeService,
             )
 
         val updatedSuoritus = service.sendYkiSuoritusToKoski(suoritus).getOrThrow()
@@ -124,6 +132,7 @@ class KoskiServiceTest(
                 customVktSuoritusRepository,
                 vktSuoritusService,
                 koskiErrorService,
+                timeService,
             )
         val suoritus =
             generateRandomYkiSuoritusEntity().copy(id = 1)
@@ -155,6 +164,7 @@ class KoskiServiceTest(
                 customVktSuoritusRepository,
                 vktSuoritusService,
                 koskiErrorService,
+                timeService,
             )
 
         ykiSuoritusRepository.saveAllNewEntities(
@@ -202,6 +212,7 @@ class KoskiServiceTest(
                 customVktSuoritusRepository,
                 vktSuoritusService,
                 koskiErrorService,
+                timeService,
             )
 
         ykiSuoritusRepository.saveAllNewEntities(
@@ -236,6 +247,7 @@ class KoskiServiceTest(
                 customVktSuoritusRepository,
                 vktSuoritusService,
                 koskiErrorService,
+                timeService,
             )
 
         val invalid =
@@ -284,6 +296,7 @@ class KoskiServiceTest(
                 customVktSuoritusRepository,
                 vktSuoritusService,
                 koskiErrorService,
+                timeService,
             )
 
         val legacy =
@@ -339,6 +352,89 @@ class KoskiServiceTest(
         assertEquals(lahetetyt.map { it.solkiId }, listOf(viimeisinVersio.solkiId))
     }
 
+    @Test
+    fun `YKI-lähetys KOSKI-palveluun estetään kun blockedUntil on tulevaisuudessa`() {
+        val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
+        val blockedUntil = LocalDateTime.of(2026, 6, 22, 9, 0)
+
+        val service =
+            KoskiService(
+                mockRestClientBuilder.build(),
+                koskiYkiRequestMapper,
+                koskiVktRequestMapper,
+                ykiSuoritusRepository,
+                customVktSuoritusRepository,
+                vktSuoritusService,
+                koskiErrorService,
+                timeService,
+                ykiTransferBlockedUntil = blockedUntil,
+            )
+
+        ykiSuoritusRepository.saveAllNewEntities(listOf(generateRandomYkiSuoritusEntity()))
+
+        timeService.fixClock(
+            blockedUntil
+                .minusMinutes(1)
+                .atZone(TimeService.zoneId)
+                .toInstant(),
+        )
+
+        val report = service.sendYkiSuorituksetToKoski().getOrThrow()
+
+        assertEquals(0, report.successfulTransfers)
+        assertEquals(0, report.totalCount)
+        assertEquals(blockedUntil, report.blockedUntil)
+        assertTrue(report.toString().contains("estetty"))
+        assertTrue(report.toString().contains(blockedUntil.toString()))
+
+        val storedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
+        assertEquals(1, storedSuoritukset.size)
+        assertEquals(false, storedSuoritukset[0].koskiSiirtoKasitelty)
+
+        mockServer.verify()
+    }
+
+    @Test
+    fun `YKI-lähetys KOSKI-palveluun etenee kun blockedUntil on menneisyydessä`() {
+        val koskiResponse = successfulKoskiResponseFor("1.2.246.562.24.20281155246", 183424)
+        val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
+        mockServer
+            .expect(requestTo("oppija"))
+            .andRespond(withSuccess(koskiResponse, MediaType.APPLICATION_JSON))
+
+        val blockedUntil = LocalDateTime.of(2026, 6, 22, 9, 0)
+
+        val service =
+            KoskiService(
+                mockRestClientBuilder.build(),
+                koskiYkiRequestMapper,
+                koskiVktRequestMapper,
+                ykiSuoritusRepository,
+                customVktSuoritusRepository,
+                vktSuoritusService,
+                koskiErrorService,
+                timeService,
+                ykiTransferBlockedUntil = blockedUntil,
+            )
+
+        ykiSuoritusRepository.saveAllNewEntities(listOf(generateRandomYkiSuoritusEntity()))
+
+        timeService.fixClock(
+            blockedUntil
+                .plusMinutes(1)
+                .atZone(TimeService.zoneId)
+                .toInstant(),
+        )
+
+        val report = service.sendYkiSuorituksetToKoski().getOrThrow()
+
+        assertEquals(1, report.successfulTransfers)
+        assertEquals(1, report.totalCount)
+        assertEquals(null, report.blockedUntil)
+
+        mockServer.verify()
+    }
+
     private fun setupKoskiMock(response: String): KoskiService {
         val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
         mockServer
@@ -358,6 +454,7 @@ class KoskiServiceTest(
             customVktSuoritusRepository,
             vktSuoritusService,
             koskiErrorService,
+            timeService,
         )
     }
 


### PR DESCRIPTION

Lisää konfiguroitava kitu.koski.yki.transferBlockedUntil-aikaleima, jonka
ollessa tulevaisuudessa KoskiService.sendYkiSuorituksetToKoski palauttaa
heti ilman repository- tai KOSKI-kutsuja. Aika tulkitaan Europe/Helsinki-
vyöhykkeessä TimeService-abstraktion kautta.

Tuotannossa estoa pidetään voimassa 2026-06-22T09:00:00 asti; muissa
ympäristöissä (local, untuva, qa) ominaisuutta ei aseteta, joten siirrot
etenevät normaalisti integraation testausta varten.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
