### PR TITLE
OPHKOTO-161: YKI-filtteröinti arviointitilalla

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/html/DisplayEnum.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/html/DisplayEnum.kt
@@ -1,0 +1,5 @@
+package fi.oph.kitu.html
+
+interface DisplayEnum {
+    fun displayText(): String
+}

--- a/server/src/main/kotlin/fi/oph/kitu/html/table/TableFilterDialog.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/html/table/TableFilterDialog.kt
@@ -2,6 +2,7 @@
 
 package fi.oph.kitu.html.table
 
+import fi.oph.kitu.html.DisplayEnum
 import fi.oph.kitu.html.ModalCommand
 import fi.oph.kitu.html.input
 import fi.oph.kitu.html.modal
@@ -128,6 +129,7 @@ inline fun <reified E : Enum<E>> enumValueName(value: E?): String =
     when (value) {
         is Koodisto.KoodiviiteNimella -> value.nimi.toString()
         is Nimetty -> value.nimi.toString()
+        is DisplayEnum -> value.displayText()
         null -> "Kaikki"
         else -> value.name
     }

--- a/server/src/main/kotlin/fi/oph/kitu/yki/Arviointitila.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/Arviointitila.kt
@@ -1,11 +1,13 @@
 package fi.oph.kitu.yki
 
+import fi.oph.kitu.html.DisplayEnum
+import fi.oph.kitu.html.table.HideInTableFilter
 import java.time.LocalDate
 
 // Solki-arviointitilat + Kielitutkintorekisterin omat tilat
 enum class Arviointitila(
     val viewText: String,
-) {
+) : DisplayEnum {
     ILMOITTAUTUNUT("Ilmoittautunut"),
     PERUTTU("Ilmoittautuminen peruttu"),
     EI_SUORITUSTA("Ei suoritusta"),
@@ -16,12 +18,15 @@ enum class Arviointitila(
     TARKISTUSARVIOINTI_HYVAKSYTTY("Tarkistusarviointi hyväksytty"),
 
     @Deprecated("Poistuu käytöstä uuden arviointitilamallin myötä")
+    @HideInTableFilter
     KESKEYTETTY("Suoritus keskeytetty"),
     ;
 
     fun arvioitu() = listOf(ARVIOITU, TARKISTUSARVIOITAVA).contains(this) || tarkistusarvioitu()
 
     fun tarkistusarvioitu() = listOf(TARKISTUSARVIOITU, TARKISTUSARVIOINTI_HYVAKSYTTY).contains(this)
+
+    override fun displayText(): String = viewText
 }
 
 fun laskeArviointitila(

--- a/server/src/main/kotlin/fi/oph/kitu/yki/YkiSuorituksetParams.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/YkiSuorituksetParams.kt
@@ -25,6 +25,7 @@ data class YkiSuorituksetParams(
     var tutkintotaso: Tutkintotaso? = null,
     var piilotaHenkilotiedot: Boolean = false,
     val piilotaVanhentuneetTiedot: Boolean = false,
+    val arviointitila: Arviointitila? = null,
 ) {
     fun toMap(): Map<String, String?> =
         mapOf(
@@ -39,6 +40,7 @@ data class YkiSuorituksetParams(
             "tutkintotaso" to tutkintotaso?.toString(),
             "piilotaHenkilotiedot" to piilotaHenkilotiedot.toTrueOrNull(),
             "piilotaVanhentuneetTiedot" to piilotaVanhentuneetTiedot.toTrueOrNull(),
+            "arviointitila" to arviointitila?.toString(),
         )
 
     fun toFilter() =
@@ -48,6 +50,7 @@ data class YkiSuorituksetParams(
             loppupaiva = tutkintoloppu,
             tutkintokieli = tutkintokieli,
             tutkintotaso = tutkintotaso,
+            arviointitila = arviointitila,
         )
 
     fun toOrder() =

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuorituksetPage.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuorituksetPage.kt
@@ -20,6 +20,7 @@ import fi.oph.kitu.html.table.httpParams
 import fi.oph.kitu.html.table.tableFilterDialog
 import fi.oph.kitu.html.table.toggleFilter
 import fi.oph.kitu.webmvc.Links
+import fi.oph.kitu.yki.Arviointitila
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import fi.oph.kitu.yki.YkiSuorituksetParams
@@ -141,6 +142,9 @@ fun FlowContent.ykiSuoritusFilterButton(params: YkiSuorituksetParams) {
         }
         fieldSet {
             enumFilter<Tutkintotaso>("tutkintotaso", "Tutkintotaso", params.tutkintotaso)
+        }
+        fieldSet {
+            enumFilter<Arviointitila>("arviointitila", "Arviointitila", params.arviointitila)
         }
         fieldSet {
             toggleFilter("versionHistory", "Näytä versiohistoria", params.versionHistory)

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusFilter.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusFilter.kt
@@ -2,6 +2,7 @@ package fi.oph.kitu.yki.suoritukset
 
 import fi.oph.kitu.jdbc.SortDirection
 import fi.oph.kitu.jdbc.SqlFilterBuilder
+import fi.oph.kitu.yki.Arviointitila
 import fi.oph.kitu.yki.Tutkintokieli
 import fi.oph.kitu.yki.Tutkintotaso
 import java.time.LocalDate
@@ -12,6 +13,7 @@ data class YkiSuoritusFilter(
     val loppupaiva: LocalDate? = null,
     val tutkintokieli: Tutkintokieli? = null,
     val tutkintotaso: Tutkintotaso? = null,
+    val arviointitila: Arviointitila? = null,
 ) {
     fun whereSql(): String? = toSql().whereClauseOrNull()
 
@@ -29,6 +31,10 @@ data class YkiSuoritusFilter(
             add(loppupaiva?.let { "tutkintopaiva <= :filter_loppupaiva" }, "filter_loppupaiva" to loppupaiva)
             add(tutkintokieli?.let { "tutkintokieli = :filter_kieli" }, "filter_kieli" to tutkintokieli?.name)
             add(tutkintotaso?.let { "tutkintotaso = :filter_taso" }, "filter_taso" to tutkintotaso?.name)
+            add(
+                arviointitila?.let { "arviointitila = :filter_arviointitila" },
+                "filter_arviointitila" to arviointitila?.name,
+            )
         }
 
     private fun searchTerms(): List<String> =

--- a/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/yki/suoritukset/YkiSuoritusRepository.kt
@@ -226,11 +226,8 @@ class YkiSuoritusRepository(
                 )
             } else {
                 buildSql(
-                    if (distinct) {
-                        "SELECT COUNT(DISTINCT solki_id) FROM yki_suoritus"
-                    } else {
-                        "SELECT COUNT(*) FROM yki_suoritus"
-                    },
+                    withCtes("suoritus" to selectSuorituksetRoot(distinct)),
+                    "SELECT COUNT(*) FROM suoritus AS yki_suoritus",
                     filter.whereSql(),
                 )
             }

--- a/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/yki/YkiSuoritusRepositoryTest.kt
@@ -331,4 +331,53 @@ class YkiSuoritusRepositoryTest(
         assertEquals(found, count, "count ja find tuloksen koko poikkesivat alitauluhaarassa")
         assertEquals(2L, count)
     }
+
+    @Test
+    fun `count suoritukset arviointitila-filtterillä laskee vain viimeisimmän version`() {
+        val kasittelyPvm = LocalDate.of(2025, 6, 15)
+        val suoritus =
+            generateRandomYkiSuoritusEntity().copy(
+                arviointitila = Arviointitila.TARKISTUSARVIOITU,
+                tarkistusarvioinninKasittelyPvm = kasittelyPvm,
+            )
+        ykiSuoritusRepository.saveAllNewEntities(listOf(suoritus))
+        ykiSuoritusRepository.hyvaksyTarkistusarvioinnit(
+            suoritusIds = listOf(suoritus.solkiId),
+            pvm = kasittelyPvm,
+        )
+
+        val tarkistusarvioituFilter = YkiSuoritusFilter(arviointitila = Arviointitila.TARKISTUSARVIOITU)
+        val hyvaksyttyFilter = YkiSuoritusFilter(arviointitila = Arviointitila.TARKISTUSARVIOINTI_HYVAKSYTTY)
+
+        assertAll(
+            {
+                assertEquals(
+                    0L,
+                    ykiSuoritusRepository.countSuoritukset(tarkistusarvioituFilter),
+                    "vanhentunutta TARKISTUSARVIOITU-versiota ei pidä laskea mukaan",
+                )
+            },
+            {
+                assertEquals(
+                    ykiSuoritusRepository.find(tarkistusarvioituFilter).count().toLong(),
+                    ykiSuoritusRepository.countSuoritukset(tarkistusarvioituFilter),
+                    "count ja find poikkesivat TARKISTUSARVIOITU-suodatuksella",
+                )
+            },
+            {
+                assertEquals(
+                    1L,
+                    ykiSuoritusRepository.countSuoritukset(hyvaksyttyFilter),
+                    "viimeisimmän version TARKISTUSARVIOINTI_HYVAKSYTTY pitää tulla lasketuksi",
+                )
+            },
+            {
+                assertEquals(
+                    ykiSuoritusRepository.find(hyvaksyttyFilter).count().toLong(),
+                    ykiSuoritusRepository.countSuoritukset(hyvaksyttyFilter),
+                    "count ja find poikkesivat TARKISTUSARVIOINTI_HYVAKSYTTY-suodatuksella",
+                )
+            },
+        )
+    }
 }


### PR DESCRIPTION

Korjaa samalla lukumäärään liittynyt bugi, joka otti mukaan historiarivit, vaikka luvussa pitäisi olla mukana vain suorituksen uusin versio.
