### PR TITLE
Järjestä koto-tehtäväpaketit listauksessa uusin ensin

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiService.kt
@@ -148,11 +148,7 @@ class TehtavapankkiService(
     }
 
     @WithSpan
-    fun listTehtavapaketit(): Map<String, List<TehtavapakettiObject>> =
-        listAllObjects()
-            .filter { it.filename.lowercase().endsWith(".xml") }
-            .groupBy { it.filename.substringBefore("/") }
-            .mapValues { (_, v) -> v.sortedByDescending { it.timestamp } }
+    fun listTehtavapaketit(): Map<String, List<TehtavapakettiObject>> = groupTehtavapaketit(listAllObjects())
 
     @WithSpan
     fun countTehtavapaketit(): Long = listTehtavapaketit().size.toLong()
@@ -352,6 +348,15 @@ data class FailedAsset(
     val filename: String,
     val reason: String,
 )
+
+internal fun groupTehtavapaketit(objects: List<TehtavapakettiObject>): Map<String, List<TehtavapakettiObject>> =
+    objects
+        .filter { it.filename.lowercase().endsWith(".xml") }
+        .groupBy { it.filename.substringBefore("/") }
+        .mapValues { (_, versions) -> versions.sortedByDescending { it.timestamp } }
+        .entries
+        .sortedByDescending { (_, versions) -> versions.first().timestamp }
+        .associate { it.toPair() }
 
 // AWS palauttaa ETagin lainausmerkeissä; karsitaan ne ennen vertailua.
 private fun String.normalizeETag(): String = this.trim('"')

--- a/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiServiceTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/kotoutumiskoulutus/koealusta/tehtavapankki/TehtavapankkiServiceTest.kt
@@ -514,6 +514,39 @@ class TehtavapankkiServiceTest(
     }
 
     @Test
+    fun `groupTehtavapaketit jarjestaa ryhmat uusin ensin ja versiot ryhman sisalla uusin ensin`() {
+        val base = Instant.parse("2026-01-01T00:00:00Z")
+
+        fun obj(
+            folder: String,
+            offsetSeconds: Long,
+        ) = TehtavapakettiObject(
+            key = "$folder/$offsetSeconds.xml",
+            filename = "$folder/$offsetSeconds.xml",
+            size = 1,
+            timestamp = base.plusSeconds(offsetSeconds),
+        )
+
+        val result =
+            groupTehtavapaketit(
+                listOf(
+                    obj("1-Vanha", 5),
+                    obj("3-Uusin", 30),
+                    obj("2-Keski", 20),
+                    obj("1-Vanha", 10),
+                    obj("3-Uusin", 25),
+                    TehtavapakettiObject("muu/note.txt", "muu/note.txt", 1, base.plusSeconds(99)),
+                ),
+            )
+
+        assertEquals(listOf("3-Uusin", "2-Keski", "1-Vanha"), result.keys.toList())
+        assertEquals(
+            listOf(base.plusSeconds(10), base.plusSeconds(5)),
+            result.getValue("1-Vanha").map { it.timestamp },
+        )
+    }
+
+    @Test
     fun `countTehtavapaketit laskee jokaisen S3-kansion vaikka courseid on sama`() {
         s3Client.putObject(
             { it.bucket(TEST_BUCKET).key("17-Kielitesti_esimerkki/2026-01-01T00:00:00-0.xml") },


### PR DESCRIPTION
Koto-tehtäväpankin listauksessa tehtäväpaketit (S3-kansiot) palautuivat S3:n aakkosjärjestyksessä (kansion nimen mukaan), ei päivämäärän mukaan. Järjestetään ryhmät nyt kunkin ryhmän uusimman version aikaleiman mukaan laskevasti, jolloin tuorein tehtäväpaketti näkyy ylimpänä. Versiot ryhmän sisällä olivat jo ennestään uusin ensin.

Ryhmittely- ja järjestyslogiikka eriytettiin puhtaaksi, testattavaksi `groupTehtavapaketit`-funktioksi, jota `listTehtavapaketit` kutsuu.

## Testit

- `TehtavapankkiServiceTest`: `groupTehtavapaketit` järjestää ryhmät uusin ensin ja versiot ryhmän sisällä uusin ensin (deterministinen yksikkötesti, ei riipu S3-aikaleimoista).

Koko `TehtavapankkiServiceTest`- ja `TehtavapankkiViewControllerTest`-luokat sekä `check-formatting.sh` vihreä.

🤖 Generated with [Claude Code](https://claude.com/claude-code)