### PR TITLE
Korjaa koto-tehtäväpakettien lukumäärä ja listauksen ryhmätiivistelmä

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
@@ -155,6 +155,9 @@ class TehtavapankkiService(
             .mapValues { (_, v) -> v.sortedByDescending { it.timestamp } }
 
     @WithSpan
+    fun countTehtavapaketit(): Long = listTehtavapaketit().size.toLong()
+
+    @WithSpan
     fun listAllObjects(): List<TehtavapakettiObject> =
         useS3 { bucket ->
             listAllObjects(bucket).map {

--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiViewController.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiViewController.kt
@@ -1,6 +1,5 @@
 package fi.oph.kitu.kotoutumiskoulutus.koealusta.tehtavapankki
 
-import fi.oph.kitu.tehtavapankki.TehtavapakettiEntity
 import fi.oph.kitu.tehtavapankki.TehtavapankkiRepository
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -27,20 +26,16 @@ class TehtavapankkiViewController(
     @GetMapping("")
     fun listView(): ResponseEntity<String> {
         val tehtavapaketit = tehtavapankkiService.listTehtavapaketit()
-        val pakettiIdsByS3Avain =
-            tehtavapankkiRepository.findIdsByS3Avain(
-                tehtavapaketit.values.flatten().map { it.key },
-            )
-        // Hae viimeisin DB-paketti per S3-ryhmä (kansio). Ryhmän nimi on
-        // muotoa "{courseid}-{sanitized_coursename}", samaa logiikkaa kuin
-        // MoodleSourceIdentifiers käyttää avaimen jäsentämiseen.
-        val latestPakettiByGroup: Map<String, TehtavapakettiEntity?> =
-            tehtavapaketit.keys.associateWith { group ->
-                val courseId = group.substringBefore('-')
-                tehtavapankkiRepository.findLatestPakettiBySource(
-                    TehtavapankkiIngestService.LAHDEJARJESTELMA,
-                    courseId,
-                )
+        val paketitByS3Avain =
+            tehtavapankkiRepository
+                .findPaketitByS3Avaimet(tehtavapaketit.values.flatten().map { it.key })
+                .associateBy { it.s3Avain!! }
+        val pakettiIdsByS3Avain = paketitByS3Avain.mapValues { (_, paketti) -> paketti.id!! }
+        // Ryhmän tiivistelmä kuvaa juuri sen kansion uusinta versiota, jotta saman
+        // courseid:n eri kansiot eivät näytä samaa (väärää) lähdetietoa.
+        val latestPakettiByGroup =
+            tehtavapaketit.mapValues { (_, objects) ->
+                objects.firstNotNullOfOrNull { paketitByS3Avain[it.key] }
             }
         return ResponseEntity.ok(
             TehtavapankkiPage.render(tehtavapaketit, pakettiIdsByS3Avain, latestPakettiByGroup),

--- a/server/src/main/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepository.kt
@@ -174,14 +174,6 @@ class TehtavapankkiRepository(
     }
 
     @WithSpan
-    fun countDistinctPaketit(): Long =
-        jdbc.queryForObject(
-            "SELECT COUNT(*) FROM (SELECT DISTINCT lahdejarjestelma, lahde_id FROM tehtavapaketti) t",
-            emptyMap<String, Any>(),
-            Long::class.java,
-        ) ?: 0
-
-    @WithSpan
     fun findPakettiById(id: Int): TehtavapakettiEntity? =
         jdbc
             .query(

--- a/server/src/main/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepository.kt
@@ -280,18 +280,17 @@ class TehtavapankkiRepository(
         )
 
     /**
-     * Karttaa S3-avaimet niihin tehtäväpaketteihin, jotka on jo tallennettu
-     * tietokantaan. Annetuista avaimista palautuvat vain ne, joille löytyy rivi.
+     * Hakee annettuja S3-avaimia vastaavat tehtäväpaketit. Palautuvat vain ne
+     * avaimet, joille löytyy rivi tietokannasta.
      */
     @WithSpan
-    fun findIdsByS3Avain(s3Avaimet: Collection<String>): Map<String, Int> {
-        if (s3Avaimet.isEmpty()) return emptyMap()
-        return jdbc
-            .query(
-                "SELECT s3_avain, id FROM tehtavapaketti WHERE s3_avain IN (:keys)",
-                mapOf("keys" to s3Avaimet),
-            ) { rs, _ -> rs.getString("s3_avain") to rs.getInt("id") }
-            .toMap()
+    fun findPaketitByS3Avaimet(s3Avaimet: Collection<String>): List<TehtavapakettiEntity> {
+        if (s3Avaimet.isEmpty()) return emptyList()
+        return jdbc.query(
+            "SELECT * FROM tehtavapaketti WHERE s3_avain IN (:keys)",
+            mapOf("keys" to s3Avaimet),
+            TehtavapakettiEntity.fromRow,
+        )
     }
 }
 

--- a/server/src/main/kotlin/fi/oph/kitu/webmvc/DashboardService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/webmvc/DashboardService.kt
@@ -1,9 +1,9 @@
 package fi.oph.kitu.webmvc
 
 import fi.oph.kitu.koski.KoskiErrorService
+import fi.oph.kitu.kotoutumiskoulutus.koealusta.tehtavapankki.TehtavapankkiService
 import fi.oph.kitu.kotoutumiskoulutus.suoritukset.CustomKielitestiSuoritusRepository
 import fi.oph.kitu.kotoutumiskoulutus.suoritukset.error.KielitestiSuoritusErrorRepository
-import fi.oph.kitu.tehtavapankki.TehtavapankkiRepository
 import fi.oph.kitu.util.cache.InMemoryCache
 import fi.oph.kitu.util.scheduling.SchedulerStatsRepository
 import fi.oph.kitu.vkt.CustomVktSuoritusRepository
@@ -13,6 +13,7 @@ import fi.oph.kitu.yki.suoritukset.YkiSuoritusPoikkeamaRepository
 import fi.oph.kitu.yki.suoritukset.YkiSuoritusRepository
 import fi.oph.kitu.yki.suoritukset.error.YkiSuoritusErrorService
 import io.opentelemetry.instrumentation.annotations.WithSpan
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.stereotype.Service
 import java.time.Instant
 import kotlin.time.Duration.Companion.seconds
@@ -27,7 +28,7 @@ class DashboardService(
     private val customVktSuoritusRepository: CustomVktSuoritusRepository,
     private val customKielitestiSuoritusRepository: CustomKielitestiSuoritusRepository,
     private val kielitestiSuoritusErrorRepository: KielitestiSuoritusErrorRepository,
-    private val tehtavapankkiRepository: TehtavapankkiRepository,
+    private val tehtavapankkiServiceProvider: ObjectProvider<TehtavapankkiService>,
     private val schedulerStatsRepository: SchedulerStatsRepository,
     private val koskiErrorService: KoskiErrorService,
 ) {
@@ -87,7 +88,7 @@ class DashboardService(
     private fun computeKoto(): KotoStats =
         KotoStats(
             suoritusCount = customKielitestiSuoritusRepository.countSuoritukset().toLong(),
-            tehtavapaketitCount = tehtavapankkiRepository.countDistinctPaketit(),
+            tehtavapaketitCount = tehtavapankkiServiceProvider.getIfAvailable()?.countTehtavapaketit() ?: 0L,
             latestReceivedAt = customKielitestiSuoritusRepository.findLatestLastModified(),
             importErrorCount = kielitestiSuoritusErrorRepository.count(),
         )

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiServiceTest.kt
@@ -514,6 +514,28 @@ class TehtavapankkiServiceTest(
     }
 
     @Test
+    fun `countTehtavapaketit laskee jokaisen S3-kansion vaikka courseid on sama`() {
+        s3Client.putObject(
+            { it.bucket(TEST_BUCKET).key("17-Kielitesti_esimerkki/2026-01-01T00:00:00-0.xml") },
+            RequestBody.fromString("<questions/>"),
+        )
+        s3Client.putObject(
+            { it.bucket(TEST_BUCKET).key("17-Kielitesti_opettaja_pilotointi/2026-02-02T00:00:00-0.xml") },
+            RequestBody.fromString("<questions/>"),
+        )
+
+        assertEquals(
+            2,
+            tehtavapankkiService.countTehtavapaketit(),
+            "Saman courseid:n eri kansioiden pitäisi laskeutua erikseen, kuten listausnäkymässä",
+        )
+        assertEquals(
+            tehtavapankkiService.listTehtavapaketit().size.toLong(),
+            tehtavapankkiService.countTehtavapaketit(),
+        )
+    }
+
+    @Test
     fun `getTemporaryDownloadUrl palauttaa toimivan signed URL_n`() {
         val key = "42-Suomi_alkeet/2026-01-01T00:00:00-0.xml"
         val content = "<questions><q id=\"1\"/></questions>"

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiViewControllerTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiViewControllerTest.kt
@@ -7,6 +7,7 @@ import fi.oph.kitu.LocalStackContainerConfiguration.Companion.TEST_BUCKET
 import fi.oph.kitu.oid.Oid
 import fi.oph.kitu.security.Authority
 import fi.oph.kitu.security.cas.CasUserDetails
+import fi.oph.kitu.tehtavapankki.TehtavapakettiEntity
 import fi.oph.kitu.tehtavapankki.TehtavapankkiRepository
 import fi.oph.kitu.util.result.getOrThrow
 import org.junit.jupiter.api.BeforeEach
@@ -187,6 +188,52 @@ class TehtavapankkiViewControllerTest(
         assertContains(response, xmlKey.substringBefore("/"))
         assertContains(response, "Näytä sisältö")
         assertContains(response, "/koto-tehtavapankki/paketti/$pakettiId")
+    }
+
+    @Test
+    fun `listView nayttaa kullekin saman courseid_n kansiolle sen oman lahdeversion`() {
+        val esimerkkiKey = "17-Kielitesti_esimerkki/2026-01-01T00:00:00-0.xml"
+        val pilotointiKey = "17-Kielitesti_opettaja_pilotointi/2026-02-02T00:00:00-0.xml"
+        s3Client.putObject(
+            { it.bucket(TEST_BUCKET).key(esimerkkiKey) },
+            RequestBody.fromString("<questions/>"),
+        )
+        s3Client.putObject(
+            { it.bucket(TEST_BUCKET).key(pilotointiKey) },
+            RequestBody.fromString("<questions/>"),
+        )
+        repository.insertPaketti(
+            TehtavapakettiEntity(
+                lahdejarjestelma = TehtavapankkiIngestService.LAHDEJARJESTELMA,
+                lahdeId = "17",
+                nimi = "Kielitesti esimerkki",
+                versioHash = "hash-esimerkki",
+                s3Avain = esimerkkiKey,
+                lahdeVersion = "vEsimerkki",
+            ),
+        )
+        repository.insertPaketti(
+            TehtavapakettiEntity(
+                lahdejarjestelma = TehtavapankkiIngestService.LAHDEJARJESTELMA,
+                lahdeId = "17",
+                nimi = "Kielitesti opettaja pilotointi",
+                versioHash = "hash-pilotointi",
+                s3Avain = pilotointiKey,
+                lahdeVersion = "vPilotointi",
+            ),
+        )
+
+        val response =
+            mockMvc
+                .perform(get("/koto-tehtavapankki").session(virkailijaSession()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+        // Saman courseid:n kummankin kansion tiivistelmä näyttää oman versionsa
+        // eikä courseid:n viimeisintä.
+        assertContains(response, "versio vEsimerkki")
+        assertContains(response, "versio vPilotointi")
     }
 
     private fun ingestFixture(): Int {

--- a/server/src/test/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/tehtavapankki/TehtavapankkiRepositoryTest.kt
@@ -281,18 +281,18 @@ class TehtavapankkiRepositoryTest(
     }
 
     @Test
-    fun `findIdsByS3Avain palauttaa loytyneet avaimet ja jattaa tuntemattomat pois`() {
+    fun `findPaketitByS3Avaimet palauttaa loytyneet paketit ja jattaa tuntemattomat pois`() {
         val pakettiIdA = seedPaketti(lahdeId = "1", versioHash = "h1", s3Avain = "1-foo/a.xml")
         val pakettiIdB = seedPaketti(lahdeId = "2", versioHash = "h2", s3Avain = "2-bar/b.xml")
 
-        val map =
-            repo.findIdsByS3Avain(
+        val paketit =
+            repo.findPaketitByS3Avaimet(
                 listOf("1-foo/a.xml", "2-bar/b.xml", "ei-loydy/c.xml"),
             )
 
-        assertEquals(setOf("1-foo/a.xml", "2-bar/b.xml"), map.keys)
-        assertEquals(pakettiIdA, map["1-foo/a.xml"])
-        assertEquals(pakettiIdB, map["2-bar/b.xml"])
+        assertEquals(setOf("1-foo/a.xml", "2-bar/b.xml"), paketit.map { it.s3Avain }.toSet())
+        assertEquals(pakettiIdA, paketit.single { it.s3Avain == "1-foo/a.xml" }.id)
+        assertEquals(pakettiIdB, paketit.single { it.s3Avain == "2-bar/b.xml" }.id)
     }
 
     @Test


### PR DESCRIPTION
Korjaa kaksi saman juurisyyn (courseid vs. S3-kansio -identiteetti) aiheuttamaa virhettä koto-tehtäväpankissa. Saman courseid:n kurssista syntyy useita S3-kansioita kun kurssi nimetään uudelleen (esim. `17-Kielitesti_esimerkki` ja `17-Kielitesti_opettaja_pilotointi`), mutta tietokannan `lahde_id` on pelkkä courseid.

## 1. Etusivun tehtäväpakettien lukumäärä (commit 1)

Etusivu laski paketit tietokannan `(lahdejarjestelma, lahde_id)` -pareista, jolloin saman courseid:n eri kansiot laskeutuivat yhdeksi — etusivu näytti `1`, vaikka listaussivu näytti `2`. Luku lasketaan nyt samasta S3-listauksesta kuin tehtäväpankkisivu (`listTehtavapaketit().size`), joten luvut täsmäävät. Poistettu käytöstä jäänyt `countDistinctPaketit`.

## 2. Listauksen ryhmäkohtainen tiivistelmä (commit 2)

Ryhmän tiivistelmärivi (kieli · versio · generoitu) haettiin courseid:llä (`findLatestPakettiBySource`), joten saman courseid:n eri kansiot näyttivät saman (väärän) lähdetiedon — vanhempi kansio leimautui uudemman metadatalla. Tiivistelmä haetaan nyt kunkin kansion oman S3-avaimen perusteella. Samalla `findIdsByS3Avain` korvattiin koko paketin palauttavalla `findPaketitByS3Avaimet`-haulla, josta johdetaan sekä rivilinkit että tiivistelmä yhdellä kyselyllä.

Rivikohtaiset "Näytä sisältö" -linkit olivat jo ennestään oikein (avaimena tarkka `s3_avain`).

## Testit

- `TehtavapankkiServiceTest`: saman courseid:n eri kansiot laskeutuvat erikseen.
- `TehtavapankkiViewControllerTest`: kummankin kansion tiivistelmä näyttää oman versionsa.
- `TehtavapankkiRepositoryTest`: `findPaketitByS3Avaimet` palauttaa löytyneet, ohittaa tuntemattomat.

Koko backend-buildiin (`./mvnw test`) ja `check-formatting.sh`-ajoon nähden vihreä.

## Jatkokohde (ei tässä)

Ingestin dedup-polku (`TehtavapankkiIngestService`) avaimena niin ikään courseid (`existsByVersionHash` + `findLatestPakettiBySource` → `updateLahdeMetadata`). Jos kaksi saman courseid:n kansiota lataa identtisen sisällön, jälkimmäinen deduppautuu ensimmäiseen ja päivittää väärän kansion rivin. Korjaus vaatisi paketti-identiteetin (kansio vs. courseid) ja `UNIQUE`-rajoitteen uudelleenmäärittelyn — laajempi muutos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)