### PR TITLE
Päästä OPHTesti-suoritukset KOSKI-lähetyksen tulpasta läpi

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/koski/KoskiService.kt
@@ -155,12 +155,16 @@ class KoskiService(
 
     @WithSpan
     fun sendYkiSuorituksetToKoski(): Either<KoskiTechnicalException, KoskiTransferReport> {
-        if (isYkiTransferBlocked()) {
-            return KoskiTransferReport(0, 0, blockedUntil = ykiTransferBlockedUntil).right()
-        }
-        val suoritukset = ykiSuoritusRepository.findKoskeenLahettamattomatSuoritukset()
+        val transferBlocked = isYkiTransferBlocked()
+        val suoritukset =
+            ykiSuoritusRepository
+                .findKoskeenLahettamattomatSuoritukset()
+                .filter { !transferBlocked || it.isOphTesti() }
         val results = suoritukset.map { sendYkiSuoritusToKoski(it) }
-        return reportErrors(results.map { it.map { suoritus -> YkiMappingId(suoritus.solkiId) } })
+        return reportErrors(
+            results.map { it.map { suoritus -> YkiMappingId(suoritus.solkiId) } },
+            blockedUntil = ykiTransferBlockedUntil.takeIf { transferBlocked },
+        )
     }
 
     private fun isYkiTransferBlocked(): Boolean {
@@ -202,6 +206,7 @@ class KoskiService(
 
     private inline fun <reified T : KoskiErrorMappingId> reportErrors(
         results: List<Either<KoskiException, T>?>,
+        blockedUntil: LocalDateTime? = null,
     ): Either<KoskiTechnicalException, KoskiTransferReport> {
         val (success, failed) = results.filterNotNull().splitIntoValuesAndErrors()
         success.forEach { id -> koskiErrors.reset(id) }
@@ -215,6 +220,7 @@ class KoskiService(
         return KoskiTransferReport(
             success.size,
             results.size,
+            blockedUntil = blockedUntil,
         ).right()
     }
 }
@@ -225,15 +231,16 @@ data class KoskiTransferReport(
     val timestamp: LocalDateTime = LocalDateTime.now(),
     val blockedUntil: LocalDateTime? = null,
 ) {
-    override fun toString(): String =
-        if (blockedUntil != null) {
-            "KOSKI-lähetys estetty $blockedUntil asti"
-        } else {
-            (
-                listOfNotNull(
-                    "Viimeisin onnistunut eräajo: $timestamp",
-                    "Siirretty $successfulTransfers / $totalCount",
-                )
+    override fun toString(): String {
+        val eraajo =
+            listOf(
+                "Viimeisin onnistunut eräajo: $timestamp",
+                "Siirretty $successfulTransfers / $totalCount",
             ).joinToString("; ")
+        return if (blockedUntil != null) {
+            "KOSKI-lähetys estetty $blockedUntil asti; $eraajo"
+        } else {
+            eraajo
         }
+    }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/tiedontuontischema/Lahdejarjestelmallinen.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/tiedontuontischema/Lahdejarjestelmallinen.kt
@@ -12,6 +12,8 @@ data class LahdejarjestelmanTunniste(
 ) {
     override fun toString() = "$lahde:$id"
 
+    fun toTunnus() = "${lahde.tunnusPrefix}.$id"
+
     companion object {
         fun from(s: String): LahdejarjestelmanTunniste {
             val tokens = s.split(":", limit = 2)
@@ -26,9 +28,17 @@ data class LahdejarjestelmanTunniste(
     }
 }
 
-enum class Lahdejarjestelma {
-    KIOS,
-    Solki,
-    OPHTesti,
-    Unknown,
+enum class Lahdejarjestelma(
+    val tunnusPrefix: String,
+) {
+    KIOS("kios"),
+    Solki("yki"),
+    OPHTesti("ophtesti"),
+    Unknown("tuntematon"),
+    ;
+
+    companion object {
+        fun ofTunnus(tunnus: String): Lahdejarjestelma =
+            entries.firstOrNull { tunnus.startsWith("${it.tunnusPrefix}.") } ?: Unknown
+    }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusEntity.kt
@@ -5,6 +5,7 @@ import fi.oph.kitu.jdbc.getTypedArrayOrNull
 import fi.oph.kitu.koodisto.Koodisto
 import fi.oph.kitu.oid.Oid
 import fi.oph.kitu.tiedontuontischema.Henkilosuoritus
+import fi.oph.kitu.tiedontuontischema.Lahdejarjestelma
 import fi.oph.kitu.tiedontuontischema.YkiSuoritus
 import fi.oph.kitu.util.IgnoreForEquality
 import fi.oph.kitu.util.result.getOrThrow
@@ -95,6 +96,8 @@ data class YkiSuoritusEntity(
             TutkinnonOsa.RS -> rakenteetJaSanasto
             TutkinnonOsa.YL -> yleisarvosana
         }
+
+    fun isOphTesti(): Boolean = Lahdejarjestelma.ofTunnus(lahdejarjestelmanTunnus) == Lahdejarjestelma.OPHTesti
 
     fun tarkistusarviointiHyvaksyttyViewText(): String? =
         tarkistusarviointiHyvaksyttyPvm?.finnishDate()
@@ -217,6 +220,7 @@ data class YkiSuoritusEntity(
                     arviointitila = arviointitila,
                     arviointitilaLahetetty = null,
                     arviointitilanLahetysvirhe = null,
+                    lahdejarjestelmanTunnus = lahdejarjestelmanId.toTunnus(),
                 )
             }
         }

--- a/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/koski/KoskiServiceTest.kt
@@ -5,6 +5,8 @@ import fi.oph.kitu.DBContainerConfiguration
 import fi.oph.kitu.TestTimeService
 import fi.oph.kitu.auditlogs.OpenTelemetryTestConfig
 import fi.oph.kitu.dev.mockdata.generateRandomYkiSuoritusEntity
+import fi.oph.kitu.tiedontuontischema.Lahdejarjestelma
+import fi.oph.kitu.tiedontuontischema.LahdejarjestelmanTunniste
 import fi.oph.kitu.util.TimeService
 import fi.oph.kitu.util.result.getOrThrow
 import fi.oph.kitu.vkt.CustomVktSuoritusRepository
@@ -431,6 +433,60 @@ class KoskiServiceTest(
         assertEquals(1, report.successfulTransfers)
         assertEquals(1, report.totalCount)
         assertEquals(null, report.blockedUntil)
+
+        mockServer.verify()
+    }
+
+    @Test
+    fun `OPHTesti-suoritus lähetetään KOSKI-palveluun vaikka muiden lähetys on estetty`() {
+        val ophTestiSuoritus =
+            generateRandomYkiSuoritusEntity()
+                .copy(
+                    lahdejarjestelmanTunnus =
+                        LahdejarjestelmanTunniste("123456", Lahdejarjestelma.OPHTesti).toTunnus(),
+                )
+        val solkiSuoritus = generateRandomYkiSuoritusEntity()
+
+        val mockServer = MockRestServiceServer.bindTo(mockRestClientBuilder).build()
+        mockServer
+            .expect(requestTo("oppija"))
+            .andRespond(withSuccess(successfulKoskiResponseFor(ophTestiSuoritus), MediaType.APPLICATION_JSON))
+
+        val blockedUntil = LocalDateTime.of(2026, 6, 22, 9, 0)
+
+        val service =
+            KoskiService(
+                mockRestClientBuilder.build(),
+                koskiYkiRequestMapper,
+                koskiVktRequestMapper,
+                ykiSuoritusRepository,
+                customVktSuoritusRepository,
+                vktSuoritusService,
+                koskiErrorService,
+                timeService,
+                ykiTransferBlockedUntil = blockedUntil,
+            )
+
+        ykiSuoritusRepository.saveAllNewEntities(listOf(ophTestiSuoritus, solkiSuoritus))
+
+        timeService.fixClock(
+            blockedUntil
+                .minusMinutes(1)
+                .atZone(TimeService.zoneId)
+                .toInstant(),
+        )
+
+        val report = service.sendYkiSuorituksetToKoski().getOrThrow()
+
+        assertEquals(1, report.successfulTransfers)
+        assertEquals(1, report.totalCount)
+        assertEquals(blockedUntil, report.blockedUntil)
+        assertTrue(report.toString().contains("estetty"))
+        assertTrue(report.toString().contains("Siirretty 1 / 1"))
+
+        val storedSuoritukset = ykiService.allSuoritukset(versionHistory = false)
+        assertEquals(true, storedSuoritukset.first { it.isOphTesti() }.koskiSiirtoKasitelty)
+        assertEquals(false, storedSuoritukset.first { !it.isOphTesti() }.koskiSiirtoKasitelty)
 
         mockServer.verify()
     }

--- a/server/src/test/kotlin/fi/oph/kitu/tiedontuontischema/LahdejarjestelmallinenTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/tiedontuontischema/LahdejarjestelmallinenTest.kt
@@ -1,0 +1,26 @@
+package fi.oph.kitu.tiedontuontischema
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LahdejarjestelmallinenTest {
+    @Test
+    fun `toTunnus tuottaa lahdejarjestelman prefiksin ja idn`() {
+        assertEquals("yki.123", LahdejarjestelmanTunniste("123", Lahdejarjestelma.Solki).toTunnus())
+        assertEquals("ophtesti.123", LahdejarjestelmanTunniste("123", Lahdejarjestelma.OPHTesti).toTunnus())
+        assertEquals("kios.abc", LahdejarjestelmanTunniste("abc", Lahdejarjestelma.KIOS).toTunnus())
+    }
+
+    @Test
+    fun `ofTunnus tunnistaa lahdejarjestelman prefiksista`() {
+        assertEquals(Lahdejarjestelma.OPHTesti, Lahdejarjestelma.ofTunnus("ophtesti.123"))
+        assertEquals(Lahdejarjestelma.KIOS, Lahdejarjestelma.ofTunnus("kios.123"))
+        assertEquals(Lahdejarjestelma.Solki, Lahdejarjestelma.ofTunnus("yki.123456"))
+    }
+
+    @Test
+    fun `ofTunnus palauttaa Unknown tuntemattomalle prefiksille`() {
+        assertEquals(Lahdejarjestelma.Unknown, Lahdejarjestelma.ofTunnus("foo.123"))
+        assertEquals(Lahdejarjestelma.Unknown, Lahdejarjestelma.ofTunnus("123"))
+    }
+}


### PR DESCRIPTION
YKI-suoritusten lähetys KOSKI-palveluun on estetty tuotannossa 2026-06-22 asti. Lisätään poikkeus: OPHTesti-lähdejärjestelmästä tulleet suoritukset lähetetään myös eston aikana, jotta integraatio voidaan testata päästä päähän ennen tulpan aukeamista.

Tähän asti OPHTesti-suorituksia ei voinut erottaa muista: YkiSuoritusEntity tallensi jokaiselle suoritukselle lahdejarjestelmanTunnukseksi "yki.<solkiId>" ja hukkasi lähdejärjestelmän. Tehdään lähdejärjestelmästä pysyvä ja tunnistettava tallentamalla tunnuksen prefix Lahdejarjestelma-enumiin ("yki" varataan Solkille, jotta olemassa olevat rivit ja niiden KOSKI-lähdejärjestelmänId säilyvät ennallaan).

- LahdejarjestelmanTunniste.toTunnus() / Lahdejarjestelma.ofTunnus(): muunnos prefiksin ja idn välillä (VktSuoritusEntityn käyttämä toString()/from() jätetään koskematta)
- YkiSuoritusEntity.from() tallentaa tunnuksen prefiksillä + isOphTesti()-apuri
- KoskiService.sendYkiSuorituksetToKoski() suodattaa eston aikana vain OPHTesti-suoritukset läpi; raportti näyttää sekä eston että siirtomäärät