### PR TITLE
Korjaa YKI-suoritusten haku etu- ja sukunimellä

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusFilter.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusFilter.kt
@@ -21,26 +21,34 @@ data class YkiSuoritusFilter(
 
     private fun toSql() =
         SqlFilterBuilder().apply {
-            add(searchQuery(), "filter_search" to "%${search.orEmpty()}%")
+            searchTerms().forEachIndexed { i, term ->
+                val param = "filter_search_$i"
+                add(searchTermClause(param), param to "%$term%")
+            }
             add(alkupaiva?.let { "tutkintopaiva >= :filter_alkupaiva" }, "filter_alkupaiva" to alkupaiva)
             add(loppupaiva?.let { "tutkintopaiva <= :filter_loppupaiva" }, "filter_loppupaiva" to loppupaiva)
             add(tutkintokieli?.let { "tutkintokieli = :filter_kieli" }, "filter_kieli" to tutkintokieli?.name)
             add(tutkintotaso?.let { "tutkintotaso = :filter_taso" }, "filter_taso" to tutkintotaso?.name)
         }
 
-    private fun searchQuery(): String? =
-        search?.takeIf { it.isNotEmpty() }?.let {
-            """
-            suorittajan_oid ILIKE :filter_search
-            OR etunimet ILIKE :filter_search
-            OR sukunimi ILIKE :filter_search
-            OR email ILIKE :filter_search
-            OR hetu ILIKE :filter_search
-            OR jarjestajan_tunnus_oid ILIKE :filter_search
-            OR jarjestajan_nimi ILIKE :filter_search
-            OR yki_suoritus.solki_id::text ILIKE :filter_search
-            """.trimIndent()
-        }
+    private fun searchTerms(): List<String> =
+        search
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.split(Regex("\\s+"))
+            .orEmpty()
+
+    private fun searchTermClause(param: String): String =
+        """
+        suorittajan_oid ILIKE :$param
+        OR etunimet ILIKE :$param
+        OR sukunimi ILIKE :$param
+        OR email ILIKE :$param
+        OR hetu ILIKE :$param
+        OR jarjestajan_tunnus_oid ILIKE :$param
+        OR jarjestajan_nimi ILIKE :$param
+        OR yki_suoritus.solki_id::text ILIKE :$param
+        """.trimIndent()
 }
 
 data class YkiSuoritusOrder(

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
@@ -152,6 +152,32 @@ class YkiSuoritusRepositoryTest(
     }
 
     @Test
+    fun `find suoritus with first name and surname search term`() {
+        val target =
+            generateRandomYkiSuoritusEntity().copy(
+                etunimet = "Matti",
+                sukunimi = "Virtanen",
+            )
+        val decoy =
+            generateRandomYkiSuoritusEntity().copy(
+                etunimet = "Matti",
+                sukunimi = "Korhonen",
+            )
+        ykiSuoritusRepository.saveAllNewEntities(listOf(target, decoy))
+
+        val byFullName = ykiSuoritusRepository.find(YkiSuoritusFilter(search = "Matti Virtanen"))
+        assertEquals(1, byFullName.count())
+        assertEquals(target, byFullName.first().copy(id = null))
+
+        val byReversedName = ykiSuoritusRepository.find(YkiSuoritusFilter(search = "Virtanen Matti"))
+        assertEquals(1, byReversedName.count())
+        assertEquals(target, byReversedName.first().copy(id = null))
+
+        val byWrongCombo = ykiSuoritusRepository.find(YkiSuoritusFilter(search = "Matti Lahtinen"))
+        assertEquals(0, byWrongCombo.count())
+    }
+
+    @Test
     fun `find suoritus with solki id search term`() {
         val target = generateRandomYkiSuoritusEntity().copy(solkiId = 314159)
         val other =


### PR DESCRIPTION
## Ongelma

YKI-suoritusten listanäkymässä haku koko nimellä (esim. `Matti Virtanen`) ei palauttanut tuloksia, vaikka vastaava suoritus oli olemassa. Haku pelkällä etunimellä tai pelkällä sukunimellä toimi.

**Juurisyy** — `YkiSuoritusFilter.toSql()` sitoi koko hakusanan yhtenä parametrina `%hakusana%` ja vertasi sitä jokaiseen sarakkeeseen `OR`:lla:

```sql
etunimet ILIKE '%Matti Virtanen%' OR sukunimi ILIKE '%Matti Virtanen%' OR ...
```

`etunimet` sisältää `Matti` ja `sukunimi` `Virtanen` eri sarakkeissa, joten mikään yksittäinen sarake ei sisällä koko merkkijonoa → ei osumia.

## Korjaus

Hakusana pilkotaan välilyönneillä termeiksi. Jokaisen termin on osuttava **johonkin** haetuista sarakkeista (OR sarakkeiden yli), ja termit yhdistetään **AND**:lla, joten kaikkien termien on osuttava. Näin:

- `Matti Virtanen` osuu (termi `Matti` → `etunimet`, termi `Virtanen` → `sukunimi`)
- haku on järjestysriippumaton (`Virtanen Matti` toimii myös)
- yhden termin haku säilyy ennallaan (OID, hetu, solki_id, monisanaiset järjestäjän nimet osuvat edelleen)

Korjaus hyödyntää olemassa olevaa `SqlFilterBuilder`-mekaniikkaa, joka jo kietoo jokaisen lausekkeen sulkuihin ja yhdistää ne `AND`:lla — muutoksia tarvittiin vain `YkiSuoritusFilter`-tiedostoon.

## Testit

Lisätty testi `find suoritus with first name and surname search term`, joka kattaa koko nimen, käänteisen järjestyksen ja väärän yhdistelmän.

- `./mvnw test -Dtest=YkiSuoritusRepositoryTest` → Tests run: 14, Failures: 0, Errors: 0
- `./scripts/check-formatting.sh` → puhdas

🤖 Generated with [Claude Code](https://claude.com/claude-code)