### PR TITLE
OPHKOTO-xxx: Lisää etusivulle lisää statistiikkaa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Backend tests spin up PostgreSQL via Testcontainers — Docker must be running. 
 
 ### Layout
 
-- `server/` — Spring Boot 4.0.6 + Kotlin backend. Source roots are `src/main/kotlin` and `src/test/kotlin` (configured in `pom.xml`, not the Maven defaults). Packages under `fi.oph.kitu/` are organized by **feature domain**, not by layer.
+- `server/` — Spring Boot 4.1.0 + Kotlin backend. Source roots are `src/main/kotlin` and `src/test/kotlin` (configured in `pom.xml`, not the Maven defaults). Packages under `fi.oph.kitu/` are organized by **feature domain**, not by layer.
 - `infra/` — AWS CDK (TypeScript) app. `bin/infra.ts` wires four stages: `Util` (shared ECR repo + GitHub Actions roles), then `Dev`/`Test`/`Prod`. Each env stage composes stacks (`service-stack`, `db-stack`, `network-stack`, `alarms-stack`, `bastion-stack`, `backups-stack`, `koski-audit-logs-integration-stack`, ...). Deploys pick the container by `TAG` env var.
 - `e2e/` — Playwright tests against a real server + Postgres.
 - `scripts/` — bash helpers for local env, AWS profile/secret setup, tmux orchestration.

--- a/server/src/main/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepository.kt
@@ -174,6 +174,14 @@ class TehtavapankkiRepository(
     }
 
     @WithSpan
+    fun countDistinctPaketit(): Long =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM (SELECT DISTINCT lahdejarjestelma, lahde_id FROM tehtavapaketti) t",
+            emptyMap<String, Any>(),
+            Long::class.java,
+        ) ?: 0
+
+    @WithSpan
     fun findPakettiById(id: Int): TehtavapakettiEntity? =
         jdbc
             .query(

--- a/server/src/main/kotlin/fi/oph/kitu/util/scheduling/SchedulerStatsRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/util/scheduling/SchedulerStatsRepository.kt
@@ -1,0 +1,24 @@
+package fi.oph.kitu.util.scheduling
+
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class SchedulerStatsRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    @WithSpan
+    fun countCurrentlyRunning(): Long =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM scheduled_tasks WHERE picked = true",
+            Long::class.java,
+        ) ?: 0
+
+    @WithSpan
+    fun countCurrentlyFailing(): Long =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM scheduled_tasks WHERE consecutive_failures > 0",
+            Long::class.java,
+        ) ?: 0
+}

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/DashboardService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/DashboardService.kt
@@ -3,7 +3,9 @@ package fi.oph.kitu.webmvc
 import fi.oph.kitu.koski.KoskiErrorService
 import fi.oph.kitu.kotoutumiskoulutus.suoritukset.CustomKielitestiSuoritusRepository
 import fi.oph.kitu.kotoutumiskoulutus.suoritukset.error.KielitestiSuoritusErrorRepository
+import fi.oph.kitu.tehtavapankki.TehtavapankkiRepository
 import fi.oph.kitu.util.cache.InMemoryCache
+import fi.oph.kitu.util.scheduling.SchedulerStatsRepository
 import fi.oph.kitu.vkt.CustomVktSuoritusRepository
 import fi.oph.kitu.yki.arvioijat.YkiArvioijaRepository
 import fi.oph.kitu.yki.arvioijat.error.YkiArvioijaErrorService
@@ -25,11 +27,14 @@ class DashboardService(
     private val customVktSuoritusRepository: CustomVktSuoritusRepository,
     private val customKielitestiSuoritusRepository: CustomKielitestiSuoritusRepository,
     private val kielitestiSuoritusErrorRepository: KielitestiSuoritusErrorRepository,
+    private val tehtavapankkiRepository: TehtavapankkiRepository,
+    private val schedulerStatsRepository: SchedulerStatsRepository,
     private val koskiErrorService: KoskiErrorService,
 ) {
     private val ykiCache = InMemoryCache<Unit, YkiStats>(ttl = 60.seconds) { computeYki() }
     private val vktCache = InMemoryCache<Unit, VktStats>(ttl = 60.seconds) { computeVkt() }
     private val kotoCache = InMemoryCache<Unit, KotoStats>(ttl = 60.seconds) { computeKoto() }
+    private val adminCache = InMemoryCache<Unit, AdminStats>(ttl = 60.seconds) { computeAdmin() }
 
     @WithSpan
     fun getYkiStats(): YkiStats = ykiCache.get(Unit) ?: error("ykiCache returned null; computeYki must yield non-null")
@@ -42,17 +47,24 @@ class DashboardService(
         kotoCache.get(Unit) ?: error("kotoCache returned null; computeKoto must yield non-null")
 
     @WithSpan
+    fun getAdminStats(): AdminStats =
+        adminCache.get(Unit) ?: error("adminCache returned null; computeAdmin must yield non-null")
+
+    @WithSpan
     fun getStats(): DashboardStats =
         DashboardStats(
             yki = getYkiStats(),
             vkt = getVktStats(),
             koto = getKotoStats(),
+            admin = getAdminStats(),
         )
 
     private fun computeYki(): YkiStats =
         YkiStats(
             suoritusCount = ykiSuoritusRepository.countSuoritukset(),
             arvioijaCount = ykiArvioijaRepository.count(),
+            tarkistusarvioinnitOdottamassaCount =
+                ykiSuoritusRepository.countTarkistusarvioinnitOdottamassaHyvaksyntaa(),
             latestReceivedAt = ykiSuoritusRepository.findLatestReceivedAt(),
             suoritusImportErrorCount = ykiSuoritusErrorService.countErrors(),
             arvioijaImportErrorCount = ykiArvioijaErrorService.countErrors(),
@@ -75,8 +87,15 @@ class DashboardService(
     private fun computeKoto(): KotoStats =
         KotoStats(
             suoritusCount = customKielitestiSuoritusRepository.countSuoritukset().toLong(),
+            tehtavapaketitCount = tehtavapankkiRepository.countDistinctPaketit(),
             latestReceivedAt = customKielitestiSuoritusRepository.findLatestLastModified(),
             importErrorCount = kielitestiSuoritusErrorRepository.count(),
+        )
+
+    private fun computeAdmin(): AdminStats =
+        AdminStats(
+            runningCount = schedulerStatsRepository.countCurrentlyRunning(),
+            failingCount = schedulerStatsRepository.countCurrentlyFailing(),
         )
 }
 
@@ -84,11 +103,13 @@ data class DashboardStats(
     val yki: YkiStats,
     val vkt: VktStats,
     val koto: KotoStats,
+    val admin: AdminStats,
 )
 
 data class YkiStats(
     val suoritusCount: Long,
     val arvioijaCount: Long,
+    val tarkistusarvioinnitOdottamassaCount: Long,
     val latestReceivedAt: Instant?,
     val suoritusImportErrorCount: Long,
     val arvioijaImportErrorCount: Long,
@@ -107,6 +128,12 @@ data class VktStats(
 
 data class KotoStats(
     val suoritusCount: Long,
+    val tehtavapaketitCount: Long,
     val latestReceivedAt: Instant?,
     val importErrorCount: Long,
+)
+
+data class AdminStats(
+    val runningCount: Long,
+    val failingCount: Long,
 )

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/HomeController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/HomeController.kt
@@ -25,6 +25,10 @@ class HomeController(
     fun kotoCard(): ResponseEntity<String> =
         cachedFragment(HomePage.renderKotoCardContent(dashboardService.getKotoStats()))
 
+    @GetMapping("/dashboard/admin", produces = ["text/html"])
+    fun adminCard(): ResponseEntity<String> =
+        cachedFragment(HomePage.renderAdminCardContent(dashboardService.getAdminStats()))
+
     private fun cachedFragment(body: String): ResponseEntity<String> =
         ResponseEntity
             .ok()

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/HomePage.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/HomePage.kt
@@ -34,7 +34,7 @@ object HomePage {
                     contentKey = "koto",
                     title = "Kotoutumiskoulutuksen kielitaidon päättötesti",
                 )
-                adminCard()
+                lazyCard(groupId = "admin", contentKey = "admin", title = "Ylläpito")
             }
             javascript(loaderScript())
         }
@@ -54,10 +54,15 @@ object HomePage {
             kotoRows(s)
         }
 
+    fun renderAdminCardContent(s: AdminStats): String =
+        createHTML().ul(classes = "dashboard-stats") {
+            adminRows(s)
+        }
+
     private fun UL.ykiRows(s: YkiStats) {
         statRow("Suoritukset", s.suoritusCount, Links.Yki.suoritukset())
         statRow("Arvioijat", s.arvioijaCount, Links.Yki.arvioijat())
-        statRow("Tarkistusarvioinnit", value = null, href = Links.Yki.tarkistusArvioinnit())
+        statRow("Tarkistusarvioinnit", s.tarkistusarvioinnitOdottamassaCount, Links.Yki.tarkistusArvioinnit())
         statRow(
             label = "Suoritusten tuonnin virheet",
             value = s.suoritusImportErrorCount,
@@ -113,7 +118,7 @@ object HomePage {
 
     private fun UL.kotoRows(s: KotoStats) {
         statRow("Suoritukset", s.suoritusCount, Links.Kielitesti.suoritukset())
-        statRow("Tehtäväpaketit", value = null, href = Links.Tehtavapankki.list())
+        statRow("Tehtäväpaketit", s.tehtavapaketitCount, Links.Tehtavapankki.list())
         statRow(
             label = "Tuonnin virheet",
             value = s.importErrorCount,
@@ -121,6 +126,17 @@ object HomePage {
             errorIfNonZero = true,
         )
         latestReceivedRow(s.latestReceivedAt, Links.Kielitesti.suoritukset())
+    }
+
+    private fun UL.adminRows(s: AdminStats) {
+        statRow("Käynnissä olevat eräajot", s.runningCount, Links.Admin.dbScheduler())
+        statRow(
+            label = "Eräajot virhetilassa",
+            value = s.failingCount,
+            href = Links.Admin.dbScheduler(),
+            errorIfNonZero = true,
+        )
+        statRow("Eräajojen hallinta", value = null, href = Links.Admin.dbScheduler())
     }
 
     private fun FlowContent.lazyCard(
@@ -143,17 +159,6 @@ object HomePage {
             }
         }
     }
-
-    private fun FlowContent.adminCard() =
-        card {
-            testId("admin-links")
-            cardContent {
-                h2(classes = "dashboard-card-title") { +"Ylläpito" }
-                ul(classes = "dashboard-stats") {
-                    statRow("Eräajojen hallinta", value = null, href = Links.Admin.dbScheduler())
-                }
-            }
-        }
 
     private fun UL.statRow(
         label: String,
@@ -197,11 +202,13 @@ object HomePage {
         val ykiUrl = Links.Dashboard.yki()
         val vktUrl = Links.Dashboard.vkt()
         val kotoUrl = Links.Dashboard.koto()
+        val adminUrl = Links.Dashboard.admin()
         return """
             const cards = [
-                { id: "yki",  url: "$ykiUrl" },
-                { id: "vkt",  url: "$vktUrl" },
-                { id: "koto", url: "$kotoUrl" },
+                { id: "yki",   url: "$ykiUrl" },
+                { id: "vkt",   url: "$vktUrl" },
+                { id: "koto",  url: "$kotoUrl" },
+                { id: "admin", url: "$adminUrl" },
             ];
             cards.forEach(({ id, url }) => {
                 const target = document.querySelector('[data-card-content="' + id + '"]');

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/Links.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/Links.kt
@@ -21,6 +21,8 @@ object Links {
         fun vkt(): String = linkTo(methodOn(HomeController::class.java).vktCard()).toString()
 
         fun koto(): String = linkTo(methodOn(HomeController::class.java).kotoCard()).toString()
+
+        fun admin(): String = linkTo(methodOn(HomeController::class.java).adminCard()).toString()
     }
 
     object Admin {

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
@@ -201,6 +201,19 @@ class YkiSuoritusRepository(
         }
 
     @WithSpan
+    fun countTarkistusarvioinnitOdottamassaHyvaksyntaa(): Long =
+        jdbcNamedParameterTemplate.queryForObject(
+            buildSql(
+                withCtes(
+                    "viimeisin_suoritus" to selectSuorituksetFull(viimeisin = true, "WHERE arviointitila = :tila"),
+                ),
+                "SELECT COUNT(*) FROM viimeisin_suoritus",
+            ),
+            mapOf("tila" to Arviointitila.TARKISTUSARVIOITU.name),
+            Long::class.java,
+        ) ?: 0
+
+    @WithSpan
     fun countSuoritukset(
         filter: YkiSuoritusFilter = YkiSuoritusFilter(),
         distinct: Boolean = true,

--- a/server/src/test/kotlin/fi/oph/kitu/util/scheduling/SchedulerStatsRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/util/scheduling/SchedulerStatsRepositoryTest.kt
@@ -1,0 +1,43 @@
+package fi.oph.kitu.util.scheduling
+
+import fi.oph.kitu.DBContainerConfiguration
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.jdbc.core.JdbcTemplate
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@Import(DBContainerConfiguration::class)
+class SchedulerStatsRepositoryTest(
+    @param:Autowired private val repository: SchedulerStatsRepository,
+    @param:Autowired private val jdbc: JdbcTemplate,
+) {
+    @Test
+    fun `laskee kaynnissa olevat ja virhetilassa olevat erajaot`() {
+        val runningBefore = repository.countCurrentlyRunning()
+        val failingBefore = repository.countCurrentlyFailing()
+
+        jdbc.update(
+            "INSERT INTO scheduled_tasks (task_name, task_instance, execution_time, picked, version) " +
+                "VALUES (?, ?, now(), true, 1)",
+            "test-running-task",
+            "test-running-instance",
+        )
+        jdbc.update(
+            "INSERT INTO scheduled_tasks " +
+                "(task_name, task_instance, execution_time, picked, consecutive_failures, version) " +
+                "VALUES (?, ?, now(), false, 3, 1)",
+            "test-failing-task",
+            "test-failing-instance",
+        )
+
+        try {
+            assertTrue(repository.countCurrentlyRunning() >= runningBefore + 1)
+            assertTrue(repository.countCurrentlyFailing() >= failingBefore + 1)
+        } finally {
+            jdbc.update("DELETE FROM scheduled_tasks WHERE task_name IN ('test-running-task', 'test-failing-task')")
+        }
+    }
+}

--- a/server/src/test/kotlin/fi/oph/kitu/webmvc/DashboardServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/webmvc/DashboardServiceTest.kt
@@ -31,6 +31,7 @@ class DashboardServiceTest(
         jdbc.execute("TRUNCATE TABLE koto_suoritus CASCADE")
         jdbc.execute("TRUNCATE TABLE vkt_suoritus CASCADE")
         jdbc.execute("TRUNCATE TABLE koski_error")
+        jdbc.execute("TRUNCATE TABLE tehtavapaketti CASCADE")
         clearAllCaches()
     }
 
@@ -40,6 +41,7 @@ class DashboardServiceTest(
 
         assertEquals(0L, stats.yki.suoritusCount)
         assertEquals(0L, stats.yki.arvioijaCount)
+        assertEquals(0L, stats.yki.tarkistusarvioinnitOdottamassaCount)
         assertEquals(null, stats.yki.latestReceivedAt)
         assertEquals(0L, stats.yki.suoritusImportErrorCount)
         assertEquals(0L, stats.yki.arvioijaImportErrorCount)
@@ -54,6 +56,7 @@ class DashboardServiceTest(
         assertEquals(0L, stats.vkt.koskiErrorCount)
 
         assertEquals(0L, stats.koto.suoritusCount)
+        assertEquals(0L, stats.koto.tehtavapaketitCount)
         assertEquals(null, stats.koto.latestReceivedAt)
         assertEquals(0L, stats.koto.importErrorCount)
     }
@@ -63,6 +66,7 @@ class DashboardServiceTest(
         assertSame(dashboardService.getYkiStats(), dashboardService.getYkiStats())
         assertSame(dashboardService.getVktStats(), dashboardService.getVktStats())
         assertSame(dashboardService.getKotoStats(), dashboardService.getKotoStats())
+        assertSame(dashboardService.getAdminStats(), dashboardService.getAdminStats())
     }
 
     @Test
@@ -120,6 +124,7 @@ class DashboardServiceTest(
         clearCache("ykiCache")
         clearCache("vktCache")
         clearCache("kotoCache")
+        clearCache("adminCache")
     }
 
     private fun clearVktCache() = clearCache("vktCache")

--- a/server/src/test/kotlin/fi/oph/kitu/webmvc/HomeControllerTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/webmvc/HomeControllerTest.kt
@@ -73,9 +73,11 @@ class HomeControllerTest(
         assertContains(response, """data-card-content="koto"""")
         assertContains(response, "skeleton-row")
         assertContains(response, """aria-busy="true"""")
+        assertContains(response, """data-card-content="admin"""")
         assertContains(response, "/dashboard/yki")
         assertContains(response, "/dashboard/vkt")
         assertContains(response, "/dashboard/koto")
+        assertContains(response, "/dashboard/admin")
         assertFalse(
             response.contains("Viimeisin saapunut suoritus"),
             "\"Viimeisin saapunut suoritus\"-rivi esiintyy vain fragmenteissa, ei yläpalkin navigaatiossa",
@@ -83,10 +85,15 @@ class HomeControllerTest(
     }
 
     @Test
-    fun `admin kortin linkki renderoidaan synkronisesti`() {
-        val response = getHtml("/")
-        assertContains(response, "Eräajojen hallinta")
-        assertContains(response, "/kielitutkinnot/db-scheduler")
+    fun `dashboard admin -fragmentti palauttaa erajaotilastot ja hallintalinkin`() {
+        val fragment = getHtml("/dashboard/admin")
+
+        assertContains(fragment, """class="dashboard-stats"""")
+        assertContains(fragment, "Käynnissä olevat eräajot")
+        assertContains(fragment, "Eräajot virhetilassa")
+        assertContains(fragment, "Eräajojen hallinta")
+        assertContains(fragment, "/kielitutkinnot/db-scheduler")
+        assertFalse(fragment.contains("<html"), "Fragmenttivastaus ei sisällä sivun kuorta")
     }
 
     @Test


### PR DESCRIPTION

- YKI: "Tarkistusarvioinnit"-rivi näyttää hyväksyntää odottavien
  tarkistusarviointien määrän (arviointitila = TARKISTUSARVIOITU)
- Koto: "Tehtäväpaketit"-rivi näyttää erillisten tehtäväpakettien määrän
- Ylläpito: kortti hakee nyt lukumäärät laiskasti ja näyttää käynnissä
  olevien sekä virhetilassa olevien eräajojen määrät

Päivitä myös CLAUDE.md:n Spring Boot -versio (4.0.6 -> 4.1.0).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
