### PR TITLE
OPHKOTO-154: Tunnista virheellinen tehtäväpankki-XML latauksessa äläkä tallenna S3:een

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiClientImpl.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiClientImpl.kt
@@ -2,6 +2,8 @@ package fi.oph.kitu.kotoutumiskoulutus.koealusta.tehtavapankki
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.oph.kitu.restclient.withJacksonStreamMaxStringLength
+import fi.oph.kitu.util.defaultObjectMapper
+import fi.oph.kitu.util.toJsonNode
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.springframework.beans.factory.annotation.Value
@@ -12,6 +14,9 @@ import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.toEntity
 import org.springframework.web.util.UriComponentsBuilder
+import tools.jackson.databind.JsonNode
+import java.io.BufferedInputStream
+import java.io.InputStream
 import java.net.URI
 import java.nio.file.Files
 import java.time.Instant
@@ -37,7 +42,7 @@ class TehtavapankkiClientImpl(
     @WithSpan
     override fun listQuestionBanks(): List<QuestionBankMetadata> {
         Span.current().setAttribute("function", "local_completion_export_export_question_bank")
-        val raw =
+        val tree =
             restClient
                 .get()
                 .uri(
@@ -48,8 +53,14 @@ class TehtavapankkiClientImpl(
                     ),
                 ).accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .toEntity<RawTehtavapankkiResponse>()
-                .body!!
+                .toEntity<JsonNode>()
+                .body
+                ?: throw TehtavapankkiDownloadException("Tehtäväpankkilistan haku palautti tyhjän vastauksen")
+        if (!tree.has("questionbanks")) {
+            val detail = moodleErrorDetail(tree) ?: tree.toString().take(200)
+            throw TehtavapankkiDownloadException("Tehtäväpankkilistan haku epäonnistui: $detail")
+        }
+        val raw = defaultObjectMapper.treeToValue(tree, RawTehtavapankkiResponse::class.java)
         return raw.questionbanks.map { qb ->
             QuestionBankMetadata(
                 courseId = qb.courseid,
@@ -88,8 +99,11 @@ class TehtavapankkiClientImpl(
                             null,
                         )
                     }
-                    response.body.use { input ->
-                        Files.newOutputStream(this).use { out -> input.copyTo(out) }
+                    response.body.buffered().use { body ->
+                        if (!startsWithXml(body)) {
+                            throw nonXmlDownloadException(uri, body)
+                        }
+                        Files.newOutputStream(this).use { out -> body.copyTo(out) }
                     }
                 }
             } catch (e: Throwable) {
@@ -97,6 +111,49 @@ class TehtavapankkiClientImpl(
                 throw e
             }
         }
+
+    private fun startsWithXml(input: BufferedInputStream): Boolean {
+        val limit = 64
+        input.mark(limit)
+        try {
+            var b = input.read()
+            var read = 1
+            if (b == 0xEF) {
+                val b2 = input.read()
+                val b3 = input.read()
+                read += 2
+                if (b2 != 0xBB || b3 != 0xBF) return false
+                b = input.read()
+                read++
+            }
+            while (read < limit && (b == ' '.code || b == '\t'.code || b == '\n'.code || b == '\r'.code)) {
+                b = input.read()
+                read++
+            }
+            return b == '<'.code
+        } finally {
+            input.reset()
+        }
+    }
+
+    private fun nonXmlDownloadException(
+        uri: URI,
+        body: InputStream,
+    ): TehtavapankkiDownloadException {
+        val snippet = body.readNBytes(2_000).toString(Charsets.UTF_8)
+        val detail = moodleErrorDetail(snippet.toJsonNode()) ?: snippet.take(200)
+        return TehtavapankkiDownloadException("Tehtäväpankin XML-lataus ($uri) palautti ei-XML-sisältöä: $detail")
+    }
+
+    private fun moodleErrorDetail(node: JsonNode): String? {
+        val errorcode = node.get("errorcode")?.takeIf { it.isValueNode }?.asString()
+        val message =
+            node.get("error")?.takeIf { it.isValueNode }?.asString()
+                ?: node.get("message")?.takeIf { it.isValueNode }?.asString()
+        return listOfNotNull(errorcode?.let { "errorcode=$it" }, message)
+            .joinToString(" ")
+            .ifBlank { null }
+    }
 
     private data class RawTehtavapankkiResponse(
         @param:JsonProperty("questionbanks")

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiDownloadException.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiDownloadException.kt
@@ -1,0 +1,19 @@
+package fi.oph.kitu.kotoutumiskoulutus.koealusta.tehtavapankki
+
+/**
+ * Heitetään kun Koealustan lataus- tai listausvastaus ei ole odotettua XML:ää
+ * (esim. Moodle palauttaa HTTP 200:lla JSON-virheen). Estää virheellisen sisällön
+ * tallentumisen S3:een.
+ */
+class TehtavapankkiDownloadException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+/**
+ * Heitetään ajon lopuksi kun yksikin kurssi epäonnistui latauksessa tai ingestissä,
+ * jotta ajastettu tehtävä menee FAILED-tilaan vaikka terveet kurssit käsiteltiin.
+ */
+class TehtavapankkiImportException(
+    message: String,
+) : RuntimeException(message)

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiIngestService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiIngestService.kt
@@ -34,6 +34,63 @@ class TehtavapankkiIngestService(
     private val repository: TehtavapankkiRepository,
 ) {
     /**
+     * Ajastetun tehtävän kokonaisuus: lataa tehtäväpankit S3:een, siivoaa
+     * duplikaatit ja ingestoi kunkin kurssin uusimman XML:n tietokantaan.
+     * Vialliset kurssit ohitetaan, mutta jos yksikin lataus tai ingest
+     * epäonnistui, heitetään lopuksi [TehtavapankkiImportException] jotta
+     * tehtävä menee FAILED-tilaan.
+     */
+    @WithSpan
+    fun importAndIngest() {
+        val downloadFailures = tehtavapankkiService.importTehtavapankki()
+        // Tuoreelle siirrolle ei tule uutta avainta jos sisältö on
+        // ennallaan: poistetaan kunkin kurssin sisällä saman sisältöiset
+        // objektit jotta bucket ei kasva turhaan.
+        tehtavapankkiService.removeDuplicates()
+        // Käydään kunkin kurssin uusimmat XML:t läpi: puretaan upotetut
+        // <file>-blobit erillisiksi S3-objekteiksi (mp3-/png-assetit) ja
+        // tallennetaan parsittu sisältö yleiseen tehtäväpankki-skeemaan.
+        val ingestFailures =
+            tehtavapankkiService
+                .listTehtavapaketit()
+                .values
+                .mapNotNull { it.firstOrNull() }
+                .mapNotNull { obj ->
+                    tehtavapankkiService.extractAndUploadAssets(obj.key)
+                    ingestFromS3(obj.key).leftOrNull()?.let { obj.key to it }
+                }
+
+        Span.current().setAttribute("import.download_failures", downloadFailures.size.toLong())
+        Span.current().setAttribute("import.ingest_failures", ingestFailures.size.toLong())
+
+        if (downloadFailures.isNotEmpty() || ingestFailures.isNotEmpty()) {
+            throw TehtavapankkiImportException(failureMessage(downloadFailures, ingestFailures))
+        }
+    }
+
+    private fun failureMessage(
+        downloadFailures: List<TehtavapankkiDownloadFailure>,
+        ingestFailures: List<Pair<String, TehtavapankkiParseError>>,
+    ): String {
+        val parts = mutableListOf<String>()
+        if (downloadFailures.isNotEmpty()) {
+            parts += "latausvirheet=" + downloadFailures.joinToString("; ") { "kurssi ${it.courseId}: ${it.reason}" }
+        }
+        if (ingestFailures.isNotEmpty()) {
+            parts +=
+                "ingest-virheet=" + ingestFailures.joinToString("; ") { (key, error) -> "$key: ${error.describe()}" }
+        }
+        return "Tehtäväpankin tuonti epäonnistui (${parts.joinToString(", ")})"
+    }
+
+    private fun TehtavapankkiParseError.describe(): String =
+        when (this) {
+            is TehtavapankkiParseError.NotFound -> "ei löytynyt"
+            is TehtavapankkiParseError.InvalidXml -> "virheellinen XML: ${cause.message ?: cause::class.simpleName}"
+            is TehtavapankkiParseError.IO -> "IO-virhe: ${cause.message ?: cause::class.simpleName}"
+        }
+
+    /**
      * Lataa S3:sta löytyvän XML-tiedoston, parsii sen ja tallentaa yleiseen
      * tehtäväpankki-skeemaan (tehtavapaketti / tehtava / tehtava_vastaus /
      * tehtava_tiedosto). Versio_hash lasketaan raakojen tavujen SHA-256:sta,

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiScheduledTasks.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiScheduledTasks.kt
@@ -19,29 +19,11 @@ class TehtavapankkiScheduledTasks(
     var tehtavapankkiImportSchedule: String? = null
 
     @Bean
-    fun importKotoTehtavapankki(
-        tehtavapankkiService: TehtavapankkiService,
-        ingestService: TehtavapankkiIngestService,
-    ): Task<Void> =
+    fun importKotoTehtavapankki(ingestService: TehtavapankkiIngestService): Task<Void> =
         tracer.recurringTask(
             "Kotoutumiskoulutuksen kielitaidon tehtäväpankin lataus",
             tehtavapankkiImportSchedule!!,
         ) {
-            tehtavapankkiService.importTehtavapankki()
-            // Tuoreelle siirrolle ei tule uutta avainta jos sisältö on
-            // ennallaan: poistetaan kunkin kurssin sisällä saman sisältöiset
-            // objektit jotta bucket ei kasva turhaan.
-            tehtavapankkiService.removeDuplicates()
-            // Käydään kunkin kurssin uusimmat XML:t läpi: puretaan upotetut
-            // <file>-blobit erillisiksi S3-objekteiksi (mp3-/png-assetit) ja
-            // tallennetaan parsittu sisältö yleiseen tehtäväpankki-skeemaan.
-            tehtavapankkiService
-                .listTehtavapaketit()
-                .values
-                .mapNotNull { it.firstOrNull() }
-                .forEach {
-                    tehtavapankkiService.extractAndUploadAssets(it.key)
-                    ingestService.ingestFromS3(it.key)
-                }
+            ingestService.importAndIngest()
         }
 }

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
@@ -105,11 +105,13 @@ class TehtavapankkiService(
     }
 
     @WithSpan
-    fun importTehtavapankki() {
+    fun importTehtavapankki(): List<TehtavapankkiDownloadFailure> {
         val metas = client.listQuestionBanks()
         var skipped = 0
-        val downloads =
-            metas.mapNotNull { meta ->
+        val downloads = mutableListOf<QuestionBankDownload>()
+        val failures = mutableListOf<TehtavapankkiDownloadFailure>()
+        try {
+            metas.forEach { meta ->
                 val prev =
                     repository.findLatestFilegeneratedBySource(
                         TehtavapankkiIngestService.LAHDEJARJESTELMA,
@@ -117,15 +119,24 @@ class TehtavapankkiService(
                     )
                 if (prev != null && prev.toInstant() == meta.generated) {
                     skipped++
-                    null
                 } else {
-                    QuestionBankDownload(meta, client.downloadXml(meta))
+                    try {
+                        downloads += QuestionBankDownload(meta, client.downloadXml(meta))
+                    } catch (e: TehtavapankkiDownloadException) {
+                        failures += TehtavapankkiDownloadFailure(meta.courseId, e.message ?: "lataus epäonnistui")
+                    }
                 }
             }
+        } catch (e: Throwable) {
+            downloads.forEach { runCatching { it.close() } }
+            throw e
+        }
         Span.current().setAttribute("tehtavapankki.metas.count", metas.size.toLong())
         Span.current().setAttribute("tehtavapankki.skipped.count", skipped.toLong())
         Span.current().setAttribute("tehtavapankki.downloaded.count", downloads.size.toLong())
+        Span.current().setAttribute("tehtavapankki.failed.count", failures.size.toLong())
         uploadTehtavapankki(downloads)
+        return failures
     }
 
     @WithSpan
@@ -283,6 +294,11 @@ data class QuestionBankDownload(
 ) : AutoCloseable {
     override fun close() = xml.close()
 }
+
+data class TehtavapankkiDownloadFailure(
+    val courseId: Int,
+    val reason: String,
+)
 
 data class TehtavapakettiObject(
     val key: String,

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiClientImplTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiClientImplTest.kt
@@ -9,6 +9,7 @@ import org.springframework.test.web.client.response.MockRestResponseCreators.wit
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientResponseException
 import java.time.Instant
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
@@ -89,5 +90,105 @@ class TehtavapankkiClientImplTest {
         assertFailsWith<RestClientResponseException> {
             client.downloadXml(meta)
         }
+    }
+
+    @Test
+    fun `downloadXml heittaa kun XML-latausvastaus on Moodlen JSON-virhe`() {
+        val builder = RestClient.builder()
+        val mockServer = MockRestServiceServer.bindTo(builder).build()
+        mockServer
+            .expect(requestTo("https://example.test/koto/pluginfile.php/9/qb.xml?token=testitoken"))
+            .andRespond(
+                withSuccess(
+                    """{"error":"Pääsyn hallinnan poikkeus","errorcode":"accessexception","stacktrace":null,"debuginfo":null,"reproductionlink":null}""",
+                    MediaType.APPLICATION_JSON,
+                ),
+            )
+
+        val client =
+            TehtavapankkiClientImpl(builder).apply {
+                koealustaToken = "testitoken"
+                koealustaBaseUrl = "https://example.test/koto"
+            }
+
+        val meta =
+            QuestionBankMetadata(
+                courseId = 9,
+                courseName = "Suomi virheellinen",
+                published = Instant.ofEpochMilli(0),
+                generated = Instant.ofEpochMilli(0),
+                version = "v1",
+                language = "fin",
+                downloadUrl = "https://example.test/koto/pluginfile.php/9/qb.xml",
+            )
+
+        val ex =
+            assertFailsWith<TehtavapankkiDownloadException> {
+                client.downloadXml(meta)
+            }
+        assertContains(ex.message!!, "accessexception")
+    }
+
+    @Test
+    fun `downloadXml onnistuu kun runko on XML BOMilla ja alku-whitespacella`() {
+        val builder = RestClient.builder()
+        val mockServer = MockRestServiceServer.bindTo(builder).build()
+        val xml = "\uFEFF\n  <?xml version=\"1.0\"?><questions><q id=\"a\"/></questions>"
+        mockServer
+            .expect(requestTo("https://example.test/koto/pluginfile.php/9/qb.xml?token=testitoken"))
+            .andRespond(withSuccess(xml, MediaType.APPLICATION_XML))
+
+        val client =
+            TehtavapankkiClientImpl(builder).apply {
+                koealustaToken = "testitoken"
+                koealustaBaseUrl = "https://example.test/koto"
+            }
+
+        val meta =
+            QuestionBankMetadata(
+                courseId = 9,
+                courseName = "Suomi",
+                published = Instant.ofEpochMilli(0),
+                generated = Instant.ofEpochMilli(0),
+                version = "v1",
+                language = "fin",
+                downloadUrl = "https://example.test/koto/pluginfile.php/9/qb.xml",
+            )
+
+        client.downloadXml(meta).use { source ->
+            val content = source.openStream().use { it.readBytes().toString(Charsets.UTF_8) }
+            assertEquals(xml, content)
+        }
+    }
+
+    @Test
+    fun `listQuestionBanks heittaa kun vastaus on Moodlen JSON-virhe`() {
+        val builder = RestClient.builder()
+        val mockServer = MockRestServiceServer.bindTo(builder).build()
+        mockServer
+            .expect(
+                requestTo(
+                    "https://example.test/koto/webservice/rest/server.php?" +
+                        "wstoken=testitoken&moodlewsrestformat=json&" +
+                        "wsfunction=local_completion_export_export_question_bank",
+                ),
+            ).andRespond(
+                withSuccess(
+                    """{"error":"Pääsyn hallinnan poikkeus","errorcode":"accessexception","stacktrace":null,"debuginfo":null,"reproductionlink":null}""",
+                    MediaType.APPLICATION_JSON,
+                ),
+            )
+
+        val client =
+            TehtavapankkiClientImpl(builder).apply {
+                koealustaToken = "testitoken"
+                koealustaBaseUrl = "https://example.test/koto"
+            }
+
+        val ex =
+            assertFailsWith<TehtavapankkiDownloadException> {
+                client.listQuestionBanks()
+            }
+        assertContains(ex.message!!, "accessexception")
     }
 }

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiServiceTest.kt
@@ -8,6 +8,7 @@ import fi.oph.kitu.tehtavapankki.TehtavapakettiEntity
 import fi.oph.kitu.tehtavapankki.TehtavapankkiRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
@@ -17,7 +18,9 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withServerError
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClientResponseException
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import java.net.URI
@@ -26,7 +29,9 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.Base64
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -35,13 +40,22 @@ import kotlin.test.assertTrue
 @SpringBootTest
 @Import(DBContainerConfiguration::class, LocalStackContainerConfiguration::class)
 @TestPropertySource(properties = ["spring.cloud.aws.s3.enabled=true"])
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TehtavapankkiServiceTest(
     @param:Autowired private val tehtavapankkiService: TehtavapankkiService,
+    @param:Autowired private val ingestService: TehtavapankkiIngestService,
     @param:Autowired private val tehtavapankkiClient: TehtavapankkiClientImpl,
     @param:Autowired private val s3Client: S3Client,
     @param:Autowired private val repository: TehtavapankkiRepository,
     @param:Autowired private val jdbc: JdbcTemplate,
 ) {
+    // Yksi MockRestServiceServer per jaettu Spring-konteksti: clientin restClient
+    // rakennetaan laiskasti vain kerran, joten sidonta on tehtävä ennen ensimmäistä
+    // client-kutsua ja jaettava kaikkien testien kesken reset()-pohjaisesti.
+    private val mockServer: MockRestServiceServer by lazy {
+        MockRestServiceServer.bindTo(tehtavapankkiClient.restClientBuilder).build()
+    }
+
     @BeforeEach
     fun reset() {
         s3Client
@@ -51,7 +65,36 @@ class TehtavapankkiServiceTest(
                 s3Client.deleteObject { it.bucket(TEST_BUCKET).key(obj.key()) }
             }
         jdbc.execute("DELETE FROM tehtavapaketti")
+        tehtavapankkiClient.koealustaToken = "testitoken"
+        tehtavapankkiClient.koealustaBaseUrl = "https://localhost:8080/dev/koto"
+        mockServer.reset()
     }
+
+    private val listResponse =
+        """
+        {
+          "questionbanks": [
+            {
+              "courseid": 7,
+              "coursename": "Suomi 2",
+              "coursestartdate": 0,
+              "filegenerated": 1733400000,
+              "questionbankversion": "v1",
+              "language": "fin",
+              "downloadurl": "https://localhost:8080/dev/koto/pluginfile.php/7/qb.xml"
+            },
+            {
+              "courseid": 8,
+              "coursename": "Suomi 3",
+              "coursestartdate": 0,
+              "filegenerated": 1733400001,
+              "questionbankversion": "v1",
+              "language": "fin",
+              "downloadurl": "https://localhost:8080/dev/koto/pluginfile.php/8/qb.xml"
+            }
+          ]
+        }
+        """.trimIndent()
 
     @Test
     fun `uploadTehtavapankki kirjoittaa tiedostot S3-buckettiin filegenerated-suffiksilla ja user metadatan`() {
@@ -146,7 +189,6 @@ class TehtavapankkiServiceTest(
             ),
         )
 
-        val mockServer = MockRestServiceServer.bindTo(tehtavapankkiClient.restClientBuilder).build()
         mockServer
             .expect(
                 requestTo(
@@ -154,35 +196,7 @@ class TehtavapankkiServiceTest(
                         "wstoken=testitoken&moodlewsrestformat=json&" +
                         "wsfunction=local_completion_export_export_question_bank",
                 ),
-            ).andRespond(
-                withSuccess(
-                    """
-                    {
-                      "questionbanks": [
-                        {
-                          "courseid": 7,
-                          "coursename": "Suomi 2",
-                          "coursestartdate": 0,
-                          "filegenerated": 1733400000,
-                          "questionbankversion": "v1",
-                          "language": "fin",
-                          "downloadurl": "https://localhost:8080/dev/koto/pluginfile.php/7/qb.xml"
-                        },
-                        {
-                          "courseid": 8,
-                          "coursename": "Suomi 3",
-                          "coursestartdate": 0,
-                          "filegenerated": 1733400001,
-                          "questionbankversion": "v1",
-                          "language": "fin",
-                          "downloadurl": "https://localhost:8080/dev/koto/pluginfile.php/8/qb.xml"
-                        }
-                      ]
-                    }
-                    """.trimIndent(),
-                    MediaType.APPLICATION_JSON,
-                ),
-            )
+            ).andRespond(withSuccess(listResponse, MediaType.APPLICATION_JSON))
         // Vain courseid=8:n latauksen pitäisi tapahtua — courseid=7 skipataan
         // ennen pluginfile.php-kutsua.
         mockServer
@@ -190,9 +204,6 @@ class TehtavapankkiServiceTest(
             .andRespond(
                 withSuccess("<questions><q id=\"b\"/></questions>", MediaType.APPLICATION_XML),
             )
-
-        tehtavapankkiClient.koealustaToken = "testitoken"
-        tehtavapankkiClient.koealustaBaseUrl = "https://localhost:8080/dev/koto"
 
         tehtavapankkiService.importTehtavapankki()
 
@@ -221,6 +232,123 @@ class TehtavapankkiServiceTest(
                 .readAllBytes()
                 .toString(Charsets.UTF_8)
         assertEquals("<questions><q id=\"b\"/></questions>", suomi3Content)
+    }
+
+    @Test
+    fun `importTehtavapankki ohittaa ei-XML-vastauksen mutta vie terveen kurssin S3-ageen`() {
+        mockServer
+            .expect(
+                requestTo(
+                    "https://localhost:8080/dev/koto/webservice/rest/server.php?" +
+                        "wstoken=testitoken&moodlewsrestformat=json&" +
+                        "wsfunction=local_completion_export_export_question_bank",
+                ),
+            ).andRespond(withSuccess(listResponse, MediaType.APPLICATION_JSON))
+        mockServer
+            .expect(requestTo("https://localhost:8080/dev/koto/pluginfile.php/7/qb.xml?token=testitoken"))
+            .andRespond(withSuccess("<questions><q id=\"a\"/></questions>", MediaType.APPLICATION_XML))
+        mockServer
+            .expect(requestTo("https://localhost:8080/dev/koto/pluginfile.php/8/qb.xml?token=testitoken"))
+            .andRespond(
+                withSuccess(
+                    """{"error":"Pääsyn hallinnan poikkeus","errorcode":"accessexception","stacktrace":null,"debuginfo":null,"reproductionlink":null}""",
+                    MediaType.APPLICATION_JSON,
+                ),
+            )
+
+        val failures = tehtavapankkiService.importTehtavapankki()
+
+        mockServer.verify()
+
+        assertEquals(1, failures.size, "Vain courseid=8:n pitäisi epäonnistua")
+        assertEquals(8, failures.single().courseId)
+        assertContains(failures.single().reason, "accessexception")
+
+        val keys =
+            s3Client
+                .listObjectsV2 { it.bucket(TEST_BUCKET) }
+                .contents()
+                .map { it.key() }
+        assertEquals(1, keys.size, "Vain terveen courseid=7:n pitäisi olla S3:ssa, oli: $keys")
+        assertTrue(keys.single().startsWith("7-Suomi_2/"), "Avaimen pitäisi olla courseid=7, oli: ${keys.single()}")
+    }
+
+    @Test
+    fun `importTehtavapankki kaatuu valittomasti eika vie mitaan kun lataus-URL on virheellinen`() {
+        mockServer
+            .expect(
+                requestTo(
+                    "https://localhost:8080/dev/koto/webservice/rest/server.php?" +
+                        "wstoken=testitoken&moodlewsrestformat=json&" +
+                        "wsfunction=local_completion_export_export_question_bank",
+                ),
+            ).andRespond(withSuccess(listResponse, MediaType.APPLICATION_JSON))
+        mockServer
+            .expect(requestTo("https://localhost:8080/dev/koto/pluginfile.php/7/qb.xml?token=testitoken"))
+            .andRespond(withSuccess("<questions><q id=\"a\"/></questions>", MediaType.APPLICATION_XML))
+        mockServer
+            .expect(requestTo("https://localhost:8080/dev/koto/pluginfile.php/8/qb.xml?token=testitoken"))
+            .andRespond(withServerError())
+
+        assertFailsWith<RestClientResponseException> {
+            tehtavapankkiService.importTehtavapankki()
+        }
+
+        val keys =
+            s3Client
+                .listObjectsV2 { it.bucket(TEST_BUCKET) }
+                .contents()
+                .map { it.key() }
+        assertEquals(0, keys.size, "Fail-fast: mitään ei pitäisi viedä S3:een, oli: $keys")
+    }
+
+    @Test
+    fun `importAndIngest ingestoi terveen kurssin mutta heittaa kun toinen kurssi epaonnistuu`() {
+        val validQuiz =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <quiz>
+              <question type="category">
+                <category><text>${'$'}course${'$'}/top/A1</text></category>
+                <info format="html"><text/></info>
+                <idnumber/>
+              </question>
+            </quiz>
+            """.trimIndent()
+        mockServer
+            .expect(
+                requestTo(
+                    "https://localhost:8080/dev/koto/webservice/rest/server.php?" +
+                        "wstoken=testitoken&moodlewsrestformat=json&" +
+                        "wsfunction=local_completion_export_export_question_bank",
+                ),
+            ).andRespond(withSuccess(listResponse, MediaType.APPLICATION_JSON))
+        mockServer
+            .expect(requestTo("https://localhost:8080/dev/koto/pluginfile.php/7/qb.xml?token=testitoken"))
+            .andRespond(withSuccess(validQuiz, MediaType.APPLICATION_XML))
+        mockServer
+            .expect(requestTo("https://localhost:8080/dev/koto/pluginfile.php/8/qb.xml?token=testitoken"))
+            .andRespond(
+                withSuccess(
+                    """{"error":"Pääsyn hallinnan poikkeus","errorcode":"accessexception","stacktrace":null,"debuginfo":null,"reproductionlink":null}""",
+                    MediaType.APPLICATION_JSON,
+                ),
+            )
+
+        val ex =
+            assertFailsWith<TehtavapankkiImportException> {
+                ingestService.importAndIngest()
+            }
+        assertContains(ex.message!!, "accessexception")
+
+        assertNotNull(
+            repository.findLatestPakettiBySource(TehtavapankkiIngestService.LAHDEJARJESTELMA, "7"),
+            "Terveen courseid=7:n pitäisi olla ingestoitu vaikka courseid=8 epäonnistui",
+        )
+        assertNull(
+            repository.findLatestPakettiBySource(TehtavapankkiIngestService.LAHDEJARJESTELMA, "8"),
+            "Virheellistä courseid=8:aa ei pitäisi ingestoida",
+        )
     }
 
     @Test


### PR DESCRIPTION
Moodlen latauspääte palauttaa toisinaan HTTP 200:lla JSON-virheen XML:n
sijaan. Aiemmin tämä tallentui .xml-objektina S3:een ja ingest epäonnistui
hiljaa. Nyt lataus nuuhkii ensimmäisen merkitsevän tavun ja heittää
TehtavapankkiDownloadExceptionin ei-XML-sisällöstä, joten virheellistä
vastausta ei tallenneta.

- Terveet kurssit ladataan/viedään/ingestoidaan silti; vialliset ohitetaan
  ja ajo päättyy lopuksi FAILED-tilaan (TehtavapankkiImportException).
- Virheellinen lataus-URL / ei-2xx kaataa ajon välittömästi (fail-fast).
- Myös listauspääte tunnistaa Moodlen JSON-virheen.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
