### PR TITLE
Paikkaa Tomcat- ja Netty-haavoittuvuudet

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -39,8 +39,11 @@
              haavoittuvuuksien taakse. Tarkista jokainen Spring Boot -päivityksen
              yhteydessä, voiko poistaa. -->
         <!-- https://github.com/Opetushallitus/kielitutkintorekisteri/security/dependabot
-             alerts 116, 118-123 (Netty 4.2.13.Final) -->
-        <netty.version>4.2.13.Final</netty.version>
+             alerts 135-138 (Netty) -->
+        <netty.version>4.2.15.Final</netty.version>
+        <!-- https://github.com/Opetushallitus/kielitutkintorekisteri/security/dependabot
+             alerts 128-134 (Tomcat embed; Spring Boot 4.0.6 BOM tuo 11.0.21) -->
+        <tomcat.version>11.0.22</tomcat.version>
         <!-- https://github.com/Opetushallitus/kielitutkintorekisteri/security/dependabot/117
              (pgjdbc 42.7.11) -->
         <postgresql.version>42.7.11</postgresql.version>


### PR DESCRIPTION
## Mitä

Paikkaa kaikki 11 avointa Dependabot-haavoittuvuutta, jotka tulevat Spring Boot 4.0.6:n kautta transitiivisesti. Päivitetään versiot BOMin yli `pom.xml`:ssä jo dokumentoitua "pakotetut päivitykset" -tapaa noudattaen.

| Kirjasto | Ennen | Jälkeen | Alertit |
|---|---|---|---|
| `org.apache.tomcat.embed:*` | 11.0.21 (SB-BOM) | **11.0.22** | 128–134 (mm. 2 kriittistä) |
| `io.netty:*` | 4.2.13.Final (pinnattu) | **4.2.15.Final** | 135–138 |

Merkittävimmät: CVE-2026-43512 (Tomcat Digest authenticator hyväksyy tuntemattoman käyttäjän), CVE-2026-43515 (Tomcat security constraints ei sovelleta), CVE-2026-44249 (Netty IPv6 subnet filter bypass), CVE-2026-45416 (Netty SNI 16 MiB pre-alloc DoS).

## Miten

- `<netty.version>` 4.2.13.Final → 4.2.15.Final (vanha pinnaus jäi uusien alertien taakse)
- Lisätty `<tomcat.version>11.0.22</tomcat.version>` (SB 4.0.6 BOM tuo 11.0.21)
- Päivitetty alert-viittauskommentit

Nämä overridet ovat tilapäisiä: kun jokin Spring Boot 4.0.x -patch tuo Tomcat ≥ 11.0.22 ja Netty ≥ 4.2.15, molemmat voi poistaa (kuten kommentti ohjeistaa).

## Testaus

- `./mvnw dependency:tree` vahvistaa: Tomcat embed **11.0.22**, Netty **4.2.15.Final**
- `./mvnw test` → **396 testiä läpi**, BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)