### PR TITLE
OPHKOTO-154: Korjaa tehtäväpankin muistinkäyttö isoilla tiedostoilla

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ COPY --from=backend-builder --chown=10001:10001 /kitu/server/target/kitu-0.0.1-S
 
 USER 10001
 
-ENTRYPOINT ["java", "-jar", "kitu-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "kitu-0.0.1-SNAPSHOT.jar"]

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiImportService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiImportService.kt
@@ -49,7 +49,6 @@ class TehtavapankkiImportService(
 
     private fun ingestOne(key: String): Pair<String, String>? =
         try {
-            tehtavapankkiService.extractAndUploadAssets(key)
             ingestService.ingestFromS3(key).leftOrNull()?.let { key to it.describe() }
         } catch (e: Exception) {
             Span.current().setAttribute("ingest.threw", true)

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiIngestService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiIngestService.kt
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
+import java.nio.file.Files
+import java.nio.file.Path
 import java.security.MessageDigest
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -45,13 +47,13 @@ class TehtavapankkiIngestService(
     fun ingestFromS3(xmlKey: String): Either<TehtavapankkiParseError, TehtavapakettiEntity> {
         Span.current().setAttribute("xml.key", xmlKey)
 
-        val bytes =
-            when (val r = tehtavapankkiService.fetchXmlBytes(xmlKey)) {
+        val loaded =
+            when (val r = loadAndUploadAssets(xmlKey)) {
                 is Either.Right -> r.value
                 is Either.Left -> return r.value.left()
             }
 
-        val versioHash = sha256(bytes)
+        val versioHash = loaded.versioHash
         val source = MoodleSourceIdentifiers.fromS3Key(xmlKey)
         val lahdeFilegenerated =
             source.filegeneratedMs?.let { OffsetDateTime.ofInstant(Instant.ofEpochMilli(it), ZoneOffset.UTC) }
@@ -93,11 +95,7 @@ class TehtavapankkiIngestService(
             return latest.right()
         }
 
-        val quiz =
-            when (val r = parser.parse(bytes.inputStream())) {
-                is Either.Right -> r.value
-                is Either.Left -> return r.value.left()
-            }
+        val quiz = loaded.quiz
 
         val pakettiId =
             repository.insertPaketti(
@@ -213,10 +211,43 @@ class TehtavapankkiIngestService(
         return repository.findPakettiById(pakettiId)!!.right()
     }
 
+    /**
+     * Lataa XML:n S3:sta väliaikaistiedostoon, laskee versio_hashin ja parsii
+     * sisällön streamaten — koko tiedostoa ei materialisoida muistiin. Parsittua
+     * sisältöä käytetään sekä assettien purkuun että ingestiin (yksi parsinta).
+     */
+    private fun loadAndUploadAssets(xmlKey: String): Either<TehtavapankkiParseError, LoadedQuiz> {
+        val tempFile =
+            when (val r = tehtavapankkiService.fetchToTempFile(xmlKey)) {
+                is Either.Right -> r.value
+                is Either.Left -> return r.value.left()
+            }
+        return try {
+            val versioHash = sha256(tempFile)
+            when (val r = Files.newInputStream(tempFile).use { parser.parse(it) }) {
+                is Either.Right -> {
+                    tehtavapankkiService.uploadAssets(xmlKey, r.value)
+                    LoadedQuiz(r.value, versioHash).right()
+                }
+
+                is Either.Left -> {
+                    r.value.left()
+                }
+            }
+        } finally {
+            Files.deleteIfExists(tempFile)
+        }
+    }
+
     companion object {
         const val LAHDEJARJESTELMA: String = "moodle.koealusta"
     }
 }
+
+private data class LoadedQuiz(
+    val quiz: TehtavapankkiQuiz,
+    val versioHash: String,
+)
 
 private data class PendingTehtava(
     val question: IngestableQuestion,
@@ -271,9 +302,17 @@ internal data class MoodleSourceIdentifiers(
     }
 }
 
-private fun sha256(bytes: ByteArray): String {
-    val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
-    return digest.joinToString("") { "%02x".format(it) }
+private fun sha256(path: Path): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    Files.newInputStream(path).use { input ->
+        val buffer = ByteArray(64 * 1024)
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            digest.update(buffer, 0, read)
+        }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
 private fun IngestableQuestion.embeddedFiles(): List<EmbeddedFile> =

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
@@ -16,6 +16,8 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import java.io.ByteArrayInputStream
 import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -228,12 +230,13 @@ class TehtavapankkiService(
     @WithSpan
     fun extractAndUploadAssets(xmlKey: String): Either<TehtavapankkiParseError, AssetExtractResult> {
         Span.current().setAttribute("xml.key", xmlKey)
-        val quiz =
-            when (val parsed = fetchAndParseFromS3(xmlKey)) {
-                is Either.Right -> parsed.value
-                is Either.Left -> return parsed.value.left()
-            }
+        return fetchAndParseFromS3(xmlKey).map { quiz -> uploadAssets(xmlKey, quiz) }
+    }
 
+    fun uploadAssets(
+        xmlKey: String,
+        quiz: TehtavapankkiQuiz,
+    ): AssetExtractResult {
         val prefix = "${xmlKey.removeSuffix(".xml")} assets/"
         val uploaded = mutableListOf<String>()
         val failed = mutableListOf<FailedAsset>()
@@ -256,28 +259,46 @@ class TehtavapankkiService(
         Span.current().setAttribute("assets.uploaded", uploaded.size.toLong())
         Span.current().setAttribute("assets.failed", failed.size.toLong())
 
-        return AssetExtractResult(xmlKey, uploaded, failed).right()
+        return AssetExtractResult(xmlKey, uploaded, failed)
     }
 
+    /**
+     * Lataa S3-objektin väliaikaistiedostoon streamaten, jottei isoa tehtäväpankkia
+     * tarvitse materialisoida muistiin. Kutsujan vastuulla on poistaa tiedosto.
+     */
     @WithSpan
-    fun fetchXmlBytes(key: String): Either<TehtavapankkiParseError, ByteArray> {
+    fun fetchToTempFile(key: String): Either<TehtavapankkiParseError, Path> {
         Span.current().setAttribute("s3.key", key)
         val resource =
             useS3 { bucket ->
                 if (objectExists(bucket, key)) download(bucket, key) else null
             } ?: return TehtavapankkiParseError.NotFound.left()
+        val tempFile = Files.createTempFile("tehtavapankki-ingest-", ".xml")
         return try {
-            resource.inputStream.use { it.readBytes() }.right()
+            resource.inputStream.use { input ->
+                Files.newOutputStream(tempFile).use { output -> input.copyTo(output) }
+            }
+            tempFile.right()
         } catch (e: Throwable) {
+            Files.deleteIfExists(tempFile)
             TehtavapankkiParseError.IO(e).left()
         }
     }
 
     @WithSpan
     fun fetchAndParseFromS3(key: String): Either<TehtavapankkiParseError, TehtavapankkiQuiz> =
-        when (val bytes = fetchXmlBytes(key)) {
-            is Either.Right -> parser.parse(bytes.value.inputStream())
-            is Either.Left -> bytes.value.left()
+        when (val tempFile = fetchToTempFile(key)) {
+            is Either.Right -> {
+                try {
+                    Files.newInputStream(tempFile.value).use { parser.parse(it) }
+                } finally {
+                    Files.deleteIfExists(tempFile.value)
+                }
+            }
+
+            is Either.Left -> {
+                tempFile.value.left()
+            }
         }
 
     @WithSpan

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiXmlParser.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiXmlParser.kt
@@ -6,17 +6,26 @@ import arrow.core.right
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.springframework.stereotype.Service
+import tools.jackson.core.StreamReadConstraints
 import tools.jackson.databind.DeserializationFeature
 import tools.jackson.databind.JsonNode
+import tools.jackson.dataformat.xml.XmlFactory
 import tools.jackson.dataformat.xml.XmlMapper
 import java.io.InputStream
 
 @Service
 class TehtavapankkiXmlParser {
+    // Tehtäväpankit sisältävät base64-upotettuja mediatiedostoja, jotka voivat
+    // ylittää Jacksonin oletusrajan (20 MB). Nostetaan lataus­polun rajan tasalle.
     private val xmlMapper: XmlMapper =
         XmlMapper
-            .builder()
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .builder(
+                XmlFactory
+                    .builder()
+                    .streamReadConstraints(
+                        StreamReadConstraints.builder().maxStringLength(200_000_000).build(),
+                    ).build(),
+            ).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .build()
 
     @WithSpan


### PR DESCRIPTION

Iso tehtäväpankki kaatoi ingestin OutOfMemoryErroriin (Java heap space).
Syitä kaksi:

- 4 GB:n kontti antoi JVM:lle vain ~1 GB keon (oletus 25 %), koska
  ENTRYPOINT ajoi pelkkää java -jar. Lisätään -XX:MaxRAMPercentage=75.0.
- Ingest luki koko tiedoston ByteArrayhin ja parsi XML-puun kahdesti per
  paketti. Nyt S3-objekti streamataan väliaikaistiedostoon, versio_hash
  lasketaan streamaten ja sisältö parsitaan kerran (jaetaan assettien
  purun ja tietokantaingestin kesken).

Lisäksi nostetaan XML-parserin merkkijonoraja 20 MB → 200 MB lataus­polun
tasalle, jotta isoja base64-upotettuja mediatiedostoja sisältävä paketti
ei kaadu parsintaan.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
