### PR TITLE
Manuaalinen koko vuoden YKI-poikkeamatarkistus

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiScheduledTasks.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiScheduledTasks.kt
@@ -32,6 +32,9 @@ class YkiScheduledTasks(
     @Value($$"${kitu.yki.scheduling.anomalyCheck.schedule}")
     lateinit var ykiAnomalyCheckSchedule: String
 
+    @Value($$"${kitu.yki.scheduling.anomalyCheckFullYear.schedule}")
+    lateinit var ykiAnomalyCheckFullYearSchedule: String
+
     @Value($$"${kitu.yki.scheduling.importArvioijat.schedule}")
     lateinit var ykiImportArvioijatSchedule: String
 
@@ -41,6 +44,22 @@ class YkiScheduledTasks(
         tracer.recurringStatefulTask("Tarkista poikkeamat YKI-suorituksissa", ykiAnomalyCheckSchedule) {
             val today = LocalDate.now(HELSINKI)
             val from = today.minus(anomalyCheckLookback(today)).atStartOfDay(HELSINKI).toInstant()
+            ykiService.checkYkiAnomalies(from)
+        }
+
+    @WithSpan
+    @Bean
+    fun onDemandFullYearAnomalyCheck(ykiService: YkiService): Task<Void> =
+        tracer.recurringStatefulTask(
+            "Tarkista poikkeamat YKI-suorituksissa (koko vuosi, manuaalinen)",
+            ykiAnomalyCheckFullYearSchedule,
+        ) {
+            val from =
+                LocalDate
+                    .now(HELSINKI)
+                    .minusYears(1)
+                    .atStartOfDay(HELSINKI)
+                    .toInstant()
             ykiService.checkYkiAnomalies(from)
         }
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -39,6 +39,7 @@ db-scheduler-ui.log-limit=1000
 kitu.yki.scheduling.enabled=false
 kitu.yki.scheduling.import.schedule=-
 kitu.yki.scheduling.anomalyCheck.schedule=-
+kitu.yki.scheduling.anomalyCheckFullYear.schedule=-
 kitu.yki.scheduling.importArvioijat.schedule=-
 kitu.yki.scheduling.retrySendingFailedArviointitilat.schedule=FIXED_DELAY|3600s
 kitu.yki.username=${YKI_API_USER}


### PR DESCRIPTION
## Mitä

Lisää db-scheduler-tehtävän **"Tarkista poikkeamat YKI-suorituksissa (koko vuosi, manuaalinen)"**, jolla operaattori voi ajaa koko vuoden YKI-poikkeamatarkistuksen milloin tahansa.

## Miksi

Päivittäinen `dailyAnomalyCheck` katsoo koko vuoden taaksepäin vain tiettyinä päivinä (`anomalyCheckLookback`). Operaattorilla ei ole tapaa ajaa koko vuoden tarkistusta haluamanaan päivänä.

## Miten

- Uusi `@Bean onDemandFullYearAnomalyCheck` (`YkiScheduledTasks.kt`) peilaa `dailyAnomalyCheck`-tehtävää, mutta käyttää aina vuoden lookbackia (`LocalDate.now(HELSINKI).minusYears(1)`) ja ajaa `YkiService.checkYkiAnomalies(from)`.
- Aikataulu `kitu.yki.scheduling.anomalyCheckFullYear.schedule=-` → `DisabledSchedule`: tehtävä ei aja itsestään. Ei override-rivejä env-tiedostoissa → manuaalinen kaikissa ympäristöissä.
- Käynnistys db-scheduler-UI:n **Run now** -napilla (`/kielitutkinnot/db-scheduler`, etusivun "Eräajojen hallinta"). Sama konventio kuin nykyisillä disabled-tehtävillä. Ajetaan taustalla (ei HTTP-timeout-riskiä) ja on idempotentti (poikkeamat upsertataan `(solki_id, kentta)`-avaimella).

## Testaus

- `./mvnw test-compile` ✅
- Sovellus bootattu (e2e-profiili, scheduling enabled): käynnistysloki vahvistaa tehtävän rekisteröityvän `DisabledSchedule`lla ja "will not schedule a new execution" -merkinnän. `e2e/tests/yki/yki-poikkeamat.spec.ts` 13/13 läpi.
- `./scripts/format.sh` + `check-formatting.sh` puhdas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)