### PR TITLE
OPHKOTO-169: Lue lokalisointikäännökset vaikka palvelu vastaa octet-streamilla

### DIFF
--- a/server/src/main/kotlin/fi/oph/kitu/i18n/LokalisointiRestClientConfig.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/i18n/LokalisointiRestClientConfig.kt
@@ -1,6 +1,7 @@
 package fi.oph.kitu.i18n
 
 import fi.oph.kitu.config.ConditionalOnNonEmptyProperty
+import fi.oph.kitu.restclient.withOctetStreamJsonConverter
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -18,5 +19,6 @@ class LokalisointiRestClientConfig(
     fun restClient(): RestClient =
         restClientBuilder
             .baseUrl("https://$opintopolkuHostname")
+            .withOctetStreamJsonConverter()
             .build()
 }

--- a/server/src/main/kotlin/fi/oph/kitu/restclient/RestClientExtensions.kt
+++ b/server/src/main/kotlin/fi/oph/kitu/restclient/RestClientExtensions.kt
@@ -94,3 +94,15 @@ private fun createObjectMapperWithLargerBuffer(maxStringLen: Int): JsonMapper =
                         .build(),
                 ).build(),
         ).build()
+
+// The OPH lokalisointi proxy serves the published translation JSON with
+// Content-Type: application/octet-stream (nosniff), which the default Jackson
+// converter refuses to read. Claim octet-stream too so the body still parses as JSON.
+fun RestClient.Builder.withOctetStreamJsonConverter(): RestClient.Builder =
+    this.clone().configureMessageConverters { cs ->
+        cs.registerDefaults().withJsonConverter(
+            JacksonJsonHttpMessageConverter().apply {
+                supportedMediaTypes = supportedMediaTypes + MediaType.APPLICATION_OCTET_STREAM
+            },
+        )
+    }

--- a/server/src/main/resources/application-local-opintopolku.properties
+++ b/server/src/main/resources/application-local-opintopolku.properties
@@ -8,6 +8,8 @@ kitu.koski.baseUrl=http://localhost:7021/koski/api/
 kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=true
 kitu.kotoutumiskoulutus.koealusta.scheduling.importTehtavapankki.schedule=DAILY|01:00
 
+kitu.lokalisointi.namespace=
+
 # --- Offline-kehityksen oletukset ---
 # Korvaa ${ENV_VAR}-paikanvaraajat, jotka muutoin haetaan AWS Secrets Managerista
 # scripts/ensure_aws_secrets.sh:n kautta. Profiilikohtainen tiedosto voittaa

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -20,6 +20,8 @@ kitu.appUrl=http://localhost:8080/kielitutkinnot
 kitu.opintopolkuHostname=virkailija.untuvaopintopolku.fi
 kitu.uses-ssl-proxy=false
 
+kitu.lokalisointi.namespace=kielitutkintorekisteri
+
 kitu.kotoutumiskoulutus.koealusta.baseurl=https://kielitesti.mmg.fi
 kitu.kotoutumiskoulutus.koealusta.scheduling.enabled=true
 kitu.kotoutumiskoulutus.koealusta.scheduling.import.schedule=DAILY|00:00

--- a/server/src/test/kotlin/fi/oph/kitu/i18n/LokalisointiClientTest.kt
+++ b/server/src/test/kotlin/fi/oph/kitu/i18n/LokalisointiClientTest.kt
@@ -1,5 +1,6 @@
 package fi.oph.kitu.i18n
 
+import fi.oph.kitu.restclient.withOctetStreamJsonConverter
 import io.opentelemetry.api.OpenTelemetry
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
@@ -18,18 +19,18 @@ class LokalisointiClientTest {
 
     @Test
     fun `yhdistaa kielikohtaiset kaannokset LocalizedStringeiksi`() {
-        val builder = RestClient.builder().baseUrl(baseUrl)
+        val builder = RestClient.builder().baseUrl(baseUrl).withOctetStreamJsonConverter()
         val server = MockRestServiceServer.bindTo(builder).build()
 
         server
             .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/fi.json"))
-            .andRespond(withSuccess("""{"nav.yki":"Yleinen kielitutkinto"}""", MediaType.APPLICATION_JSON))
+            .andRespond(withSuccess("""{"nav.yki":"Yleinen kielitutkinto"}""", MediaType.APPLICATION_OCTET_STREAM))
         server
             .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/sv.json"))
-            .andRespond(withSuccess("""{"nav.yki":"Allmän språkexamen"}""", MediaType.APPLICATION_JSON))
+            .andRespond(withSuccess("""{"nav.yki":"Allmän språkexamen"}""", MediaType.APPLICATION_OCTET_STREAM))
         server
             .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/en.json"))
-            .andRespond(withSuccess("""{"nav.arvioijat":"Assessors"}""", MediaType.APPLICATION_JSON))
+            .andRespond(withSuccess("""{"nav.arvioijat":"Assessors"}""", MediaType.APPLICATION_OCTET_STREAM))
 
         val client = LokalisointiClient(builder.build(), tracer, "kielitutkintorekisteri")
 
@@ -45,12 +46,12 @@ class LokalisointiClientTest {
 
     @Test
     fun `julkaisematon kieli (404) ei esta muiden kielten latausta`() {
-        val builder = RestClient.builder().baseUrl(baseUrl)
+        val builder = RestClient.builder().baseUrl(baseUrl).withOctetStreamJsonConverter()
         val server = MockRestServiceServer.bindTo(builder).build()
 
         server
             .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/fi.json"))
-            .andRespond(withSuccess("""{"nav.yki":"Yleinen kielitutkinto"}""", MediaType.APPLICATION_JSON))
+            .andRespond(withSuccess("""{"nav.yki":"Yleinen kielitutkinto"}""", MediaType.APPLICATION_OCTET_STREAM))
         server
             .expect(requestTo("$baseUrl/lokalisointi/tolgee/kielitutkintorekisteri/sv.json"))
             .andRespond(withStatus(HttpStatus.NOT_FOUND))


### PR DESCRIPTION
## Ongelma (havaittu QA:lla, jatkoa PR:lle #3126)

Etusivu ilmoitti edelleen kaikki 387 käännösavainta puuttuviksi. Lokalisointipalvelu (proxy) tarjoilee julkaistut käännös-JSONit **`Content-Type: application/octet-stream`** (+ `nosniff`), jota oletusarvoinen Jackson-konvertteri **ei suostu lukemaan**:

```
UnknownContentTypeException: no suitable HttpMessageConverter found for response type
[java.util.Map<String, String>] and content type [application/octet-stream]
```

Tämä kaataa `fetchLocale`n **heti fi:llä** (haetaan ensimmäisenä), joten `TolgeeMessages` jää tyhjäksi ja kaikki koodin avaimet näkyvät puuttuvina. Tämä on ensisijainen syy; #3126:n 404-korjaus (julkaisemattomat sv/en) ei yksin auta, koska fi ei koskaan latautunut.

## Korjaus

`RestClientExtensions.withOctetStreamJsonConverter` rekisteröi Jackson-konvertterin myös `application/octet-stream`-tyypille, ja se on otettu käyttöön `lokalisointiRestClient`issä. Testit toistavat nyt octet-stream-vastaukset (`LokalisointiClientTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
