### PR TITLE
OPHKOTO-169: Korjaa lokalisoinnin lataus kun kieltä ei ole vielä julkaistu Tolgeessa

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/i18n/LokalisointiClient.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/i18n/LokalisointiClient.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.toEntity
 
@@ -44,18 +45,23 @@ class LokalisointiClient(
             .use { span ->
                 val locale = language.name.lowercase()
                 span.setAttribute("locale", locale)
-                restClient
-                    .get()
-                    .uri(
-                        "/lokalisointi/tolgee/{namespace}/{locale}.json",
-                        mapOf(
-                            "namespace" to namespace,
-                            "locale" to locale,
-                        ),
-                    ).accept(MediaType.APPLICATION_JSON)
-                    .retrieve()
-                    .toEntity<Map<String, String>>()
-                    .body
-                    ?: emptyMap()
+                try {
+                    restClient
+                        .get()
+                        .uri(
+                            "/lokalisointi/tolgee/{namespace}/{locale}.json",
+                            mapOf(
+                                "namespace" to namespace,
+                                "locale" to locale,
+                            ),
+                        ).accept(MediaType.APPLICATION_JSON)
+                        .retrieve()
+                        .toEntity<Map<String, String>>()
+                        .body
+                        ?: emptyMap()
+                } catch (e: HttpClientErrorException.NotFound) {
+                    span.setAttribute("localeNotPublished", "$locale (${e.statusCode.value()})")
+                    emptyMap()
+                }
             }
 }

--- a/server/src/test/kotlin/fi/oph/kitu/i18n/LokalisointiClientTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/i18n/LokalisointiClientTest.kt
@@ -2,9 +2,11 @@ package fi.oph.kitu.i18n
 
 import io.opentelemetry.api.OpenTelemetry
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 import org.springframework.web.client.RestClient
 import kotlin.test.assertEquals
@@ -38,6 +40,30 @@ class LokalisointiClientTest {
         assertNull(result["nav.yki"]?.en)
         assertEquals("Assessors", result["nav.arvioijat"]?.en)
         assertNull(result["nav.arvioijat"]?.fi)
+        server.verify()
+    }
+
+    @Test
+    fun `julkaisematon kieli (404) ei esta muiden kielten latausta`() {
+        val builder = RestClient.builder().baseUrl(baseUrl)
+        val server = MockRestServiceServer.bindTo(builder).build()
+
+        server
+            .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/fi.json"))
+            .andRespond(withSuccess("""{"nav.yki":"Yleinen kielitutkinto"}""", MediaType.APPLICATION_JSON))
+        server
+            .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/sv.json"))
+            .andRespond(withStatus(HttpStatus.NOT_FOUND))
+        server
+            .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/en.json"))
+            .andRespond(withStatus(HttpStatus.NOT_FOUND))
+
+        val client = LokalisointiClient(builder.build(), tracer, "kielitutkintorekisteri")
+
+        val result = client.fetchAll()
+
+        assertEquals(mapOf("nav.yki" to "Yleinen kielitutkinto"), result.mapValues { it.value.fi })
+        assertNull(result["nav.yki"]?.sv)
         server.verify()
     }
 }


### PR DESCRIPTION
## Ongelma (havaittu QA:lla)

Etusivu ilmoitti **387 puuttuvaa käännösavainta**, vaikka Tolgeen fi.json palautuu oikein (387 avainta):
`https://virkailija.testiopintopolku.fi/lokalisointi/tolgee/kielitutkintorekisteri/fi.json`

## Juurisyy

`LokalisointiClient.fetchAll` hakee fi/sv/en-tiedostot ja yhdistää ne. Ruotsin ja englannin käännöksiä **ei ole vielä julkaistu** Tolgeessa, joten `sv.json` ja `en.json` palauttavat **404**. `retrieve()` heittää poikkeuksen 404:llä, jolloin koko `fetchAll` kaatui, `@RetryOutboundIntegration` yritti turhaan uudelleen ja `LokalisointiLoader.runCatching` nieli virheen — `TolgeeMessages` jäi **tyhjäksi**, joten jokainen koodissa oleva avain näkyi "puuttuvana".

## Korjaus

`fetchLocale` palauttaa nyt tyhjän mapin, kun kieltä ei ole vielä julkaistu (404). Julkaistut kielet latautuvat normaalisti ja puuttuvat kielet fallbackaavat suomeen. Myöhemmin julkaistavat sv/en latautuvat ajoitetun päivityksen kautta ilman uudelleenkäynnistystä. Muut virheet (5xx, verkko) käyttäytyvät kuten ennenkin (retry + ei kaada käynnistystä).

Testi: `LokalisointiClientTest` — fi 200 + sv/en 404 → `fetchAll` palauttaa fi-avaimet kaatumatta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
