### PR TITLE
Automergeaa GitHub Actions -digestit Renovatessa

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,11 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "automerge": true
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Ongelma

Joukko Renovate-PR:iä (mm. #2905, #2906, #2909, #2932, #2964, #2969, #3018) jäi 3 viikoksi jumiin `renovate/stability-days`-tarkistukseen, vaikka 3 päivän `minimumReleaseAge` täyttyi aikaa sitten.

Syy: `renovate/stability-days` on Renovaten kirjoittama commit-status, jonka se päivittää vain rebaseatessaan branchin. Konffi automergeää vain `minor`/`patch`-päivitykset — **ei `digest`-tyyppiä**. `helpers:pinGitHubActionDigests` tuottaa juuri digest-päivityksiä, joten ne eivät koskaan automergeytyneet, kukaan ei mergennyt niitä käsin, eikä Renovate enää rebaseannut niitä → status jäi pysyvästi pendingiksi. (`renovate/stability-days` ei ole pakollinen check, joten PR:t olivat teknisesti mergettävissä, mutta jäivät roikkumaan.)

## Korjaus

Lisätään `packageRule`, joka automergeää `github-actions`-managerin `digest`/`pinDigest`-päivitykset. `minimumReleaseAge: 3 days` pätee yhä, eli digestit odottavat silti 3 vrk ennen automergeä.

## Testaus

- `renovate-config-validator` ✅ "Config validated successfully"
- Validi JSON + prettier

Olemassa olevat jumittuneet PR:t triggeröidään erikseen Dependency Dashboardin (#196) "rebase all open PRs" -ruksilla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)